### PR TITLE
Add BAut types and two equivalent types of finite sets

### DIFF
--- a/core/lib/types/BAut.agda
+++ b/core/lib/types/BAut.agda
@@ -1,0 +1,32 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+open import lib.Basics
+open import lib.NType2
+open import lib.NConnected
+open import lib.types.Nat
+open import lib.types.Subtype
+open import lib.types.Truncation
+
+-- classifying types of automorphism groups of types
+module lib.types.BAut where
+
+BAut : ∀ {i} → Type i → Type (lsucc i)
+BAut {i} A = Σ (Type i) λ X → Trunc -1 (A == X)
+
+BAut-prop : ∀ {i} (A : Type i) → SubtypeProp (Type i) (lsucc i)
+BAut-prop A = ((λ X → Trunc -1 (A == X)) , (λ X → Trunc-level))
+
+pBAut : ∀ {i} → Type i → Ptd (lsucc i)
+de⊙ (pBAut A) = BAut A
+pt (pBAut A) = A , [ idp ]
+
+BAut-trunc-path : ∀ {i} (A X : Type i) → (tp : Trunc -1 (A == X))
+                  → Trunc -1 ((A , [ idp ]) == (X , tp) :> BAut A)
+BAut-trunc-path {i} A X = Trunc-elim (λ p → Trunc-level)
+                          λ p → [ pair= p (prop-has-all-paths-↓ Trunc-level) ]
+
+BAut-conn : ∀ {i} (A : Type i) → is-connected 0 (BAut A)
+fst (BAut-conn A) = [ pt (pBAut A) ]
+snd (BAut-conn A) = Trunc-elim (λ x → raise-level (from-nat 0) Trunc-level [ A , [ idp ] ] x)
+                               (λ { (X , tp) → <– (Trunc=-equiv [ A , [ idp ] ] [ X , tp ])
+                                                  (BAut-trunc-path A X tp) })

--- a/core/lib/types/Coproduct.agda
+++ b/core/lib/types/Coproduct.agda
@@ -154,3 +154,21 @@ module _ {i j k} {A : Type i} {B : Type j} (P : A ⊔ B → Type k) where
       from-to : ∀ fg → from (to fg) == fg
       from-to fg = λ= λ where (inl _) → idp
                               (inr _) → idp
+
+-- the empty type is a unit for the coproduct
+Coprod-unit-left : ∀ {i} (A : Type i) → ⊥ ⊔ A ≃ A
+Coprod-unit-left {i} (A) = equiv to from to-from from-to
+  where
+    to : ⊥ ⊔ A → A
+    to (inl ())
+    to (inr a) = a
+
+    from : A → ⊥ ⊔ A
+    from a = inr a
+
+    to-from : (a : A) → to (from a) == a
+    to-from a = idp
+
+    from-to : (x : ⊥ ⊔ A) → from (to x) == x
+    from-to (inl ())
+    from-to (inr a) = idp

--- a/core/lib/types/Types.agda
+++ b/core/lib/types/Types.agda
@@ -3,6 +3,7 @@
 module lib.types.Types where
 
 open import lib.Basics
+open import lib.types.BAut public
 open import lib.types.BigWedge public
 open import lib.types.Bool public
 open import lib.types.Choice public

