### PR TITLE
simple transcription of Eckmann-Hilton argument (book 2.1.6)

### DIFF
--- a/lib/PathGroupoid.agda
+++ b/lib/PathGroupoid.agda
@@ -101,13 +101,20 @@ module _ {i} {A : Type i} where
     → p ∙ q == p ∙ q'
   _∙ₗ_ {q = q} {q' = q'} idp β = β
 
-  _⋆2_ : {x y z : A} {p p' : x == y} {q q' : y == z} (α : p == p') (β : q == q')
+  _⋆2_ : {x y z : A} {p p' : x == y} {q q' : y == z}
+         (α : p == p') (β : q == q')
     → p ∙ q == p' ∙ q'
   _⋆2_ {p' = p'} {q = q} α β = (α ∙ᵣ q) ∙ (p' ∙ₗ β)
 
-  _⋆'2_ : {x y z : A} {p p' : x == y} {q q' : y == z} (α : p == p') (β : q == q')
+  _⋆'2_ : {x y z : A} {p p' : x == y} {q q' : y == z}
+          (α : p == p') (β : q == q')
     → p ∙ q == p' ∙ q'
   _⋆'2_ {p = p} {q' = q'} α β = (p ∙ₗ β) ∙ (α ∙ᵣ q')
+
+  ⋆2=⋆'2 : {x y z : A} {p p' : x == y} {q q' : y == z}
+           (α : p == p') (β : q == q')
+    → α ⋆2 β == α ⋆'2 β
+  ⋆2=⋆'2 {p = idp} {q = idp} idp idp = idp
 
 module _ {i} {A : Type i} where
 

--- a/lib/types/LoopSpace.agda
+++ b/lib/types/LoopSpace.agda
@@ -129,25 +129,10 @@ module _ {i} {X : Ptd i} where
   conc^2-comm α β = ! (⋆2=conc^ α β) ∙ ⋆2=⋆'2 α β ∙ ⋆'2=conc^ α β
     where
       ⋆2=conc^ : (α β : Ω^ 2 X) → α ⋆2 β == conc^ 2 α β
-      ⋆2=conc^ α β = α ⋆2 β
-                       =⟨ idp ⟩
-                     (∙-unit-r idp ∙ α ∙ ! (∙-unit-r idp)) ∙ β
-                       =⟨ idp ⟩
-                     (α ∙ ! (∙-unit-r idp)) ∙ β
-                       =⟨ ∙-unit-r α |in-ctx (λ π → π ∙ β) ⟩
-                     α ∙ β ∎
+      ⋆2=conc^ α β = ap (λ π → π ∙ β) (∙-unit-r α)
 
       ⋆'2=conc^ : (α β : Ω^ 2  X) → α ⋆'2 β == conc^ 2 β α
-      ⋆'2=conc^ α β = α ⋆'2 β
-                        =⟨ idp ⟩
-                      β ∙ (∙-unit-r idp ∙ α ∙ ! (∙-unit-r idp))
-                        =⟨ idp ⟩
-                      β ∙ (α ∙ ! (∙-unit-r idp))
-                        =⟨ ∙-unit-r α |in-ctx (λ π → β ∙ π) ⟩
-                      β ∙ α ∎
-
-      ⋆2=⋆'2 : (α β : Ω^ 2 X) → α ⋆2 β == α ⋆'2 β
-      ⋆2=⋆'2 idp idp = idp
+      ⋆'2=conc^ α β = ap (λ π → β ∙ π) (∙-unit-r α)
 
 {- Pushing truncation through loop space -}
 module _ {i} where


### PR DESCRIPTION
This is a straightforward transcription of the commutativity of composition in loop spaces from book theorem 2.1.6, because I didn't find it elsewhere in the library.  I was unable to make it go through with the horizontal compositions that were already there in PathGroupoid (∙2 etc); in fact, I was unable to prove some simple lemmas about them for reasons that I don't understand yet.

If this theorem is already in the library somewhere that I missed, I apologize for the trouble.