--- a/theorems/homotopy/FinSet.agda
+++ b/theorems/homotopy/FinSet.agda
@@ -1,0 +1,97 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+open import HoTT
+import homotopy.ConstantToSetExtendsToProp as ConstExt
+open import homotopy.Pigeonhole
+
+module homotopy.FinSet where
+
+-- the explicit type of finite sets, carrying the cardinality on its sleeve
+FinSet-exp : Type₁
+FinSet-exp = Σ ℕ λ n → BAut (Fin n)
+
+FinSet-prop : SubtypeProp Type₀ (lsucc lzero)
+FinSet-prop = (λ A → Trunc -1 (Σ ℕ λ n → Fin n == A)) , λ A → Trunc-level
+
+-- the implicit type of finite sets, hiding the cardinality in prop. trunc.
+FinSet : Type₁
+FinSet = Subtype FinSet-prop
+
+FinSet= : {A B : FinSet} → fst A == fst B → A == B
+FinSet= = Subtype=-out FinSet-prop
+
+FinFS : ℕ → FinSet
+FinFS n = Fin n , [ n , idp ]
+
+UnitFS : FinSet
+UnitFS = ⊤ , [ S O , ua Fin-equiv-Coprod ∙ ap (λ C → C ⊔ ⊤) (ua Fin-equiv-Empty)
+                     ∙ ua (Coprod-unit-left ⊤) ]
+
+Fin-inj-lemma : {n m : ℕ} → n < m → Fin m == Fin n → ⊥
+Fin-inj-lemma {n} {m} n<m p = i≠j (<– (ap-equiv (coe-equiv p) i j) q)
+  where
+    i : Fin m
+    i = fst (pigeonhole n<m (coe p))
+
+    j : Fin m
+    j = fst (snd (pigeonhole n<m (coe p)))
+
+    i≠j : i ≠ j
+    i≠j = fst (snd (snd (pigeonhole n<m (coe p))))
+
+    q : coe p i == coe p j
+    q = snd (snd (snd (pigeonhole n<m (coe p))))
+    
+Fin-inj : (n m : ℕ) → Fin n == Fin m → n == m
+Fin-inj n m p with ℕ-trichotomy n m
+Fin-inj n m p | inl q = q
+Fin-inj n m p | inr (inl q) = ⊥-rec (Fin-inj-lemma q (! p))
+Fin-inj n m p | inr (inr q) = ⊥-rec (Fin-inj-lemma q p)
+
+FinSet-aux-prop : (A : Type₀) → SubtypeProp ℕ (lsucc lzero)
+FinSet-aux-prop A = (λ n → Trunc -1 (Fin n == A)) , (λ n → Trunc-level)
+  
+FinSet-aux : (A : FinSet) → Subtype (FinSet-aux-prop (fst A))
+FinSet-aux (A , tz) = CE.ext tz
+  where
+    to : (Σ ℕ λ n → Fin n == A) → Subtype (FinSet-aux-prop A)
+    to (n , p) = n , [ p ]
+
+    to-const : (z₁ z₂ : Σ ℕ λ n → Fin n == A) → to z₁ == to z₂
+    to-const (n₁ , p₁) (n₂ , p₂) = Subtype=-out (FinSet-aux-prop A) (Fin-inj n₁ n₂ (p₁ ∙ ! p₂))
+
+    module CE =
+      ConstExt (Subtype-level (FinSet-aux-prop A) ℕ-is-set) to to-const
+
+card : FinSet → ℕ
+card A = fst (FinSet-aux A)
+
+card-eq : (A : FinSet) (n : ℕ) → Trunc -1 (Fin n == fst A) → card A == n
+card-eq (A , tz) n tp = Trunc-rec (ℕ-is-set (card (A , tz)) n) (λ p →
+  ap card (FinSet= {A , tz} {FinFS n} (! p)) ) tp
+
+FinSet-equiv : FinSet-exp ≃ FinSet
+FinSet-equiv = equiv to from to-from from-to
+  where
+    to : FinSet-exp → FinSet
+    to (n , A , tp) = A , Trunc-rec Trunc-level (λ p → [ n , p ]) tp
+
+    from : FinSet → FinSet-exp
+    from A = card A , fst A , snd (FinSet-aux A)
+
+    to-from : (A : FinSet) → to (from A) == A
+    to-from A = pair= idp (prop-has-all-paths Trunc-level (snd (to (from A))) (snd A))
+
+    from-to : (A : FinSet-exp) → from (to A) == A
+    from-to A = pair= (card-eq (to A) (fst A) (snd (snd A)))
+      (↓-Subtype-in (λ n → BAut-prop (Fin n)) (↓-cst-in idp))
+
+FinSet-elim-prop : ∀ {j} {P : FinSet → Type j} (p : (A : FinSet) → has-level -1 (P A))
+                   (d : (n : ℕ) → P (FinFS n)) → (A : FinSet) → P A
+FinSet-elim-prop {j} {P} p d (A , tz) = Trunc-elim (λ tw → p (A , tw))
+  (λ {(n , p) → transport P (FinSet= p) (d n)}) tz
+
+finset-has-dec-eq : (A : FinSet) → has-dec-eq (fst A)
+finset-has-dec-eq = FinSet-elim-prop (λ A → has-dec-eq-is-prop) λ n → Fin-has-dec-eq
+
+-- todo: closure of FinSet under product, coproduct, exponential, etc.

--- a/theorems/homotopy/Pigeonhole.agda
+++ b/theorems/homotopy/Pigeonhole.agda
@@ -1,0 +1,111 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+open import HoTT
+
+-- This file contains a helper module for FinSet,
+-- proving the finite pigeonhole principle
+module homotopy.Pigeonhole where
+
+{-
+  loosely based on code by copumpkin and xplat via byorgey
+-}
+
+incl : ∀ {m n} (m<n : m < n) → Fin m → Fin n
+incl m<n (k , k<m) = k , <-trans k<m m<n
+
+incl-ne : ∀ {n} (i : Fin n) → ¬ (incl ltS i == n , ltS)
+incl-ne {n} (k , k<n) p = <-to-≠ k<n (ap fst p)
+
+Dec-Σ-Fin : ∀ {ℓ} {n} (P : Fin n → Type ℓ) (dec-P : (i : Fin n) → Dec (P i))
+             → Dec (Σ (Fin n) λ i → P i)
+Dec-Σ-Fin {ℓ} {O} P dec-P = inr λ z → –> Fin-equiv-Empty (fst z)
+Dec-Σ-Fin {ℓ} {S n} P dec-P with Dec-Σ-Fin {ℓ} {n} (P ∘ (incl ltS)) (dec-P ∘ (incl ltS))
+Dec-Σ-Fin {ℓ} {S n} P dec-P | inl z = inl (incl ltS (fst z) , snd z)
+Dec-Σ-Fin {ℓ} {S n} P dec-P | inr ¬z with dec-P (n , ltS)
+Dec-Σ-Fin {ℓ} {S n} P dec-P | inr ¬z | (inl p)  = inl ((n , ltS) , p)
+Dec-Σ-Fin {ℓ} {S n} P dec-P | inr ¬z | (inr ¬p) = inr ¬w
+  where
+    ¬w : Σ (Fin (S n)) P → ⊥
+    ¬w ((_ , ltS) , p) = ¬p p
+    ¬w ((k , ltSR k<n) , p) = ¬z ((k , k<n) , p)
+
+<-trans-S : {m n k : ℕ} → m < n → n < (S k) → m < k
+<-trans-S m<n ltS = m<n
+<-trans-S m<n (ltSR n<k) = <-trans m<n n<k
+
+ℕ-dichotomy : {m n : ℕ} → m ≠ n → (m < n) ⊔ (n < m)
+ℕ-dichotomy {m} {n} m≠n with ℕ-trichotomy m n
+ℕ-dichotomy {m} {n} m≠n | inl p = ⊥-rec (m≠n p)
+ℕ-dichotomy {m} {n} m≠n | inr x = x
+
+Fin-fst-= : ∀ {n} {i j : Fin n} → fst i == fst j → i == j
+Fin-fst-= {n} {i , i<n} {j , j<n} = Subtype=-out (Fin-prop n)
+
+punchout : ∀ {n} (i j : Fin (S n)) → i ≠ j → Fin n
+punchout {n} (i , i<Sn) (j , j<Sn) i≠j with ℕ-dichotomy (i≠j ∘ Fin-fst-=)
+punchout {n} (i , i<Sn) (.(S i) , Si<Sn) i≠j | inl ltS = i , <-trans-S ltS Si<Sn
+punchout {n} (i , i<Sn) (S j , Sj<Sn) i≠j | inl (ltSR i<j) = j , <-cancel-S Sj<Sn
+punchout {n} (i , i<Sn) (j , j<Sn) i≠j | inr j<i = j , <-trans-S j<i i<Sn
+
+punchout-inj : ∀ {n} (i j k : Fin (S n)) (i≠j : i ≠ j) (i≠k : i ≠ k)
+               → punchout i j i≠j == punchout i k i≠k → j == k
+punchout-inj {n} (i , i<Sn) (j , j<Sn) (k , k<Sn) i≠j i≠k q with ℕ-dichotomy (i≠j ∘ Fin-fst-=)
+punchout-inj {n} (i , i<Sn) (.(S i) , Si<Sn) (k , k<Sn) i≠j i≠k q | inl ltS with ℕ-dichotomy (i≠k ∘ Fin-fst-=)
+punchout-inj {n} (i , i<Sn) (.(S i) , Si<Sn) (.(S i) , _) i≠j i≠k q | inl ltS | inl ltS = Fin-fst-= idp
+punchout-inj {n} (i , i<Sn) (.(S i) , Si<Sn) (S k , Sk<Sn) i≠j i≠k q | inl ltS | inl (ltSR i<k) = ⊥-rec (<-to-≠ i<k (ap fst q))
+punchout-inj {n} (i , i<Sn) (.(S i) , Si<Sn) (k , k<Sn) i≠j i≠k q | inl ltS | inr k<i = ⊥-rec (i≠k (Fin-fst-= (ap fst q)))
+punchout-inj {n} (i , i<Sn) (S j , Sj<Sn) (k , k<Sn) i≠j i≠k q | inl (ltSR i<j) with ℕ-dichotomy (i≠k ∘ Fin-fst-=)
+punchout-inj {n} (i , i<Sn) (S j , Sj<Sn) (.(S i) , Si<Sn) i≠j i≠k q | inl (ltSR i<j) | inl ltS = ⊥-rec (<-to-≠ i<j (! (ap fst q)))
+punchout-inj {n} (i , i<Sn) (S j , Sj<Sn) (S k , Sk<Sn) i≠j i≠k q | inl (ltSR i<j) | inl (ltSR i<k) = Fin-fst-= (ap S (ap fst q))
+punchout-inj {n} (i , i<Sn) (S j , Sj<Sn) (k , k<Sn) i≠j i≠k q | inl (ltSR i<j) | inr k<i = ⊥-rec (<-to-≠ (<-trans k<i i<j) (! (ap fst q)))
+punchout-inj {n} (i , i<Sn) (j , j<Sn) (k , k<Sn) i≠j i≠k q | inr j<i with ℕ-dichotomy (i≠k ∘ Fin-fst-=)
+punchout-inj {n} (i , i<Sn) (j , j<Sn) (.(S i) , Si<Sn) i≠j i≠k q | inr j<i | (inl ltS) = ⊥-rec (i≠j (Fin-fst-= (! (ap fst q))))
+punchout-inj {n} (i , i<Sn) (j , j<Sn) (S k , Sk<Sn) i≠j i≠k q | inr j<i | (inl (ltSR i<k)) = ⊥-rec (<-to-≠ (<-trans j<i i<k) (ap fst q))
+punchout-inj {n} (i , i<Sn) (j , j<Sn) (k , k<Sn) i≠j i≠k q | inr j<i | (inr k<i) = Fin-fst-= (ap fst q)
+
+pigeonhole-special : ∀ {n} (f : Fin (S n) → Fin n)
+                     → Σ (Fin (S n)) λ i → Σ (Fin (S n)) λ j → (i ≠ j) × (f i == f j)
+pigeonhole-special {O} f = ⊥-rec (–> Fin-equiv-Empty (f (O , ltS)))
+pigeonhole-special {S n} f with Dec-Σ-Fin (λ i → f (incl ltS i) == f (S n , ltS))
+                                          (λ i → Fin-has-dec-eq (f (incl ltS i)) (f (S n , ltS)))
+pigeonhole-special {S n} f | inl (i , p) = incl ltS i , (S n , ltS) , incl-ne i , p
+pigeonhole-special {S n} f | inr h = incl ltS i , incl ltS j , (λ q → i≠j (Fin-fst-= (ap fst q))) ,
+     punchout-inj (f (S n , ltS)) (f (incl ltS i)) (f (incl ltS j))
+     (λ q → h (i , Fin-fst-= (! (ap fst q))))
+     (λ q → h (j , Fin-fst-= (! (ap fst q))))
+     (Fin-fst-= (ap fst p))
+  where
+    g : Fin (S n) → Fin n
+    g k = punchout (f (S n , ltS)) (f (incl ltS k)) λ p → h (k , Fin-fst-= (! (ap fst p)))
+
+    i : Fin (S n)
+    i = fst (pigeonhole-special g)
+
+    j : Fin (S n)
+    j = fst (snd (pigeonhole-special g))
+
+    i≠j : i ≠ j
+    i≠j = fst (snd (snd (pigeonhole-special g)))
+
+    p : g i == g j
+    p = snd (snd (snd (pigeonhole-special g)))
+
+pigeonhole : ∀ {m n} (m<n : m < n) (f : Fin n → Fin m)
+             → Σ (Fin n) λ i → Σ (Fin n) λ j → (i ≠ j) × (f i == f j)
+pigeonhole {m} {.(S m)} ltS f = pigeonhole-special f
+pigeonhole {m} {(S n)} (ltSR p) f = i , j , ¬q , Subtype=-out (Fin-prop m) (ap fst r)
+  where
+    g : Fin (S n) → Fin n
+    g k = fst (f k) , <-trans (snd (f k)) p
+
+    i : Fin (S n)
+    i = fst (pigeonhole-special g)
+
+    j : Fin (S n)
+    j = fst (snd (pigeonhole-special g))
+
+    ¬q : i == j → ⊥
+    ¬q = fst (snd (snd (pigeonhole-special g)))
+
+    r : g i == g j
+    r = snd (snd (snd (pigeonhole-special g)))


### PR DESCRIPTION
Since the FinSet equivalence requires ConstantToSetExtendsToProp, I've put FinSet.agda in theorems/homotopy, but that's not ideal. Perhaps it would be better to move ConstantToSetExtendsToProp to core and then put FinSet in core/lib/types?