### PR TITLE
Use instance arguments for `has-level n`

### DIFF
--- a/core/lib/Base.agda
+++ b/core/lib/Base.agda
@@ -53,6 +53,11 @@ of-type A u = u
 infix 40 of-type
 syntax of-type A u =  u :> A
 
+{- Instance search -}
+
+⟨⟩ : ∀ {i} {A : Type i} {{a : A}} → A
+⟨⟩ {{a}} = a
+
 {- Identity type
 
 The identity type is called [Path] and [_==_] because the symbol [=] is

--- a/core/lib/Equivalence.agda
+++ b/core/lib/Equivalence.agda
@@ -233,7 +233,7 @@ lower-equiv = equiv lower lift (λ _ → idp) (λ _ → idp)
 {- Any contractible type is equivalent to (all liftings of) the unit type -}
 module _ {i} {A : Type i} (h : is-contr A) where
   contr-equiv-Unit : A ≃ Unit
-  contr-equiv-Unit = equiv (λ _ → unit) (λ _ → fst h) (λ _ → idp) (snd h)
+  contr-equiv-Unit = equiv (λ _ → unit) (λ _ → contr-center h) (λ _ → idp) (contr-path h)
 
   contr-equiv-LiftUnit : ∀ {j} → A ≃ Lift {j = j} Unit
   contr-equiv-LiftUnit = lower-equiv ⁻¹ ∘e contr-equiv-Unit
@@ -285,11 +285,11 @@ module _ {i j} {A : Type i} {B : Type j} where
 {- Equivalent types have the same truncation level -}
 abstract
   equiv-preserves-level : ∀ {i j} {A : Type i} {B : Type j} {n : ℕ₋₂} (e : A ≃ B)
-    → (has-level n A → has-level n B)
-  equiv-preserves-level {n = ⟨-2⟩} e (x , p) =
-    (–> e x , (λ y → ap (–> e) (p _) ∙ <–-inv-r e y))
-  equiv-preserves-level {n = S n} e c = λ x y →
-     equiv-preserves-level (ap-equiv (e ⁻¹) x y ⁻¹) (c (<– e x) (<– e y))
+    {{_ : has-level n A}} → has-level n B
+  equiv-preserves-level {n = ⟨-2⟩} e {{p}} =
+    has-level-make (–> e (contr-center p) , (λ y → ap (–> e) (contr-path p _) ∙ <–-inv-r e y))
+  equiv-preserves-level {n = S n} e {{c}} = has-level-make (λ x y →
+    equiv-preserves-level (ap-equiv (e ⁻¹) x y ⁻¹) {{has-level-apply c (<– e x) (<– e y)}})
 
 {- This is a collection of type equivalences involving basic type formers.
    We exclude Empty since Π₁-Empty requires λ=.

--- a/core/lib/Equivalence.agda
+++ b/core/lib/Equivalence.agda
@@ -287,8 +287,8 @@ abstract
   equiv-preserves-level : ∀ {i j} {A : Type i} {B : Type j} {n : ℕ₋₂} (e : A ≃ B)
     {{_ : has-level n A}} → has-level n B
   equiv-preserves-level {n = ⟨-2⟩} e {{p}} =
-    has-level-make (–> e (contr-center p) , (λ y → ap (–> e) (contr-path p _) ∙ <–-inv-r e y))
-  equiv-preserves-level {n = S n} e {{c}} = has-level-make (λ x y →
+    has-level-in (–> e (contr-center p) , (λ y → ap (–> e) (contr-path p _) ∙ <–-inv-r e y))
+  equiv-preserves-level {n = S n} e {{c}} = has-level-in (λ x y →
     equiv-preserves-level (ap-equiv (e ⁻¹) x y ⁻¹) {{has-level-apply c (<– e x) (<– e y)}})
 
 {- This is a collection of type equivalences involving basic type formers.

--- a/core/lib/Equivalence2.agda
+++ b/core/lib/Equivalence2.agda
@@ -44,14 +44,14 @@ is-contr-map {A = A} {B = B} f = (y : B) → is-contr (hfiber f y)
 equiv-is-contr-map : ∀ {i j} {A : Type i} {B : Type j} {f : A → B}
   → (is-equiv f → is-contr-map f)
 equiv-is-contr-map e y =
-   equiv-preserves-level (Σ-emap-l (_== y) (_ , e) ⁻¹) (pathto-is-contr y)
+   equiv-preserves-level (Σ-emap-l (_== y) (_ , e) ⁻¹)
 
 contr-map-is-equiv : ∀ {i j} {A : Type i} {B : Type j} {f : A → B}
   → (is-contr-map f → is-equiv f)
 contr-map-is-equiv {f = f} cm = is-eq _
-  (λ b → fst (fst (cm b)))
-  (λ b → snd (fst (cm b)))
-  (λ a → ap fst (snd (cm (f a)) (a , idp)))
+  (λ b → fst (contr-center (cm b)))
+  (λ b → snd (contr-center (cm b)))
+  (λ a → ap fst (contr-path (cm (f a)) (a , idp)))
 
 
 fiber=-econv : ∀ {i j} {A : Type i} {B : Type j} {h : A → B} {y : B}
@@ -81,11 +81,11 @@ module _ {i j} {A : Type i} {B : Type j} {f : A → B} (e : is-equiv f) where
 
   equiv-linv-is-contr : is-contr (linv f)
   equiv-linv-is-contr = equiv-preserves-level (Σ-emap-r λ _ → λ=-equiv ⁻¹)
-                          (equiv-is-contr-map (pre∘-is-equiv e) (idf A))
+                          {{equiv-is-contr-map (pre∘-is-equiv e) (idf A)}}
 
   equiv-rinv-is-contr : is-contr (rinv f)
   equiv-rinv-is-contr = equiv-preserves-level (Σ-emap-r λ _ → λ=-equiv ⁻¹)
-                          (equiv-is-contr-map (post∘-is-equiv e) (idf B))
+                          {{equiv-is-contr-map (post∘-is-equiv e) (idf B)}}
 
 module _ {i j} {A : Type i} {B : Type j} {f : A → B} where
 
@@ -109,7 +109,7 @@ module _ {i j} {A : Type i} {B : Type j} {f : A → B} where
 equiv-rcoh-is-contr : ∀ {i j} {A : Type i} {B : Type j} {f : A → B}
                       (e : is-equiv f) → (v : rinv f) → is-contr (rcoh f v)
 equiv-rcoh-is-contr {f = f} e v = equiv-preserves-level ((rcoh-econv v)⁻¹)
-  (Π-level (λ x → =-preserves-level (equiv-is-contr-map e (f x))))
+  {{Π-level (λ x → =-preserves-level (equiv-is-contr-map e (f x)))}}
 
 rinv-and-rcoh-is-equiv : ∀ {i j} {A : Type i} {B : Type j} {h : A → B}
   → Σ (rinv h) (rcoh h) ≃ is-equiv h
@@ -124,14 +124,19 @@ is-equiv-is-prop : ∀ {i j} {A : Type i} {B : Type j} {f : A → B}
   → is-prop (is-equiv f)
 is-equiv-is-prop = inhab-to-contr-is-prop λ e →
   equiv-preserves-level rinv-and-rcoh-is-equiv
-    (Σ-level (equiv-rinv-is-contr e) (equiv-rcoh-is-contr e))
+    {{Σ-level (equiv-rinv-is-contr e) (equiv-rcoh-is-contr e)}}
+
+instance
+  is-equiv-level : ∀ {i j} {A : Type i} {B : Type j} {f : A → B} {n : ℕ₋₂}
+    → has-level (S n) (is-equiv f)
+  is-equiv-level = prop-has-level-S is-equiv-is-prop
 
 is-equiv-prop : ∀ {i j} {A : Type i} {B : Type j}
   → SubtypeProp (A → B) (lmax i j)
 is-equiv-prop = is-equiv , λ f → is-equiv-is-prop
 
 ∘e-unit-r : ∀ {i} {A B : Type i} (e : A ≃ B) → (e ∘e ide A) == e
-∘e-unit-r e = pair= idp (prop-has-all-paths is-equiv-is-prop _ _)
+∘e-unit-r e = pair= idp (prop-has-all-paths _ _)
 
 ua-∘e : ∀ {i} {A B : Type i}
   (e₁ : A ≃ B) {C : Type i} (e₂ : B ≃ C) → ua (e₂ ∘e e₁) == ua e₁ ∙ ua e₂
@@ -159,7 +164,7 @@ module _ {j} {B : Empty → Type j} where
   Σ₁-Empty = equiv (⊥-rec ∘ fst) ⊥-rec ⊥-elim (⊥-rec ∘ fst)
 
   Π₁-Empty : Π Empty B ≃ Unit
-  Π₁-Empty = equiv (cst tt) (cst ⊥-elim) (λ _ → contr-has-all-paths Unit-is-contr _ _) (λ _ → λ= ⊥-elim)
+  Π₁-Empty = equiv (cst tt) (cst ⊥-elim) (λ _ → contr-has-all-paths _ _) (λ _ → λ= ⊥-elim)
 
 Σ₂-Empty : ∀ {i} {A : Type i} → Σ A (λ _ → Empty) ≃ Empty
 Σ₂-Empty = equiv (⊥-rec ∘ snd) ⊥-rec ⊥-elim (⊥-rec ∘ snd)

--- a/core/lib/Equivalence2.agda
+++ b/core/lib/Equivalence2.agda
@@ -120,16 +120,17 @@ rinv-and-rcoh-is-equiv {h = h} = equiv f g (λ _ → idp) (λ _ → idp)
         g : is-equiv h → Σ (rinv h) (rcoh h)
         g t = ((is-equiv.g t , is-equiv.f-g t) , (is-equiv.g-f t , is-equiv.adj t))
 
-is-equiv-is-prop : ∀ {i j} {A : Type i} {B : Type j} {f : A → B}
-  → is-prop (is-equiv f)
-is-equiv-is-prop = inhab-to-contr-is-prop λ e →
-  equiv-preserves-level rinv-and-rcoh-is-equiv
-    {{Σ-level (equiv-rinv-is-contr e) (equiv-rcoh-is-contr e)}}
+abstract
+  is-equiv-is-prop : ∀ {i j} {A : Type i} {B : Type j} {f : A → B}
+    → is-prop (is-equiv f)
+  is-equiv-is-prop = inhab-to-contr-is-prop λ e →
+    equiv-preserves-level rinv-and-rcoh-is-equiv
+      {{Σ-level (equiv-rinv-is-contr e) (equiv-rcoh-is-contr e)}}
 
-instance
-  is-equiv-level : ∀ {i j} {A : Type i} {B : Type j} {f : A → B} {n : ℕ₋₂}
-    → has-level (S n) (is-equiv f)
-  is-equiv-level = prop-has-level-S is-equiv-is-prop
+  instance
+    is-equiv-level : ∀ {i j} {A : Type i} {B : Type j} {f : A → B} {n : ℕ₋₂}
+      → has-level (S n) (is-equiv f)
+    is-equiv-level = prop-has-level-S is-equiv-is-prop
 
 is-equiv-prop : ∀ {i j} {A : Type i} {B : Type j}
   → SubtypeProp (A → B) (lmax i j)

--- a/core/lib/Function2.agda
+++ b/core/lib/Function2.agda
@@ -13,9 +13,9 @@ module _ {i j k} {A : Type i} {B : Type j} {C : Type k}
   abstract
     ∘-is-surj : is-surj g → is-surj f → is-surj (g ∘ f)
     ∘-is-surj g-is-surj f-is-surj c =
-      Trunc-rec Trunc-level
+      Trunc-rec
         (λ{(b , gb=c) →
-          Trunc-rec Trunc-level
+          Trunc-rec
           (λ{(a , fa=b) → [ a , ap g fa=b ∙ gb=c ]})
           (f-is-surj b)})
         (g-is-surj c)

--- a/core/lib/Funext.agda
+++ b/core/lib/Funext.agda
@@ -39,7 +39,7 @@ module FunextNonDep {j} {B : Type j} {f g : A → B} (h : f ∼ g)
       fst-is-equiv =
         is-eq fst (λ z → (z , (z , idp))) (λ _ → idp)
           (λ x' → ap (λ x → (_ , x))
-                        (contr-has-all-paths (pathfrom-is-contr (fst x')) _ _))
+                        (contr-has-all-paths _ _))
 
       comp-fst-is-equiv : is-equiv (λ (f : A → free-path-space-B)
                                      → (λ x → fst (f x)))
@@ -64,7 +64,7 @@ module WeakFunext {j} {P : A → Type j} (e : (x : A) → is-contr (P x)) where
   abstract
     weak-λ= : is-contr (Π A P)
     weak-λ= = transport (λ Q → is-contr (Π A Q)) (! P-is-Unit)
-                            ((λ x → lift unit) , (λ y → λ=-nondep (λ x → idp)))
+                            (has-level-make ((λ x → lift unit) , (λ y → λ=-nondep (λ x → idp))))
 
 -- Naive dependent function extensionality
 
@@ -80,8 +80,9 @@ module FunextDep {j} {P : A → Type j} {f g : Π A P} (h : f ∼ g)
     Q-is-contr : (x : A) → is-contr (Q x)
     Q-is-contr x = pathfrom-is-contr (f x)
 
-    ΠAQ-is-contr : is-contr (Π A Q)
-    ΠAQ-is-contr = weak-λ= Q-is-contr
+    instance
+      ΠAQ-is-contr : is-contr (Π A Q)
+      ΠAQ-is-contr = weak-λ= Q-is-contr
 
   Q-f : Π A Q
   Q-f x = (f x , idp)
@@ -91,7 +92,7 @@ module FunextDep {j} {P : A → Type j} {f g : Π A P} (h : f ∼ g)
 
   abstract
     Q-f==Q-g : Q-f == Q-g
-    Q-f==Q-g = contr-has-all-paths ΠAQ-is-contr Q-f Q-g
+    Q-f==Q-g = contr-has-all-paths Q-f Q-g
 
   λ= : f == g
   λ= = ap (λ u x → fst (u x)) Q-f==Q-g
@@ -108,8 +109,8 @@ module StrongFunextDep {j} {P : A → Type j} where
   λ=-idp : (f : Π A P)
     → idp == λ= (λ x → idp {a = f x})
   λ=-idp f = ap (ap (λ u x → fst (u x)))
-    (contr-has-all-paths (=-preserves-level
-                         (ΠAQ-is-contr (λ x → idp)))
+    (contr-has-all-paths {{=-preserves-level
+                           (ΠAQ-is-contr (λ x → idp))}}
                          idp (Q-f==Q-g (λ x → idp)))
 
   λ=-η : {f g : Π A P} (p : f == g)

--- a/core/lib/Funext.agda
+++ b/core/lib/Funext.agda
@@ -64,7 +64,7 @@ module WeakFunext {j} {P : A → Type j} (e : (x : A) → is-contr (P x)) where
   abstract
     weak-λ= : is-contr (Π A P)
     weak-λ= = transport (λ Q → is-contr (Π A Q)) (! P-is-Unit)
-                            (has-level-make ((λ x → lift unit) , (λ y → λ=-nondep (λ x → idp))))
+                            (has-level-in ((λ x → lift unit) , (λ y → λ=-nondep (λ x → idp))))
 
 -- Naive dependent function extensionality
 

--- a/core/lib/NConnected.agda
+++ b/core/lib/NConnected.agda
@@ -26,7 +26,7 @@ has-conn-fibers {A = A} {B = B} n f =
 
 {- all inhabited types are -1-connected -}
 inhab-conn : ∀ {i} {A : Type i} (a : A) → is-connected -1 A
-inhab-conn a = has-level-make ([ a ] , prop-has-all-paths [ a ])
+inhab-conn a = has-level-in ([ a ] , prop-has-all-paths [ a ])
 
 {- connectedness is a prop -}
 is-connected-is-prop : ∀ {i} {n : ℕ₋₂} {A : Type i}
@@ -90,7 +90,7 @@ conn-extend-general : ∀ {i j} {A : Type i} {B : Type j} {n k : ℕ₋₂}
   → ∀ t → has-level k (Σ (Π B (fst ∘ P)) (λ s → (s ∘ f) == t))
 conn-extend-general {k = ⟨-2⟩} c P t =
   equiv-is-contr-map (pre∘-conn-is-equiv c P) t
-conn-extend-general {B = B} {n = n} {k = S k'} {f = f} c P t = has-level-make
+conn-extend-general {B = B} {n = n} {k = S k'} {f = f} c P t = has-level-in
   λ {(g , p) (h , q) →
     equiv-preserves-level (e g h p q)
       {{conn-extend-general {k = k'} c (Q g h) (app= (p ∙ ! q))}} }
@@ -134,7 +134,7 @@ conn-in : ∀ {i j} {A : Type i} {B : Type j} {n : ℕ₋₂} {h : A → B}
   → has-conn-fibers n h
 conn-in {A = A} {B = B} {h = h} sec b =
   let s = sec (λ b → (Trunc _ (hfiber h b) , Trunc-level))
-  in has-level-make (fst s (λ a → [ a , idp ]) b ,
+  in has-level-in (fst s (λ a → [ a , idp ]) b ,
       Trunc-elim (λ k → transport
                    (λ v → fst s (λ a → [ a , idp ]) (fst v) == [ fst k , snd v ])
                    (contr-path (pathfrom-is-contr (h (fst k))) (b , snd k))
@@ -143,7 +143,7 @@ conn-in {A = A} {B = B} {h = h} sec b =
 abstract
   pointed-conn-in : ∀ {i} {n : ℕ₋₂} (A : Type i) (a₀ : A)
     → has-conn-fibers {A = ⊤} n (cst a₀) → is-connected (S n) A
-  pointed-conn-in {n = n} A a₀ c = has-level-make
+  pointed-conn-in {n = n} A a₀ c = has-level-in
     ([ a₀ ] ,
      Trunc-elim
        (λ a → Trunc-rec
@@ -152,7 +152,7 @@ abstract
 abstract
   pointed-conn-out : ∀ {i} {n : ℕ₋₂} (A : Type i) (a₀ : A)
     {{_ : is-connected (S n) A}} → has-conn-fibers {A = ⊤} n (cst a₀)
-  pointed-conn-out {n = n} A a₀ {{c}} a = has-level-make
+  pointed-conn-out {n = n} A a₀ {{c}} a = has-level-in
     (point ,
      λ y → ! (cancel point)
            ∙ (ap out $ contr-has-all-paths (into point) (into y))
@@ -199,7 +199,7 @@ instance
     where
     lemma : (x₀ : Trunc (S n) A) → (∀ x → x₀ == x) → is-connected (S n) (Trunc m A)
     lemma = Trunc-elim
-      (λ a → λ p → has-level-make ([ [ a ] ] ,
+      (λ a → λ p → has-level-in ([ [ a ] ] ,
         Trunc-elim
           (Trunc-elim
             {{λ _ → =-preserves-level
@@ -221,7 +221,7 @@ abstract
       (λ a₀ pA →
         Trunc-elim
           {P = λ tb → (∀ ty → tb == ty) → is-connected (S m) (Σ A B)}
-          (λ b₀ pB → has-level-make
+          (λ b₀ pB → has-level-in
             ([ a₀ , b₀ ] ,
               Trunc-elim
                 {P = λ tp → [ a₀ , b₀ ] == tp}

--- a/core/lib/NConnected.agda
+++ b/core/lib/NConnected.agda
@@ -191,21 +191,22 @@ prop-over-connected :  ∀ {i j} {A : Type i} {a : A} {{p : is-connected 0 A}}
 prop-over-connected P x = conn-extend (pointed-conn-out _ _) P (λ _ → x)
 
 {- Connectedness of a truncated type -}
-Trunc-preserves-conn : ∀ {i} {A : Type i} {n : ℕ₋₂} (m : ℕ₋₂)
-  {{_ : is-connected n A}} → is-connected n (Trunc m A)
-Trunc-preserves-conn {n = ⟨-2⟩} m = Trunc-level
-Trunc-preserves-conn {A = A} {n = S n} m {{c}} = lemma (contr-center c) (contr-path c)
-  where
-  lemma : (x₀ : Trunc (S n) A) → (∀ x → x₀ == x) → is-connected (S n) (Trunc m A)
-  lemma = Trunc-elim
-    (λ a → λ p → has-level-make ([ [ a ] ] ,
-       Trunc-elim
-         (Trunc-elim
-           {{λ _ → =-preserves-level
-                    (Trunc-preserves-level (S n) Trunc-level)}}
-           (λ x → <– (Trunc=-equiv [ [ a ] ] [ [ x ] ])
-              (Trunc-fmap (ap [_])
-                (–> (Trunc=-equiv [ a ] [ x ]) (p [ x ])))))))
+instance
+  Trunc-preserves-conn : ∀ {i} {A : Type i} {n : ℕ₋₂} {m : ℕ₋₂}
+    → is-connected n A → is-connected n (Trunc m A)
+  Trunc-preserves-conn {n = ⟨-2⟩} _ = Trunc-level
+  Trunc-preserves-conn {A = A} {n = S n} {m} c = lemma (contr-center c) (contr-path c)
+    where
+    lemma : (x₀ : Trunc (S n) A) → (∀ x → x₀ == x) → is-connected (S n) (Trunc m A)
+    lemma = Trunc-elim
+      (λ a → λ p → has-level-make ([ [ a ] ] ,
+        Trunc-elim
+          (Trunc-elim
+            {{λ _ → =-preserves-level
+                      (Trunc-preserves-level (S n) Trunc-level)}}
+            (λ x → <– (Trunc=-equiv [ [ a ] ] [ [ x ] ])
+               (Trunc-fmap (ap [_])
+                 (–> (Trunc=-equiv [ a ] [ x ]) (p [ x ])))))))
 
 {- Connectedness of a Σ-type -}
 abstract
@@ -241,6 +242,7 @@ abstract
 
 {- connectedness of a path space -}
 abstract
+ instance
   path-conn : ∀ {i} {A : Type i} {x y : A} {n : ℕ₋₂}
     → is-connected (S n) A → is-connected n (x == y)
   path-conn {x = x} {y = y} cA =

--- a/core/lib/NConnected.agda
+++ b/core/lib/NConnected.agda
@@ -26,7 +26,7 @@ has-conn-fibers {A = A} {B = B} n f =
 
 {- all inhabited types are -1-connected -}
 inhab-conn : ∀ {i} {A : Type i} (a : A) → is-connected -1 A
-inhab-conn a = [ a ] , prop-has-all-paths Trunc-level [ a ]
+inhab-conn a = has-level-make ([ a ] , prop-has-all-paths [ a ])
 
 {- connectedness is a prop -}
 is-connected-is-prop : ∀ {i} {n : ℕ₋₂} {A : Type i}
@@ -45,23 +45,23 @@ abstract
           helper : Π A (fst ∘ P ∘ h)
             → (b : B) → Trunc n (Σ A (λ a → h a == b)) → (fst (P b))
           helper t b r =
-            Trunc-rec (snd (P b))
+            Trunc-rec {{snd (P b)}}
               (λ x → transport (λ y → fst (P y)) (snd x) (t (fst x)))
               r
 
           g : Π A (fst ∘ P ∘ h) → Π B (fst ∘ P)
-          g t b = helper t b (fst (c b))
+          g t b = helper t b (contr-center (c b))
 
           f-g : ∀ t → f (g t) == t
           f-g t = λ= $ λ a → transport
-            (λ r →  Trunc-rec (snd (P (h a))) _ r == t a)
-            (! (snd (c (h a)) [ (a , idp) ]))
+            (λ r →  Trunc-rec {{snd (P (h a))}} _ r == t a)
+            (! (contr-path(c (h a)) [ (a , idp) ]))
             idp
 
           g-f : ∀ k → g (f k) == k
           g-f k = λ= $ λ (b : B) →
-            Trunc-elim (λ r → =-preserves-level {x = helper (k ∘ h) b r} (snd (P b)))
-                       (λ x → lemma (fst x) b (snd x)) (fst (c b))
+            Trunc-elim {{λ r → =-preserves-level {x = helper (k ∘ h) b r} (snd (P b))}}
+                       (λ x → lemma (fst x) b (snd x)) (contr-center (c b))
             where
             lemma : ∀ xl → ∀ b → (p : h xl == b) →
               helper (k ∘ h) b [ (xl , p) ] == k b
@@ -90,13 +90,13 @@ conn-extend-general : ∀ {i j} {A : Type i} {B : Type j} {n k : ℕ₋₂}
   → ∀ t → has-level k (Σ (Π B (fst ∘ P)) (λ s → (s ∘ f) == t))
 conn-extend-general {k = ⟨-2⟩} c P t =
   equiv-is-contr-map (pre∘-conn-is-equiv c P) t
-conn-extend-general {B = B} {n = n} {k = S k'} {f = f} c P t =
+conn-extend-general {B = B} {n = n} {k = S k'} {f = f} c P t = has-level-make
   λ {(g , p) (h , q) →
-    equiv-preserves-level (e g h p q) $
-      conn-extend-general {k = k'} c (Q g h) (app= (p ∙ ! q))}
+    equiv-preserves-level (e g h p q)
+      {{conn-extend-general {k = k'} c (Q g h) (app= (p ∙ ! q))}} }
   where
     Q : (g h : Π B (fst ∘ P)) → B → (k' +2+ n) -Type _
-    Q g h b = ((g b == h b) , snd (P b) _ _)
+    Q g h b = ((g b == h b) , has-level-apply (snd (P b)) _ _)
 
     app=-ap : ∀ {i j k} {A : Type i} {B : Type j} {C : B → Type k}
       (f : A → B) {g h : Π B C} (p : g == h)
@@ -134,31 +134,28 @@ conn-in : ∀ {i j} {A : Type i} {B : Type j} {n : ℕ₋₂} {h : A → B}
   → has-conn-fibers n h
 conn-in {A = A} {B = B} {h = h} sec b =
   let s = sec (λ b → (Trunc _ (hfiber h b) , Trunc-level))
-  in (fst s (λ a → [ a , idp ]) b ,
-      λ kt → Trunc-elim (λ kt → =-preserves-level {y = kt} Trunc-level)
-        (λ k → transport
-                 (λ v → fst s (λ a → [ a , idp ]) (fst v) == [ fst k , snd v ])
-                 (snd (pathfrom-is-contr (h (fst k))) (b , snd k))
-                 (snd s (λ a → [ a , idp ]) (fst k)))
-        kt)
+  in has-level-make (fst s (λ a → [ a , idp ]) b ,
+      Trunc-elim (λ k → transport
+                   (λ v → fst s (λ a → [ a , idp ]) (fst v) == [ fst k , snd v ])
+                   (contr-path (pathfrom-is-contr (h (fst k))) (b , snd k))
+                   (snd s (λ a → [ a , idp ]) (fst k))))
 
 abstract
   pointed-conn-in : ∀ {i} {n : ℕ₋₂} (A : Type i) (a₀ : A)
     → has-conn-fibers {A = ⊤} n (cst a₀) → is-connected (S n) A
-  pointed-conn-in {n = n} A a₀ c =
+  pointed-conn-in {n = n} A a₀ c = has-level-make
     ([ a₀ ] ,
-     Trunc-elim (λ _ → =-preserves-level Trunc-level)
-       (λ a → Trunc-rec (Trunc-level {n = S n} _ _)
-             (λ x → ap [_] (snd x)) (fst $ c a)))
+     Trunc-elim
+       (λ a → Trunc-rec
+             (λ x → ap [_] (snd x)) (contr-center $ c a)))
 
 abstract
   pointed-conn-out : ∀ {i} {n : ℕ₋₂} (A : Type i) (a₀ : A)
-    → is-connected (S n) A → has-conn-fibers {A = ⊤} n (cst a₀)
-  pointed-conn-out {n = n} A a₀ c a =
+    {{_ : is-connected (S n) A}} → has-conn-fibers {A = ⊤} n (cst a₀)
+  pointed-conn-out {n = n} A a₀ {{c}} a = has-level-make
     (point ,
      λ y → ! (cancel point)
-           ∙ (ap out $ contr-has-all-paths (=-preserves-level c)
-                                           (into point) (into y))
+           ∙ (ap out $ contr-has-all-paths (into point) (into y))
            ∙ cancel y)
     where
       into-aux : Trunc n (Σ ⊤ (λ _ → a₀ == a)) → Trunc n (a₀ == a)
@@ -182,38 +179,37 @@ abstract
           =⟨ Trunc-fmap-∘ _ _ x ⟩
         Trunc-fmap (λ q → (tt , (snd q))) x
           =⟨ Trunc-elim {P = λ x → Trunc-fmap (λ q → (tt , snd q)) x == x}
-               (λ _ → =-preserves-level Trunc-level) (λ _ → idp) x ⟩
+               (λ _ → idp) x ⟩
         x =∎
 
       point : Trunc n (Σ ⊤ (λ _ → a₀ == a))
-      point = out $ contr-has-all-paths c [ a₀ ] [ a ]
+      point = out $ contr-has-all-paths [ a₀ ] [ a ]
 
-prop-over-connected :  ∀ {i j} {A : Type i} {a : A} (p : is-connected 0 A)
+prop-over-connected :  ∀ {i j} {A : Type i} {a : A} {{p : is-connected 0 A}}
   → (P : A → hProp j)
   → fst (P a) → Π A (fst ∘ P)
-prop-over-connected p P x = conn-extend (pointed-conn-out _ _ p) P (λ _ → x)
+prop-over-connected P x = conn-extend (pointed-conn-out _ _) P (λ _ → x)
 
 {- Connectedness of a truncated type -}
 Trunc-preserves-conn : ∀ {i} {A : Type i} {n : ℕ₋₂} (m : ℕ₋₂)
-  → is-connected n A → is-connected n (Trunc m A)
-Trunc-preserves-conn {n = ⟨-2⟩} m c = Trunc-level
-Trunc-preserves-conn {A = A} {n = S n} m c = lemma (fst c) (snd c)
+  {{_ : is-connected n A}} → is-connected n (Trunc m A)
+Trunc-preserves-conn {n = ⟨-2⟩} m = Trunc-level
+Trunc-preserves-conn {A = A} {n = S n} m {{c}} = lemma (contr-center c) (contr-path c)
   where
   lemma : (x₀ : Trunc (S n) A) → (∀ x → x₀ == x) → is-connected (S n) (Trunc m A)
   lemma = Trunc-elim
-    (λ _ → Π-level (λ _ → Σ-level Trunc-level
-                     (λ _ → Π-level (λ _ → =-preserves-level Trunc-level))))
-    (λ a → λ p → ([ [ a ] ] ,
-       Trunc-elim (λ _ → =-preserves-level Trunc-level)
+    (λ a → λ p → has-level-make ([ [ a ] ] ,
+       Trunc-elim
          (Trunc-elim
-           (λ _ → =-preserves-level
-                    (Trunc-preserves-level (S n) Trunc-level))
+           {{λ _ → =-preserves-level
+                    (Trunc-preserves-level (S n) Trunc-level)}}
            (λ x → <– (Trunc=-equiv [ [ a ] ] [ [ x ] ])
               (Trunc-fmap (ap [_])
                 (–> (Trunc=-equiv [ a ] [ x ]) (p [ x ])))))))
 
 {- Connectedness of a Σ-type -}
 abstract
+ instance
   Σ-conn : ∀ {i} {j} {A : Type i} {B : A → Type j} {n : ℕ₋₂}
     → is-connected n A → (∀ a → is-connected n (B a))
     → is-connected n (Σ A B)
@@ -221,25 +217,22 @@ abstract
   Σ-conn {A = A} {B = B} {n = S m} cA cB =
     Trunc-elim
       {P = λ ta → (∀ tx → ta == tx) → is-connected (S m) (Σ A B)}
-      (λ _ → Π-level (λ _ → prop-has-level-S is-contr-is-prop))
       (λ a₀ pA →
         Trunc-elim
           {P = λ tb → (∀ ty → tb == ty) → is-connected (S m) (Σ A B)}
-          (λ _ → Π-level (λ _ → prop-has-level-S is-contr-is-prop))
-          (λ b₀ pB →
+          (λ b₀ pB → has-level-make
             ([ a₀ , b₀ ] ,
               Trunc-elim
                 {P = λ tp → [ a₀ , b₀ ] == tp}
-                (λ _ → =-preserves-level Trunc-level)
                 (λ {(r , s) →
-                  Trunc-rec (Trunc-level {n = S m} _ _)
-                    (λ pa → Trunc-rec (Trunc-level {n = S m} _ _)
+                  Trunc-rec
+                    (λ pa → Trunc-rec
                       (λ pb → ap [_] (pair= pa (from-transp! B pa pb)))
                       (–> (Trunc=-equiv [ b₀ ] [ transport! B pa s ])
                           (pB [ transport! B pa s ])))
                     (–> (Trunc=-equiv [ a₀ ] [ r ]) (pA [ r ]))})))
-          (fst (cB a₀)) (snd (cB a₀)))
-      (fst cA) (snd cA)
+          (contr-center (cB a₀)) (contr-path (cB a₀)))
+      (contr-center cA) (contr-path cA)
 
   ×-conn : ∀ {i} {j} {A : Type i} {B : Type j} {n : ℕ₋₂}
     → is-connected n A → is-connected n B
@@ -252,25 +245,25 @@ abstract
     → is-connected (S n) A → is-connected n (x == y)
   path-conn {x = x} {y = y} cA =
     equiv-preserves-level (Trunc=-equiv [ x ] [ y ])
-      (contr-is-prop cA [ x ] [ y ])
+      {{has-level-apply (contr-is-prop cA) [ x ] [ y ]}}
 
 {- an n-Type which is n-connected is contractible -}
 connected-at-level-is-contr : ∀ {i} {A : Type i} {n : ℕ₋₂}
-  → has-level n A → is-connected n A → is-contr A
-connected-at-level-is-contr pA cA =
-  equiv-preserves-level (unTrunc-equiv _ pA) cA
+  {{pA : has-level n A}} {{cA : is-connected n A}} → is-contr A
+connected-at-level-is-contr {{pA}} {{cA}} =
+  equiv-preserves-level (unTrunc-equiv _) {{cA}}
 
 {- if A is n-connected and m ≤ n, then A is m-connected -}
 connected-≤T : ∀ {i} {m n : ℕ₋₂} {A : Type i}
-  → m ≤T n → is-connected n A → is-connected m A
-connected-≤T {m = m} {n = n} {A = A} leq cA =
+  → m ≤T n → {{_ : is-connected n A}} → is-connected m A
+connected-≤T {m = m} {n = n} {A = A} leq =
   transport (λ B → is-contr B)
             (ua (Trunc-fuse A m n) ∙ ap (λ k → Trunc k A) (minT-out-l leq))
-            (Trunc-preserves-level m cA)
+            (Trunc-preserves-level m ⟨⟩)
 
 {- Equivalent types have the same connectedness -}
 equiv-preserves-conn : ∀ {i j} {A : Type i} {B : Type j} {n : ℕ₋₂} (e : A ≃ B)
-  → (is-connected n A → is-connected n B)
+  {{_ : is-connected n A}} → is-connected n B
 equiv-preserves-conn {n = n} e = equiv-preserves-level (Trunc-emap n e)
 
 {- Composite of two connected functions is connected -}

--- a/core/lib/NType.agda
+++ b/core/lib/NType.agda
@@ -23,7 +23,7 @@ module _ {i} where
     -- Agda notices that the record is recursive, so we need to specify that we want eta-equality
     inductive
     eta-equality
-    constructor has-level-make
+    constructor has-level-in
     field
       has-level-apply : has-level-aux n A
   open has-level public
@@ -52,7 +52,7 @@ module _ {i} where
 
   abstract
     all-paths-is-prop : {A : Type i} → (has-all-paths A → is-prop A)
-    all-paths-is-prop {A} c = has-level-make (λ x y → has-level-make (c x y , canon-path)) where
+    all-paths-is-prop {A} c = has-level-in (λ x y → has-level-in (c x y , canon-path)) where
 
       canon-path : {x y : A} (p : x == y) → c x y == p
       canon-path {.y} {y} idp =
@@ -69,7 +69,7 @@ module _ {i} where
   raise-level ⟨-2⟩ q =
     all-paths-is-prop (λ x y → ! (contr-path q x) ∙ contr-path q y)
   raise-level (S n) q =
-    has-level-make (λ x y → raise-level n (has-level-apply q x y))
+    has-level-in (λ x y → raise-level n (has-level-apply q x y))
 
   {- Having decidable equality is stronger that being a set -}
 
@@ -102,7 +102,7 @@ module _ {i} where
       UIP idp q | inr r⊥ | _ = Empty-elim (r⊥ idp)
 
     dec-eq-is-set : {A : Type i} → has-dec-eq A → is-set A
-    dec-eq-is-set d = has-level-make (λ x y → dec-onesided-eq-is-prop x (d x) y)
+    dec-eq-is-set d = has-level-in (λ x y → dec-onesided-eq-is-prop x (d x) y)
 
   {- Relationships between levels -}
 
@@ -115,14 +115,14 @@ module _ {i} where
       prop-has-all-paths {{c}} x y = prop-path c x y
 
       inhab-prop-is-contr : A → {{_ : is-prop A}} → is-contr A
-      inhab-prop-is-contr x₀ {{p}} = has-level-make (x₀ , λ y → prop-path p x₀ y)
+      inhab-prop-is-contr x₀ {{p}} = has-level-in (x₀ , λ y → prop-path p x₀ y)
 
       inhab-to-contr-is-prop : (A → is-contr A) → is-prop A
       inhab-to-contr-is-prop c = all-paths-is-prop $
         λ x y → ! (contr-path (c x) x) ∙ contr-path (c x) y
 
       inhab-to-prop-is-prop : (A → is-prop A) → is-prop A
-      inhab-to-prop-is-prop c = has-level-make (λ x y → has-level-apply (c x) x y)
+      inhab-to-prop-is-prop c = has-level-in (λ x y → has-level-apply (c x) x y)
 
       contr-has-level : {n : ℕ₋₂} → (is-contr A → has-level n A)
       contr-has-level {n = ⟨-2⟩} p = p
@@ -146,7 +146,7 @@ module _ {i} where
       prop-is-set = prop-has-level-S
 
       =-preserves-contr : {x y : A} → is-contr A → is-contr (x == y)
-      =-preserves-contr p = has-level-make (contr-has-all-paths {{p}} _ _ , unique-path) where
+      =-preserves-contr p = has-level-in (contr-has-all-paths {{p}} _ _ , unique-path) where
           unique-path : {u v : A} (q : u == v)
             → contr-has-all-paths {{p}} u v == q
           unique-path idp = !-inv-l (contr-path p _)
@@ -161,14 +161,14 @@ module _ {i} where
     {- The type of paths from a fixed point is contractible -}
     instance
       pathfrom-is-contr : (x : A) → is-contr (Σ A (λ t → x == t))
-      pathfrom-is-contr x = has-level-make ((x , idp) , pathfrom-unique-path) where
+      pathfrom-is-contr x = has-level-in ((x , idp) , pathfrom-unique-path) where
         pathfrom-unique-path : {u : A} (pp : Σ A (λ t → u == t)) → (u , idp) == pp
         pathfrom-unique-path (u , idp) = idp
 
     {- The type of paths to a fixed point is contractible -}
     instance
       pathto-is-contr : (x : A) → is-contr (Σ A (λ t → t == x))
-      pathto-is-contr x = has-level-make ((x , idp) , pathto-unique-path) where
+      pathto-is-contr x = has-level-in ((x , idp) , pathto-unique-path) where
         pathto-unique-path : {u : A} (pp : Σ A (λ t → t == u)) → (u , idp) == pp
         pathto-unique-path (u , idp) = idp
 

--- a/core/lib/NType.agda
+++ b/core/lib/NType.agda
@@ -10,15 +10,39 @@ module _ {i} where
 
   {- Definition of contractible types and truncation levels -}
 
-  is-contr : Type i → Type i
-  is-contr A = Σ A (λ x → ((y : A) → x == y))
+  -- We define `has-level' as a record, so that it does not unfold when
+  -- applied to (S n), in order for instance arguments to work correctly
+  -- (idea by Dan Licata)
+  record has-level (n : ℕ₋₂) (A : Type i) : Type i
 
-  has-level : ℕ₋₂ → (Type i → Type i)
-  has-level ⟨-2⟩ A = is-contr A
-  has-level (S n) A = (x y : A) → has-level n (x == y)
+  has-level-aux : ℕ₋₂ → (Type i → Type i)
+  has-level-aux ⟨-2⟩ A = Σ A (λ x → ((y : A) → x == y))
+  has-level-aux (S n) A = (x y : A) → has-level n (x == y)
 
+  record has-level n A where
+    inductive
+    eta-equality
+    constructor has-level-make
+    field
+      has-level-apply : has-level-aux n A
+  open has-level public
+
+  instance
+    has-level-apply-instance : {A : Type i} {n : ℕ₋₂} {x y : A} {{p : has-level (S n) A}} → has-level n (x == y)
+    has-level-apply-instance {x = x} {y} {{p}} = has-level-apply p x y
+
+  is-contr = has-level -2
   is-prop = has-level -1
   is-set  = has-level 0
+
+  contr-center : {A : Type i} (p : is-contr A) → A
+  contr-center p = fst (has-level-apply p)
+
+  contr-path : {A : Type i} (p : is-contr A) (y : A) → contr-center p == y
+  contr-path p y = snd (has-level-apply p) y
+
+  prop-path : {A : Type i} (p : is-prop A) (x y : A) → x == y
+  prop-path p x y = contr-center (has-level-apply p x y)
 
   {- To be a mere proposition, it is sufficient that all points are equal -}
 
@@ -27,7 +51,7 @@ module _ {i} where
 
   abstract
     all-paths-is-prop : {A : Type i} → (has-all-paths A → is-prop A)
-    all-paths-is-prop {A} c x y = (c x y , canon-path) where
+    all-paths-is-prop {A} c = has-level-make (λ x y → has-level-make (c x y , canon-path)) where
 
       canon-path : {x y : A} (p : x == y) → c x y == p
       canon-path {.y} {y} idp =
@@ -43,9 +67,9 @@ module _ {i} where
     raise-level : {A : Type i} (n : ℕ₋₂)
       → (has-level n A → has-level (S n) A)
     raise-level ⟨-2⟩ q =
-      all-paths-is-prop (λ x y → ! (snd q x) ∙ snd q y)
+      all-paths-is-prop (λ x y → ! (contr-path q x) ∙ contr-path q y)
     raise-level (S n) q =
-      λ x y → raise-level n (q x y)
+      has-level-make (λ x y → raise-level n (has-level-apply q x y))
 
   {- Having decidable equality is stronger that being a set -}
 
@@ -78,27 +102,27 @@ module _ {i} where
       UIP idp q | inr r⊥ | _ = Empty-elim (r⊥ idp)
 
     dec-eq-is-set : {A : Type i} → has-dec-eq A → is-set A
-    dec-eq-is-set d x y = dec-onesided-eq-is-prop x (d x) y
+    dec-eq-is-set d = has-level-make (λ x y → dec-onesided-eq-is-prop x (d x) y)
 
   {- Relationships between levels -}
 
   module _ {A : Type i} where
     abstract
-      contr-has-all-paths : is-contr A → has-all-paths A
-      contr-has-all-paths c x y = ! (snd c x) ∙ snd c y
+      contr-has-all-paths : {{_ : is-contr A}} → has-all-paths A
+      contr-has-all-paths {{c}} x y = ! (contr-path c x) ∙ contr-path c y
 
-      prop-has-all-paths : is-prop A → has-all-paths A
-      prop-has-all-paths c x y = fst (c x y)
+      prop-has-all-paths : {{_ : is-prop A}} → has-all-paths A
+      prop-has-all-paths {{c}} x y = prop-path c x y
 
-      inhab-prop-is-contr : A → is-prop A → is-contr A
-      inhab-prop-is-contr x₀ p = (x₀ , λ y → fst (p x₀ y))
+      inhab-prop-is-contr : A → {{_ : is-prop A}} → is-contr A
+      inhab-prop-is-contr x₀ {{p}} = has-level-make (x₀ , λ y → prop-path p x₀ y)
 
       inhab-to-contr-is-prop : (A → is-contr A) → is-prop A
       inhab-to-contr-is-prop c = all-paths-is-prop $
-        λ x y → ! (snd (c x) x) ∙ snd (c x) y
+        λ x y → ! (contr-path (c x) x) ∙ contr-path (c x) y
 
       inhab-to-prop-is-prop : (A → is-prop A) → is-prop A
-      inhab-to-prop-is-prop c x y = c x x y
+      inhab-to-prop-is-prop c = has-level-make (λ x y → has-level-apply (c x) x y)
 
       contr-has-level : {n : ℕ₋₂} → (is-contr A → has-level n A)
       contr-has-level {n = ⟨-2⟩} p = p
@@ -122,31 +146,28 @@ module _ {i} where
       prop-is-set = prop-has-level-S
 
       {- If [A] has level [n], then so does [x == y] for [x y : A] -}
-      =-preserves-level : {n : ℕ₋₂} {x y : A}
-        → (has-level n A → has-level n (x == y))
-      =-preserves-level {⟨-2⟩} p = (contr-has-all-paths p _ _ , unique-path) where
-        unique-path : {u v : A} (q : u == v)
-          → contr-has-all-paths p u v == q
-        unique-path idp = !-inv-l (snd p _)
-      =-preserves-level {S n} {x} {y} p = raise-level n (p x y)
-
-      =-preserves-set : {x y : A} → (is-set A → is-set (x == y))
-      =-preserves-set = =-preserves-level
-
-      =-preserves-prop : {x y : A} → (is-prop A → is-prop (x == y))
-      =-preserves-prop = =-preserves-level
+      instance
+        =-preserves-level : {n : ℕ₋₂} {x y : A}
+          → has-level n A → has-level n (x == y)
+        =-preserves-level {⟨-2⟩} p = has-level-make (contr-has-all-paths {{p}} _ _ , unique-path) where
+          unique-path : {u v : A} (q : u == v)
+            → contr-has-all-paths {{p}} u v == q
+          unique-path idp = !-inv-l (contr-path p _)
+        =-preserves-level {S n} {x} {y} p = raise-level n (has-level-apply p x y)
 
     {- The type of paths from a fixed point is contractible -}
-    pathfrom-is-contr : (x : A) → is-contr (Σ A (λ t → x == t))
-    pathfrom-is-contr x = ((x , idp) , pathfrom-unique-path) where
-      pathfrom-unique-path : {u : A} (pp : Σ A (λ t → u == t)) → (u , idp) == pp
-      pathfrom-unique-path (u , idp) = idp
+    instance
+      pathfrom-is-contr : (x : A) → is-contr (Σ A (λ t → x == t))
+      pathfrom-is-contr x = has-level-make ((x , idp) , pathfrom-unique-path) where
+        pathfrom-unique-path : {u : A} (pp : Σ A (λ t → u == t)) → (u , idp) == pp
+        pathfrom-unique-path (u , idp) = idp
 
     {- The type of paths to a fixed point is contractible -}
-    pathto-is-contr : (x : A) → is-contr (Σ A (λ t → t == x))
-    pathto-is-contr x = ((x , idp) , pathto-unique-path) where
-      pathto-unique-path : {u : A} (pp : Σ A (λ t → t == u)) → (u , idp) == pp
-      pathto-unique-path (u , idp) = idp
+    instance
+      pathto-is-contr : (x : A) → is-contr (Σ A (λ t → t == x))
+      pathto-is-contr x = has-level-make ((x , idp) , pathto-unique-path) where
+        pathto-unique-path : {u : A} (pp : Σ A (λ t → t == u)) → (u , idp) == pp
+        pathto-unique-path (u , idp) = idp
 
     {-
     If [B] is a fibration over a contractible type [A], then any point in any
@@ -154,9 +175,11 @@ module _ {i} where
     -}
     contr-has-section : ∀ {j} {A : Type i} {B : A → Type j}
       → (is-contr A → (x : A) → (u : B x) → Π A B)
-    contr-has-section {B = B} (x , p) x₀ y₀ t = transport B (! (p x₀) ∙ p t) y₀
+    contr-has-section {B = B} p x₀ y₀ t = transport B (! (contr-path p x₀) ∙ contr-path p t) y₀
 
 {- Subtypes -}
+
+-- TODO: replace them by records, with the second field an instance field
 
 module _ {i} (A : Type i) where
   SubtypeProp : ∀ j → Type (lmax i (lsucc j))

--- a/core/lib/NType2.agda
+++ b/core/lib/NType2.agda
@@ -61,7 +61,7 @@ abstract
 
     is-contr-is-prop-aux : (x y : is-contr A) → x == y
     is-contr-is-prop-aux x y =
-      ap has-level-make
+      ap has-level-in
         (pair= (contr-path x (contr-center y))
                (↓-Π-cst-app-in (λ a → ↓-idf=cst-in' (lemma x (contr-center y) a (contr-path y a)))))
 
@@ -74,7 +74,7 @@ abstract
     has-level-aux-prop = Π-level (λ x → Π-level (λ y → has-level-is-prop))
 
     e : has-level-aux (S n) A ≃ has-level (S n) A
-    fst e = has-level-make
+    fst e = has-level-in
     is-equiv.g (snd e) = has-level-apply
     is-equiv.f-g (snd e) = λ _ → idp
     is-equiv.g-f (snd e) = λ _ → idp
@@ -169,7 +169,7 @@ hSet₀ = hSet lzero
 abstract
   ≃-contr : ∀ {i j} {A : Type i} {B : Type j}
       → is-contr A → is-contr B → is-contr (A ≃ B)
-  ≃-contr pA pB = has-level-make
+  ≃-contr pA pB = has-level-in
       ((cst (contr-center pB) , contr-to-contr-is-equiv _ pA pB)
       , (λ e → pair= (λ= (λ _ → contr-path pB _))
                      (from-transp is-equiv _ (prop-path is-equiv-is-prop _ _))))
@@ -217,7 +217,7 @@ abstract
  instance
   _-Type-level_ : (n : ℕ₋₂) (i : ULevel)
     → has-level (S n) (n -Type i)
-  (n -Type-level i) = has-level-make (λ { (A , pA) (B , pB) → aux A B pA pB}) where
+  (n -Type-level i) = has-level-in (λ { (A , pA) (B , pB) → aux A B pA pB}) where
     
     aux : (A B : Type i) (pA : has-level n A) (pB : has-level n B) → has-level n ((A , pA) == (B , pB))
     aux A B pA pB = equiv-preserves-level (nType=-econv (A , ⟨⟩) (B , ⟨⟩)) where instance _ = pA; _ = pB

--- a/core/lib/NType2.agda
+++ b/core/lib/NType2.agda
@@ -14,67 +14,77 @@ module _ {i} {A : Type i} where
   abstract
     has-dec-onesided-eq-is-prop : {x : A} → is-prop (has-dec-onesided-eq x)
     has-dec-onesided-eq-is-prop {x = x} = inhab-to-prop-is-prop λ dec →
-      Π-is-prop λ y → Dec-level (dec-onesided-eq-is-prop x dec y)
+      Π-level λ y → Dec-level (dec-onesided-eq-is-prop x dec y)
 
     has-dec-eq-is-prop : is-prop (has-dec-eq A)
-    has-dec-eq-is-prop = Π-is-prop λ _ → has-dec-onesided-eq-is-prop
+    has-dec-eq-is-prop = Π-level (λ _ → has-dec-onesided-eq-is-prop)
 
 
 module _ {i j} {A : Type i} {B : A → Type j} where
   abstract
     ↓-level : {a b : A} {p : a == b} {u : B a} {v : B b} {n : ℕ₋₂}
       → has-level (S n) (B b) → has-level n (u == v [ B ↓ p ])
-    ↓-level {p = idp} k = k _ _
+    ↓-level {p = idp} k = has-level-apply k _ _
 
     ↓-preserves-level : {a b : A} {p : a == b} {u : B a} {v : B b} {n : ℕ₋₂}
-      → has-level n (B b) → has-level n (u == v [ B ↓ p ])
-    ↓-preserves-level {p = idp} = =-preserves-level
-
-    ↓-preserves-set : {a b : A} {p : a == b} {u : B a} {v : B b}
-      → has-level 0 (B b) → has-level 0 (u == v [ B ↓ p ])
-    ↓-preserves-set = ↓-preserves-level
+      {{_ : has-level n (B b)}} → has-level n (u == v [ B ↓ p ])
+    ↓-preserves-level {p = idp} = ⟨⟩
 
     prop-has-all-paths-↓ : {x y : A} {p : x == y} {u : B x} {v : B y}
-      → (is-prop (B y) → u == v [ B ↓ p ])
-    prop-has-all-paths-↓ {p = idp} k = prop-has-all-paths k _ _
+      {{_ : is-prop (B y)}} → u == v [ B ↓ p ]
+    prop-has-all-paths-↓ {p = idp} = prop-has-all-paths _ _
 
     set-↓-has-all-paths-↓ : ∀ {k} {C : Type k}
       {x y : C → A} {p : (t : C) → x t == y t} {u : (t : C) → B (x t)} {v : (t : C) → B (y t)}
       {a b : C} {q : a == b} {α : u a == v a [ B ↓ p a ]} {β : u b == v b [ B ↓ p b ]}
-      → (is-set (B (y a)) → α == β [ (λ t → u t == v t [ B ↓ p t ]) ↓ q ])
-    set-↓-has-all-paths-↓ {q = idp} = lemma _
+      {{_ : is-set (B (y a))}} → α == β [ (λ t → u t == v t [ B ↓ p t ]) ↓ q ]
+    set-↓-has-all-paths-↓ {q = idp} {{p}} = lemma _ p
       where
         lemma : {x y : A} (p : x == y) {u : B x} {v : B y} {α β : u == v [ B ↓ p ]}
           → is-set (B y) → α == β
-        lemma idp k = fst (k _ _ _ _)
+        lemma idp k = contr-center (has-level-apply (has-level-apply k _ _) _ _)
 
 abstract
   -- Every map between contractible types is an equivalence
   contr-to-contr-is-equiv : ∀ {i j} {A : Type i} {B : Type j} (f : A → B)
     → (is-contr A → is-contr B → is-equiv f)
   contr-to-contr-is-equiv f cA cB =
-    is-eq f (λ _ → fst cA) (λ b → ! (snd cB _) ∙ snd cB b) (snd cA)
+    is-eq f (λ _ → contr-center cA) (λ b → ! (contr-path cB _) ∙ contr-path cB b) (contr-path cA)
 
   is-contr-is-prop : ∀ {i} {A : Type i} → is-prop (is-contr A)
-  is-contr-is-prop {A = A} = all-paths-is-prop (λ x y →
-    pair= (snd x (fst y))
-          (↓-Π-cst-app-in (λ a → ↓-idf=cst-in' (lemma x (fst y) a (snd y a))))) where
+  is-contr-is-prop {A = A} = all-paths-is-prop is-contr-is-prop-aux
+          where
 
     lemma : (x : is-contr A) (b a : A) (p : b == a)
-      → snd x a == snd x b ∙' p
+      → contr-path x a == contr-path x b ∙' p
     lemma x b ._ idp = idp
+
+    is-contr-is-prop-aux : (x y : is-contr A) → x == y
+    is-contr-is-prop-aux x y =
+      ap has-level-make
+        (pair= (contr-path x (contr-center y))
+               (↓-Π-cst-app-in (λ a → ↓-idf=cst-in' (lemma x (contr-center y) a (contr-path y a)))))
 
   has-level-is-prop : ∀ {i} {n : ℕ₋₂} {A : Type i}
     → is-prop (has-level n A)
   has-level-is-prop {n = ⟨-2⟩} = is-contr-is-prop
-  has-level-is-prop {n = S n} =
-    Π-level (λ x → Π-level (λ y → has-level-is-prop))
+  has-level-is-prop {n = S n} {A} = equiv-preserves-level e {{has-level-aux-prop}} where
 
-  is-prop-is-prop : ∀ {i} {A : Type i} → is-prop (is-prop A)
-  is-prop-is-prop = has-level-is-prop
+    has-level-aux-prop : is-prop (has-level-aux (S n) A)
+    has-level-aux-prop = Π-level (λ x → Π-level (λ y → has-level-is-prop))
 
-  is-set-is-prop : ∀ {i} {A : Type i} → is-prop (is-set A)
-  is-set-is-prop = has-level-is-prop
+    e : has-level-aux (S n) A ≃ has-level (S n) A
+    fst e = has-level-make
+    is-equiv.g (snd e) = has-level-apply
+    is-equiv.f-g (snd e) = λ _ → idp
+    is-equiv.g-f (snd e) = λ _ → idp
+    is-equiv.adj (snd e) = λ _ → idp
+
+  instance
+    has-level-level : ∀ {i} {n m : ℕ₋₂} {A : Type i}
+      → has-level (S m) (has-level n A)
+    has-level-level {m = ⟨-2⟩} = has-level-is-prop
+    has-level-level {m = S m} = raise-level _ has-level-level
 
 {- Subtypes. -}
 
@@ -82,16 +92,17 @@ module _ {i j} {A : Type i} (P : SubtypeProp A j) where
   private
     module P = SubtypeProp P
 
-  Subtype-level : ∀ {n : ℕ₋₂}
-    → has-level (S n) A
-    → has-level (S n) (Subtype P)
-  Subtype-level p = Σ-level p (λ x → prop-has-level-S (P.level x))
+  instance
+    Subtype-level : ∀ {n : ℕ₋₂}
+      {{_ : has-level (S n) A}}
+      → has-level (S n) (Subtype P)
+    Subtype-level = Σ-level ⟨⟩ (λ x → prop-has-level-S (P.level x))
 
   Subtype= : (x y : Subtype P) → Type i
   Subtype= x y = fst x == fst y
 
   Subtype=-out : ∀ {x y : Subtype P} → Subtype= x y → x == y
-  Subtype=-out p = pair= p (prop-has-all-paths-↓ (P.level _))
+  Subtype=-out p = pair= p (prop-has-all-paths-↓ {{P.level _}})
 
   Subtype=-β : {x y : Subtype P} (p : Subtype= x y)
     → fst= (Subtype=-out {x = x} {y = y} p) == p
@@ -100,7 +111,7 @@ module _ {i j} {A : Type i} (P : SubtypeProp A j) where
   Subtype=-η : {x y : Subtype P} (p : x == y)
     → Subtype=-out (fst= p) == p
   Subtype=-η idp = ap (pair= idp)
-    (contr-has-all-paths (P.level _ _ _) _ _)
+    (contr-has-all-paths {{has-level-apply (P.level _) _ _}} _ _)
 
   Subtype=-econv : (x y : Subtype P) → (Subtype= x y) ≃ (x == y)
   Subtype=-econv x y = equiv Subtype=-out fst= Subtype=-η Subtype=-β
@@ -112,9 +123,9 @@ module _ {i j} {A : Type i} (P : SubtypeProp A j) where
       == Subtype=-out {x} {z} (p ∙ q)
     Subtype-∙ {x} {y} {z} p q =
       Subtype=-out p ∙ Subtype=-out q
-        =⟨ Σ-∙ {p = p} {p' = q} (prop-has-all-paths-↓ (P.level (fst y))) (prop-has-all-paths-↓ (P.level (fst z))) ⟩
-      pair= (p ∙ q) (prop-has-all-paths-↓ {p = p} (P.level (fst y)) ∙ᵈ prop-has-all-paths-↓ (P.level (fst z)))
-        =⟨ contr-has-all-paths (↓-level (P.level (fst z))) _ (prop-has-all-paths-↓ (P.level (fst z)))
+        =⟨ Σ-∙ {p = p} {p' = q} (prop-has-all-paths-↓ {{P.level (fst y)}}) (prop-has-all-paths-↓ {{P.level (fst z)}}) ⟩
+      pair= (p ∙ q) (prop-has-all-paths-↓ {p = p} {{P.level (fst y)}} ∙ᵈ prop-has-all-paths-↓ {{P.level (fst z)}})
+        =⟨ contr-has-all-paths {{↓-level (P.level (fst z))}} _ (prop-has-all-paths-↓ {{P.level (fst z)}})
           |in-ctx pair= (p ∙ q) ⟩
       Subtype=-out (p ∙ q)
         =∎
@@ -125,6 +136,15 @@ is-gpd : {i : ULevel} → Type i → Type i
 is-gpd = has-level 1
 
 -- Type of all n-truncated types
+
+-- TODO: redefine it like that, so that instance arguments can work
+
+-- record _-Type_ (n : ℕ₋₂) (i : ULevel) : Type (lsucc i) where
+--   constructor _,_
+--   field
+--     El : Type i
+--     {{El-level}} : has-level n El
+-- open _-Type_ public
 
 has-level-prop : ∀ {i} → ℕ₋₂ → SubtypeProp (Type i) i
 has-level-prop n = has-level n , λ _ → has-level-is-prop
@@ -147,26 +167,18 @@ hSet₀ = hSet lzero
 -- [n -Type] is an (n+1)-type
 
 abstract
-  ≃-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j}
-    → (has-level n A → has-level n B → has-level n (A ≃ B))
-  ≃-level {n = ⟨-2⟩} pA pB =
-    ((cst (fst pB) , contr-to-contr-is-equiv _ pA pB)
-    , (λ e → pair= (λ= (λ _ → snd pB _))
-                   (from-transp is-equiv _ (fst (is-equiv-is-prop _ _)))))
-  ≃-level {n = S n} pA pB =
-    Σ-level (→-level pB) (λ _ → prop-has-level-S is-equiv-is-prop)
+  instance
+    ≃-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j}
+      → (has-level n A → has-level n B → has-level n (A ≃ B))
+    ≃-level {n = ⟨-2⟩} pA pB = has-level-make
+      ((cst (contr-center pB) , contr-to-contr-is-equiv _ pA pB)
+      , (λ e → pair= (λ= (λ _ → contr-path pB _))
+                     (from-transp is-equiv _ (prop-path is-equiv-is-prop _ _))))
+    ≃-level {n = S n} pA pB = Σ-level ⟨⟩ ⟨⟩ where instance _ = pA; _ = pB
 
-  ≃-is-set : ∀ {i j} {A : Type i} {B : Type j}
-            → is-set A → is-set B → is-set (A ≃ B)
-  ≃-is-set = ≃-level
-
-  universe-=-level : ∀ {i} {n : ℕ₋₂} {A B : Type i}
-    → (has-level n A → has-level n B → has-level n (A == B))
-  universe-=-level pA pB = equiv-preserves-level ua-equiv (≃-level pA pB)
-
-  universe-=-is-set : ∀ {i} {A B : Type i}
-    → (is-set A → is-set B → is-set (A == B))
-  universe-=-is-set = universe-=-level
+    universe-=-level : ∀ {i} {n : ℕ₋₂} {A B : Type i}
+      → (has-level n A → has-level n B → has-level n (A == B))
+    universe-=-level pA pB = equiv-preserves-level ua-equiv where instance _ = pA; _ = pB
 
 module _ {i} {n} where
   private
@@ -198,17 +210,19 @@ module _ {i} {n} where
     nType-∙ = Subtype-∙ prop
 
 abstract
+ instance
   _-Type-level_ : (n : ℕ₋₂) (i : ULevel)
     → has-level (S n) (n -Type i)
-  (n -Type-level i) A B =
-    equiv-preserves-level (nType=-econv A B)
-                          (universe-=-level (snd A) (snd B))
+  (n -Type-level i) = has-level-make (λ { (A , pA) (B , pB) → aux A B pA pB}) where
+    
+    aux : (A B : Type i) (pA : has-level n A) (pB : has-level n B) → has-level n ((A , pA) == (B , pB))
+    aux A B pA pB = equiv-preserves-level (nType=-econv (A , ⟨⟩) (B , ⟨⟩)) where instance _ = pA; _ = pB
 
-  hProp-is-set : (i : ULevel) → is-set (hProp i)
-  hProp-is-set i = -1 -Type-level i
+hProp-is-set : (i : ULevel) → is-set (hProp i)
+hProp-is-set i = -1 -Type-level i
 
-  hSet-level : (i : ULevel) → has-level 1 (hSet i)
-  hSet-level i = 0 -Type-level i
+hSet-level : (i : ULevel) → has-level 1 (hSet i)
+hSet-level i = 0 -Type-level i
 
 {- The following two lemmas are in NType2 instead of NType because of cyclic
    dependencies -}

--- a/core/lib/NType2.agda
+++ b/core/lib/NType2.agda
@@ -27,8 +27,8 @@ module _ {i j} {A : Type i} {B : A → Type j} where
     ↓-level {p = idp} k = has-level-apply k _ _
 
     ↓-preserves-level : {a b : A} {p : a == b} {u : B a} {v : B b} {n : ℕ₋₂}
-      {{_ : has-level n (B b)}} → has-level n (u == v [ B ↓ p ])
-    ↓-preserves-level {p = idp} = ⟨⟩
+      → has-level n (B b) → has-level n (u == v [ B ↓ p ])
+    ↓-preserves-level {p = idp} = =-preserves-level
 
     prop-has-all-paths-↓ : {x y : A} {p : x == y} {u : B x} {v : B y}
       {{_ : is-prop (B y)}} → u == v [ B ↓ p ]
@@ -167,18 +167,22 @@ hSet₀ = hSet lzero
 -- [n -Type] is an (n+1)-type
 
 abstract
-  instance
-    ≃-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j}
-      → (has-level n A → has-level n B → has-level n (A ≃ B))
-    ≃-level {n = ⟨-2⟩} pA pB = has-level-make
+  ≃-contr : ∀ {i j} {A : Type i} {B : Type j}
+      → is-contr A → is-contr B → is-contr (A ≃ B)
+  ≃-contr pA pB = has-level-make
       ((cst (contr-center pB) , contr-to-contr-is-equiv _ pA pB)
       , (λ e → pair= (λ= (λ _ → contr-path pB _))
                      (from-transp is-equiv _ (prop-path is-equiv-is-prop _ _))))
-    ≃-level {n = S n} pA pB = Σ-level ⟨⟩ ⟨⟩ where instance _ = pA; _ = pB
 
-    universe-=-level : ∀ {i} {n : ℕ₋₂} {A B : Type i}
-      → (has-level n A → has-level n B → has-level n (A == B))
-    universe-=-level pA pB = equiv-preserves-level ua-equiv where instance _ = pA; _ = pB
+instance
+  ≃-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j}
+    → (has-level n A → has-level n B → has-level n (A ≃ B))
+  ≃-level {n = ⟨-2⟩} = ≃-contr
+  ≃-level {n = S n} pA pB = Σ-level ⟨⟩ ⟨⟩ where instance _ = pA; _ = pB
+
+  universe-=-level : ∀ {i} {n : ℕ₋₂} {A B : Type i}
+    → (has-level n A → has-level n B → has-level n (A == B))
+  universe-=-level pA pB = equiv-preserves-level ua-equiv where instance _ = pA; _ = pB
 
 module _ {i} {n} where
   private

--- a/core/lib/Relation2.agda
+++ b/core/lib/Relation2.agda
@@ -11,7 +11,7 @@ module _ {i} {P : Type i} where
 
   instance
     Dec-level : ∀ {n} → has-level (S n) P → has-level (S n) (Dec P)
-    Dec-level {n} pP = has-level-make Dec-level-aux where
+    Dec-level {n} pP = has-level-in Dec-level-aux where
 
       Dec-level-aux : has-level-aux (S n) (Dec P)
       Dec-level-aux (inl p₁) (inl p₂) = equiv-preserves-level (inl=inl-equiv p₁ p₂ ⁻¹) {{has-level-apply pP p₁ p₂}}

--- a/core/lib/Relation2.agda
+++ b/core/lib/Relation2.agda
@@ -9,12 +9,13 @@ module lib.Relation2 where
 
 module _ {i} {P : Type i} where
 
-  Dec-level : ∀ {n} → has-level (S n) P → has-level (S n) (Dec P)
-  Dec-level {n} pP = has-level-make Dec-level-aux where
+  instance
+    Dec-level : ∀ {n} → has-level (S n) P → has-level (S n) (Dec P)
+    Dec-level {n} pP = has-level-make Dec-level-aux where
 
-    Dec-level-aux : has-level-aux (S n) (Dec P)
-    Dec-level-aux (inl p₁) (inl p₂) = equiv-preserves-level (inl=inl-equiv p₁ p₂ ⁻¹) {{has-level-apply pP p₁ p₂}}
-    Dec-level-aux (inl p) (inr ¬p) = ⊥-rec $ ¬p p
-    Dec-level-aux (inr ¬p) (inl p) = ⊥-rec $ ¬p p
-    Dec-level-aux (inr ¬p₁) (inr ¬p₂) = equiv-preserves-level (inr=inr-equiv ¬p₁ ¬p₂ ⁻¹)
+      Dec-level-aux : has-level-aux (S n) (Dec P)
+      Dec-level-aux (inl p₁) (inl p₂) = equiv-preserves-level (inl=inl-equiv p₁ p₂ ⁻¹) {{has-level-apply pP p₁ p₂}}
+      Dec-level-aux (inl p) (inr ¬p) = ⊥-rec $ ¬p p
+      Dec-level-aux (inr ¬p) (inl p) = ⊥-rec $ ¬p p
+      Dec-level-aux (inr ¬p₁) (inr ¬p₂) = equiv-preserves-level (inr=inr-equiv ¬p₁ ¬p₂ ⁻¹)
         {{has-level-apply (prop-has-level-S ⟨⟩) ¬p₁ ¬p₂}}

--- a/core/lib/Relation2.agda
+++ b/core/lib/Relation2.agda
@@ -10,10 +10,11 @@ module lib.Relation2 where
 module _ {i} {P : Type i} where
 
   Dec-level : ∀ {n} → has-level (S n) P → has-level (S n) (Dec P)
-  Dec-level pP (inl p₁) (inl p₂) =
-    equiv-preserves-level (inl=inl-equiv p₁ p₂ ⁻¹) (pP p₁ p₂)
-  Dec-level pP (inl p) (inr ¬p) = ⊥-rec $ ¬p p
-  Dec-level pP (inr ¬p) (inl p) = ⊥-rec $ ¬p p
-  Dec-level {n} pP (inr ¬p₁) (inr ¬p₂) =
-    equiv-preserves-level (inr=inr-equiv ¬p₁ ¬p₂ ⁻¹)
-      (prop-has-level-S ¬-is-prop ¬p₁ ¬p₂)
+  Dec-level {n} pP = has-level-make Dec-level-aux where
+
+    Dec-level-aux : has-level-aux (S n) (Dec P)
+    Dec-level-aux (inl p₁) (inl p₂) = equiv-preserves-level (inl=inl-equiv p₁ p₂ ⁻¹) {{has-level-apply pP p₁ p₂}}
+    Dec-level-aux (inl p) (inr ¬p) = ⊥-rec $ ¬p p
+    Dec-level-aux (inr ¬p) (inl p) = ⊥-rec $ ¬p p
+    Dec-level-aux (inr ¬p₁) (inr ¬p₂) = equiv-preserves-level (inr=inr-equiv ¬p₁ ¬p₂ ⁻¹)
+        {{has-level-apply (prop-has-level-S ⟨⟩) ¬p₁ ¬p₂}}

--- a/core/lib/groups/GroupProduct.agda
+++ b/core/lib/groups/GroupProduct.agda
@@ -46,8 +46,8 @@ module lib.groups.GroupProduct where
 
 infix 80 _×ᴳ_
 _×ᴳ_ : ∀ {i j} → Group i → Group j → Group (lmax i j)
-_×ᴳ_ (group A A-level A-struct) (group B B-level B-struct) =
-  group (A × B) (×-level A-level B-level) (×-group-struct A-struct B-struct)
+_×ᴳ_ (group A A-struct) (group B B-struct) =
+  group (A × B) (×-group-struct A-struct B-struct)
 
 
 {- general product -}
@@ -64,7 +64,7 @@ _×ᴳ_ (group A A-level A-struct) (group B B-level B-struct) =
   where open GroupStructure
 
 Πᴳ : ∀ {i j} (I : Type i) (F : I → Group j) → Group (lmax i j)
-Πᴳ I F = group (Π I (El ∘ F)) (Π-level (λ i → El-level (F i)))
+Πᴳ I F = group (Π I (El ∘ F)) {{Π-level (λ i → El-level (F i))}} -- TODO: how to get instance search to work?
                (Π-group-struct (group-struct ∘ F))
   where open Group
 

--- a/core/lib/groups/HomotopyGroup.agda
+++ b/core/lib/groups/HomotopyGroup.agda
@@ -86,7 +86,7 @@ module _ {i} where
                     ∘e Ω^-emap 1 (Ω^STruncPreIso.F r , Ω^STruncPreIso.e r))})
 
   Ω^S-group-Trunc-fuse-diag-iso : (n : ℕ) (X : Ptd i)
-    → Ω^S-group n (⊙Trunc ⟨ S n ⟩ X) Trunc-level ≃ᴳ πS n X
+    → Ω^S-group n (⊙Trunc ⟨ S n ⟩ X) ≃ᴳ πS n X
   Ω^S-group-Trunc-fuse-diag-iso n X = group-hom (fst F) pres-comp , e
     where
     r = transport (λ k → Ω^STruncPreIso n 0 k X)
@@ -99,9 +99,9 @@ abstract
   πS-Trunc-fuse-≤-iso n m X Sn≤m =
     πS n (⊙Trunc m X)
       ≃ᴳ⟨ Ω^S-group-Trunc-fuse-diag-iso n (⊙Trunc m X) ⁻¹ᴳ ⟩
-    Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X)) Trunc-level
-      ≃ᴳ⟨ Ω^S-group-emap n Trunc-level Trunc-level (≃-to-⊙≃ (Trunc-fuse-≤ (de⊙ X) Sn≤m) idp) ⟩
-    Ω^S-group n (⊙Trunc ⟨ S n ⟩ X) Trunc-level
+    Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X))
+      ≃ᴳ⟨ Ω^S-group-emap n (≃-to-⊙≃ (Trunc-fuse-≤ (de⊙ X) Sn≤m) idp) ⟩
+    Ω^S-group n (⊙Trunc ⟨ S n ⟩ X)
       ≃ᴳ⟨ Ω^S-group-Trunc-fuse-diag-iso n X ⟩
     πS n X
       ≃ᴳ∎
@@ -111,9 +111,9 @@ abstract
   πS-Trunc-fuse->-iso n m X m<n =
     πS n (⊙Trunc m X)
       ≃ᴳ⟨ Ω^S-group-Trunc-fuse-diag-iso n (⊙Trunc m X) ⁻¹ᴳ ⟩
-    Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X)) Trunc-level
+    Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X))
       ≃ᴳ⟨ contr-iso-0ᴳ _ $ inhab-prop-is-contr
-           (Group.ident (Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X)) Trunc-level))
+           (Group.ident (Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X))))
            {{Ω^-level -1 (S n) _ $ Trunc-preserves-level ⟨ S n ⟩ $
              raise-level-≤T
                (transport (λ k → m ≤T k) (+2+-comm -1 ⟨ S n ⟩₋₂) (<T-to-≤T m<n))

--- a/core/lib/groups/HomotopyGroup.agda
+++ b/core/lib/groups/HomotopyGroup.agda
@@ -44,8 +44,8 @@ abstract
   πS-Ω-split-iso n X =
     group-hom
       (Trunc-fmap (Ω^-Ω-split (S n) X))
-      (Trunc-elim (λ _ → Π-level (λ _ → =-preserves-level Trunc-level))
-        (λ p → Trunc-elim (λ _ → =-preserves-level Trunc-level)
+      (Trunc-elim
+        (λ p → Trunc-elim
           (λ q → ap [_] (Ω^S-Ω-split-∙ n X p q)))) ,
     Trunc-isemap 0 (Ω^-Ω-split-is-equiv (S n) X)
 
@@ -114,19 +114,19 @@ abstract
     Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X)) Trunc-level
       ≃ᴳ⟨ contr-iso-0ᴳ _ $ inhab-prop-is-contr
            (Group.ident (Ω^S-group n (⊙Trunc ⟨ S n ⟩ (⊙Trunc m X)) Trunc-level))
-           (Ω^-level -1 (S n) _ $ Trunc-preserves-level ⟨ S n ⟩ $
+           {{Ω^-level -1 (S n) _ $ Trunc-preserves-level ⟨ S n ⟩ $
              raise-level-≤T
                (transport (λ k → m ≤T k) (+2+-comm -1 ⟨ S n ⟩₋₂) (<T-to-≤T m<n))
-               (Trunc-level {n = m})) ⟩
+               (Trunc-level {n = m})}} ⟩
     0ᴳ ≃ᴳ∎
 
   -- XXX Naming conventions?
   πS->level-econv : ∀ {i} (n : ℕ) (m : ℕ₋₂) (X : Ptd i)
-    → (m <T ⟨ S n ⟩) → has-level m (de⊙ X)
+    → (m <T ⟨ S n ⟩) → {{_ : has-level m (de⊙ X)}}
     → πS n X ≃ᴳ 0ᴳ
-  πS->level-econv n m X lt pX =
+  πS->level-econv n m X lt =
     πS n X
-      ≃ᴳ⟨ πS-emap n (⊙unTrunc-equiv X pX ⊙⁻¹) ⟩
+      ≃ᴳ⟨ πS-emap n (⊙unTrunc-equiv X ⊙⁻¹) ⟩
     πS n (⊙Trunc m X)
       ≃ᴳ⟨ πS-Trunc-fuse->-iso n m X lt ⟩
     0ᴳ

--- a/core/lib/groups/Int.agda
+++ b/core/lib/groups/Int.agda
@@ -9,6 +9,7 @@ open import lib.types.Word
 open import lib.groups.Homomorphism
 open import lib.groups.Isomorphism
 open import lib.groups.FreeAbelianGroup
+open import lib.types.SetQuotient
 
 module lib.groups.Int where
 
@@ -23,7 +24,7 @@ module lib.groups.Int where
   }
 
 ℤ-group : Group₀
-ℤ-group = group _ ℤ-is-set ℤ-group-structure
+ℤ-group = group _ ℤ-group-structure
 
 ℤ-group-is-abelian : is-abelian ℤ-group
 ℤ-group-is-abelian = ℤ+-comm
@@ -48,8 +49,7 @@ module lib.groups.Int where
       ∙ ap (FreeAbGroup.comp Unit fs[ inr unit :: nil ]) (to-from' l)
 
     to-from : ∀ fs → to (from fs) == fs
-    to-from = FormalSum-elim (λ _ → =-preserves-set FormalSum-level)
-      to-from' (λ _ → prop-has-all-paths-↓ (FormalSum-level _ _))
+    to-from = FormalSum-elim to-from' (λ _ → prop-has-all-paths-↓)
 
     from-to : ∀ z → from (to z) == z
     from-to (pos 0) = idp

--- a/core/lib/groups/Isomorphism.agda
+++ b/core/lib/groups/Isomorphism.agda
@@ -279,7 +279,7 @@ module _ {i j} {G : Group i} {H : Group j} (φ : G →ᴳ H)
   surjᴳ-and-injᴳ-is-equiv : is-equiv φ.f
   surjᴳ-and-injᴳ-is-equiv = contr-map-is-equiv
     (λ h → let (g₁ , p₁) = Trunc-rec (idf _) (surj h) in
-      has-level-make ((g₁ , p₁) , (λ {(g₂ , p₂) →
+      has-level-in ((g₁ , p₁) , (λ {(g₂ , p₂) →
         pair= (inj g₁ g₂ (p₁ ∙ ! p₂))
                 prop-has-all-paths-↓})))
 

--- a/core/lib/groups/Isomorphism.agda
+++ b/core/lib/groups/Isomorphism.agda
@@ -139,17 +139,17 @@ module _ {i} {G H : Group i} (iso : GroupIso G H) where
       (p : Group.El G == Group.El H)
       (q : Group.El-level G == Group.El-level H [ _ ↓ p ])
       (r : Group.group-struct G == Group.group-struct H [ _ ↓ p ])
-      → ap Group.El (ap3-lemma group p q r) == p
+      → ap Group.El (ap3-lemma (λ a b c → group a {{b}} c) p q r) == p
     ap3-lemma-El idp idp idp = idp
 
   {- a homomorphism which is an equivalence gives a path between groups -}
   abstract
     uaᴳ : G == H
     uaᴳ =
-      ap3-lemma group
+      ap3-lemma (λ a b c → group a {{b}} c)
         El=
-        (prop-has-all-paths-↓ has-level-is-prop)
-        (↓-group-structure= (G.El-level) El= ident= inv= comp=)
+        prop-has-all-paths-↓
+        (↓-group-structure= El= ident= inv= comp=)
       where
       ident= : G.ident == H.ident [ (λ C → C) ↓ El= ]
       ident= = ↓-idf-ua-in _ pres-ident
@@ -271,16 +271,17 @@ module _ {i j} {G : Group i} {H : Group j} (φ : G →ᴳ H)
     module φ = GroupHom φ
 
     abstract
-      image-prop : (h : H.El) → is-prop (hfiber φ.f h)
-      image-prop h = all-paths-is-prop λ {(g₁ , p₁) (g₂ , p₂) →
-        pair= (inj g₁ g₂ (p₁ ∙ ! p₂)) (prop-has-all-paths-↓ (H.El-level _ _))}
+      instance
+        image-prop : (h : H.El) → is-prop (hfiber φ.f h)
+        image-prop h = all-paths-is-prop λ {(g₁ , p₁) (g₂ , p₂) →
+          pair= (inj g₁ g₂ (p₁ ∙ ! p₂)) prop-has-all-paths-↓}
 
   surjᴳ-and-injᴳ-is-equiv : is-equiv φ.f
   surjᴳ-and-injᴳ-is-equiv = contr-map-is-equiv
-    (λ h → let (g₁ , p₁) = Trunc-rec (image-prop h) (idf _) (surj h) in
-      ((g₁ , p₁) , (λ {(g₂ , p₂) →
+    (λ h → let (g₁ , p₁) = Trunc-rec (idf _) (surj h) in
+      has-level-make ((g₁ , p₁) , (λ {(g₂ , p₂) →
         pair= (inj g₁ g₂ (p₁ ∙ ! p₂))
-                (prop-has-all-paths-↓ (H.El-level _ _))})))
+                prop-has-all-paths-↓})))
 
   surjᴳ-and-injᴳ-iso : G ≃ᴳ H
   surjᴳ-and-injᴳ-iso = φ , surjᴳ-and-injᴳ-is-equiv

--- a/core/lib/groups/Lift.agda
+++ b/core/lib/groups/Lift.agda
@@ -21,7 +21,7 @@ Lift-group-structure GS = record
   where open GroupStructure GS
 
 Lift-group : ∀ {i j} → Group i → Group (lmax i j)
-Lift-group {j = j} G = group (Lift {j = j} El) (Lift-level El-level)
+Lift-group {j = j} G = group (Lift {j = j} El)
                              (Lift-group-structure group-struct)
   where open Group G
 

--- a/core/lib/groups/LoopSpace.agda
+++ b/core/lib/groups/LoopSpace.agda
@@ -22,12 +22,12 @@ module _ {i} (n : ℕ) (X : Ptd i) where
     inv-l = Ω^S-!-inv-l n
     }
 
-  Ω^S-group : has-level ⟨ S n ⟩ (de⊙ X) → Group i
-  Ω^S-group pX = group
+  Ω^S-group : {{_ : has-level ⟨ S n ⟩ (de⊙ X)}} → Group i
+  Ω^S-group = group
     (Ω^ (S n) X)
     -- TODO: make it find it automatically
     {{Ω^-level 0 (S n) X $
-       transport (λ t → has-level t (de⊙ X)) (! (+2+0 ⟨ S n ⟩₋₂)) pX}}
+       transport (λ t → has-level t (de⊙ X)) (! (+2+0 ⟨ S n ⟩₋₂)) ⟨⟩}}
     Ω^S-group-structure
 
 module _ {i j} (n : ℕ) {X : Ptd i} {Y : Ptd j} where
@@ -45,12 +45,12 @@ module _ {i j} (n : ℕ) {X : Ptd i} {Y : Ptd j} where
     Ω^S-group-structure-fmap F , Ω^S-group-structure-isemap F-is-equiv
 
 module _ {i j} (n : ℕ) {X : Ptd i} {Y : Ptd j}
-  (X-level : has-level ⟨ S n ⟩ (de⊙ X))
-  (Y-level : has-level ⟨ S n ⟩ (de⊙ Y))
+  {{X-level : has-level ⟨ S n ⟩ (de⊙ X)}}
+  {{Y-level : has-level ⟨ S n ⟩ (de⊙ Y)}}
   where
 
-  Ω^S-group-fmap : X ⊙→ Y → Ω^S-group n X X-level →ᴳ Ω^S-group n Y Y-level
+  Ω^S-group-fmap : X ⊙→ Y → Ω^S-group n X →ᴳ Ω^S-group n Y
   Ω^S-group-fmap = →ᴳˢ-to-→ᴳ ∘ Ω^S-group-structure-fmap n
 
-  Ω^S-group-emap : X ⊙≃ Y → Ω^S-group n X X-level ≃ᴳ Ω^S-group n Y Y-level
+  Ω^S-group-emap : X ⊙≃ Y → Ω^S-group n X ≃ᴳ Ω^S-group n Y
   Ω^S-group-emap = ≃ᴳˢ-to-≃ᴳ ∘ Ω^S-group-structure-emap n

--- a/core/lib/groups/LoopSpace.agda
+++ b/core/lib/groups/LoopSpace.agda
@@ -25,8 +25,9 @@ module _ {i} (n : ℕ) (X : Ptd i) where
   Ω^S-group : has-level ⟨ S n ⟩ (de⊙ X) → Group i
   Ω^S-group pX = group
     (Ω^ (S n) X)
-    (Ω^-level 0 (S n) X $
-       transport (λ t → has-level t (de⊙ X)) (! (+2+0 ⟨ S n ⟩₋₂)) pX)
+    -- TODO: make it find it automatically
+    {{Ω^-level 0 (S n) X $
+       transport (λ t → has-level t (de⊙ X)) (! (+2+0 ⟨ S n ⟩₋₂)) pX}}
     Ω^S-group-structure
 
 module _ {i j} (n : ℕ) {X : Ptd i} {Y : Ptd j} where

--- a/core/lib/groups/PullbackGroup.agda
+++ b/core/lib/groups/PullbackGroup.agda
@@ -49,18 +49,17 @@ module _ {i j k} (D : Group-Cospan {i} {j} {k}) where
         (φ.pres-comp h₁ h₂ ∙ ap2 G.comp p₁ p₂ ∙ ! (ψ.pres-comp k₁ k₂))};
     unit-l = λ {(pullback h k p) →
       pullback= d (H.unit-l h) (K.unit-l k)
-        (prop-has-all-paths (G.El-level _ _) _ _)};
+        (prop-has-all-paths _ _)};
     assoc = λ {(pullback h₁ k₁ p₁) (pullback h₂ k₂ p₂) (pullback h₃ k₃ p₃) →
       pullback= d (H.assoc h₁ h₂ h₃) (K.assoc k₁ k₂ k₃)
-        (prop-has-all-paths (G.El-level _ _) _ _)};
+        (prop-has-all-paths _ _)};
     inv-l = λ {(pullback h k p) →
       pullback= d (H.inv-l h) (K.inv-l k)
-        (prop-has-all-paths (G.El-level _ _) _ _)}}
+        (prop-has-all-paths _ _)}}
 
   Pullback-group : Group (lmax i (lmax j k))
   Pullback-group = record {
     El = Pullback d;
-    El-level = pullback-level 0 H.El-level K.El-level G.El-level;
     group-struct = Pullback-group-struct}
 
   pfst-hom : Pullback-group →ᴳ H
@@ -86,4 +85,4 @@ module _ {i j k} (D : Group-Cospan {i} {j} {k}) where
       pres-comp = λ j₁ j₂ → pullback= (group-cospan-out D)
         (χ.pres-comp j₁ j₂)
         (θ.pres-comp j₁ j₂)
-        (prop-has-all-paths (Group.El-level G _ _) _ _)}
+        (prop-has-all-paths _ _)}

--- a/core/lib/groups/QuotientGroup.agda
+++ b/core/lib/groups/QuotientGroup.agda
@@ -38,7 +38,7 @@ module _ {i j} {G : Group i} (P : NormalSubgroupProp G j) where
             (G.inv-inv g₁) $ P.comm g₁ (G.inv g₂) pg₁g₂⁻¹
 
       inv : SetQuot quot-group-rel → SetQuot quot-group-rel
-      inv = SetQuot-rec SetQuot-level (λ g → q[ G.inv g ]) inv-rel
+      inv = SetQuot-rec (λ g → q[ G.inv g ]) inv-rel
 
       abstract
         comp-rel-r : ∀ g₁ {g₂ g₂' : G.El} (pg₂g₂'⁻¹ : P.prop (G.diff g₂ g₂'))
@@ -50,7 +50,7 @@ module _ {i j} {G : Group i} (P : NormalSubgroupProp G j) where
           (P.conj g₁ pg₂g₂'⁻¹)
 
       comp' : G.El → SetQuot quot-group-rel → SetQuot quot-group-rel
-      comp' g₁ = SetQuot-rec SetQuot-level (λ g₂ → q[ g₁ ⊙ g₂ ]) (comp-rel-r g₁)
+      comp' g₁ = SetQuot-rec (λ g₂ → q[ g₁ ⊙ g₂ ]) (comp-rel-r g₁)
 
       abstract
         comp-rel-l : ∀ {g₁ g₁' : G.El} (pg₁g₁'⁻¹ : P.prop (G.diff g₁ g₁')) g₂
@@ -67,40 +67,34 @@ module _ {i j} {G : Group i} (P : NormalSubgroupProp G j) where
         comp'-rel : ∀ {g₁ g₁' : G.El} (pg₁g₁'⁻¹ : P.prop (G.diff g₁ g₁'))
           → comp' g₁ == comp' g₁'
         comp'-rel pg₁g₁'⁻¹ = λ= $ SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (comp-rel-l pg₁g₁'⁻¹)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓)
 
       comp : SetQuot quot-group-rel → SetQuot quot-group-rel → SetQuot quot-group-rel
-      comp = SetQuot-rec (→-is-set SetQuot-level) comp' comp'-rel
+      comp = SetQuot-rec comp' comp'-rel
 
       abstract
         unit-l : ∀ g → comp ident g == g
         unit-l = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (ap q[_] ∘ G.unit-l)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓)
 
         assoc : ∀ g₁ g₂ g₃ → comp (comp g₁ g₂) g₃ == comp g₁ (comp g₂ g₃)
         assoc = SetQuot-elim
-          (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
           (λ g₁ → SetQuot-elim
-            (λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
             (λ g₂ → SetQuot-elim
-              (λ _ → =-preserves-set SetQuot-level)
               (λ g₃ → ap q[_] $ G.assoc g₁ g₂ g₃)
-              (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _)))
-            (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → SetQuot-level _ _)))
-          (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → Π-is-prop λ _ → SetQuot-level _ _))
+              (λ _ → prop-has-all-paths-↓))
+            (λ _ → prop-has-all-paths-↓))
+          (λ _ → prop-has-all-paths-↓)
 
         inv-l : ∀ g → comp (inv g) g == ident
         inv-l = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (ap q[_] ∘ G.inv-l)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓)
 
   QuotGroup : Group (lmax i j)
-  QuotGroup = group _ SetQuot-level quot-group-struct
+  QuotGroup = group _ quot-group-struct
 
 {- helper functions -}
 module _ {i j} {G : Group i} {P : NormalSubgroupProp G j} where
@@ -135,7 +129,7 @@ module _ {i j} {G : Group i} {P : NormalSubgroupProp G j} where
           (P.comp pg₁g₂⁻¹ pg₂g₃⁻¹)
 
   quot-relᴳ-equiv : {g₁ g₂ : G.El} → P.prop (g₁ ⊙ G.inv g₂) ≃ (q[ g₁ ] == q[ g₂ ])
-  quot-relᴳ-equiv = quot-rel-equiv {R = quot-group-rel P} (P.level _)
+  quot-relᴳ-equiv = quot-rel-equiv {R = quot-group-rel P}
     quot-group-rel-is-refl
     quot-group-rel-is-sym
     quot-group-rel-is-trans

--- a/core/lib/groups/Subgroup.agda
+++ b/core/lib/groups/Subgroup.agda
@@ -40,8 +40,8 @@ module _ {i j} {G : Group i} (P : SubgroupProp G j) where
         inv-l (g , _) = Subtype=-out P.subEl-prop (G.inv-l g)
 
   Subgroup : Group (lmax i j)
-  Subgroup = group _ SubEl-level subgroup-struct
-    where abstract SubEl-level = Subtype-level P.subEl-prop G.El-level
+  Subgroup = group _ subgroup-struct
+    where abstract instance SubEl-level = Subtype-level P.subEl-prop
 
 module Subgroup {i j} {G : Group i} (P : SubgroupProp G j) where
   private

--- a/core/lib/groups/SubgroupProp.agda
+++ b/core/lib/groups/SubgroupProp.agda
@@ -13,14 +13,14 @@ record SubgroupProp {i} (G : Group i) j : Type (lmax i (lsucc j)) where
     module G = Group G
   field
     prop : G.El → Type j
-    level : ∀ g → is-prop (prop g)
+    {{level}} : ∀ {g} → is-prop (prop g)
     -- In theory being inhabited implies that the identity is included,
     -- but in practice let's just prove the identity case.
     ident : prop G.ident
     diff : ∀ {g₁ g₂} → prop g₁ → prop g₂ → prop (G.diff g₁ g₂)
 
   subEl-prop : SubtypeProp G.El j
-  subEl-prop = prop , level
+  subEl-prop = prop , (λ _ → level)
   SubEl = Subtype subEl-prop
 
   abstract
@@ -125,9 +125,6 @@ trivial-propᴳ {i} G = record {M} where
 
     ident : prop G.ident
     ident = idp
-
-    level : ∀ g → is-prop (prop g)
-    level g = G.El-level g G.ident
 
     abstract
       diff : {g₁ g₂ : G.El} → prop g₁ → prop g₂ → prop (G.diff g₁ g₂)

--- a/core/lib/groups/TruncationGroup.agda
+++ b/core/lib/groups/TruncationGroup.agda
@@ -28,20 +28,17 @@ module _ {i} {El : Type i} (GS : GroupStructure El) where
 
     abstract
       t-unit-l : (t : Trunc 0 El) → [ ident GS ] ⊗ t == t
-      t-unit-l = Trunc-elim (λ _ → =-preserves-level Trunc-level)
+      t-unit-l = Trunc-elim
         (ap [_] ∘ unit-l GS)
 
       t-assoc : (t₁ t₂ t₃ : Trunc 0 El) → (t₁ ⊗ t₂) ⊗ t₃ == t₁ ⊗ (t₂ ⊗ t₃)
       t-assoc = Trunc-elim
-        (λ _ → Π-level (λ _ → Π-level (λ _ → =-preserves-level Trunc-level)))
         (λ a → Trunc-elim
-          (λ _ → Π-level (λ _ → =-preserves-level Trunc-level))
           (λ b → Trunc-elim
-             (λ _ → =-preserves-level Trunc-level)
              (λ c → ap [_] (assoc GS a b c))))
 
       t-inv-l : (t : Trunc 0 El) → Trunc-fmap (inv GS) t ⊗ t == [ ident GS ]
-      t-inv-l = Trunc-elim (λ _ → =-preserves-level Trunc-level)
+      t-inv-l = Trunc-elim
         (ap [_] ∘ inv-l GS)
 
 
@@ -57,21 +54,14 @@ Trunc-group-× : ∀ {i j} {A : Type i} {B : Type j}
 Trunc-group-× GS HS =
   group-hom (fanout (Trunc-fmap fst) (Trunc-fmap snd))
     (Trunc-elim
-      (λ _ → (Π-level (λ _ → =-preserves-level
-                               (×-level Trunc-level Trunc-level))))
       (λ a → Trunc-elim
-        (λ _ → =-preserves-level (×-level Trunc-level Trunc-level))
         (λ b → idp))) ,
   is-eq _
     (uncurry (Trunc-fmap2 _,_))
     (uncurry (Trunc-elim
-               (λ _ → Π-level (λ _ → =-preserves-level
-                                       (×-level Trunc-level Trunc-level)))
                (λ a → Trunc-elim
-                        (λ _ → =-preserves-level
-                                 (×-level Trunc-level Trunc-level))
                         (λ b → idp))))
-    (Trunc-elim (λ _ → =-preserves-level Trunc-level) (λ _ → idp))
+    (Trunc-elim (λ _ → idp))
 
 Trunc-group-fmap : ∀ {i j} {A : Type i} {B : Type j}
   {GS : GroupStructure A} {HS : GroupStructure B}
@@ -85,8 +75,8 @@ Trunc-group-fmap {A = A} {GS = GS} {HS = HS} (group-structure-hom f p) =
       == Trunc-fmap2 (GroupStructure.comp HS)
            (Trunc-fmap f t₁) (Trunc-fmap f t₂)
     pres-comp =
-      Trunc-elim (λ _ → Π-level (λ _ → =-preserves-level Trunc-level))
-        (λ a₁ → Trunc-elim (λ _ → =-preserves-level Trunc-level)
+      Trunc-elim
+        (λ a₁ → Trunc-elim
           (λ a₂ → ap [_] (p a₁ a₂)))
 
 Trunc-group-emap : ∀ {i j} {A : Type i} {B : Type j}
@@ -95,22 +85,20 @@ Trunc-group-emap : ∀ {i j} {A : Type i} {B : Type j}
 Trunc-group-emap (φ , ie) =
   (Trunc-group-fmap φ ,
    is-eq _ (Trunc-fmap (is-equiv.g ie))
-     (Trunc-elim (λ _ → =-preserves-level Trunc-level)
+     (Trunc-elim
        (λ b → ap [_] (is-equiv.f-g ie b)))
-     (Trunc-elim (λ _ → =-preserves-level Trunc-level)
+     (Trunc-elim
        (λ a → ap [_] (is-equiv.g-f ie a))))
 
 Trunc-group-abelian : ∀ {i} {A : Type i} (GS : GroupStructure A)
   → ((a₁ a₂ : A) → GroupStructure.comp GS a₁ a₂ == GroupStructure.comp GS a₂ a₁)
   → is-abelian (Trunc-group GS)
 Trunc-group-abelian GS ab =
-  Trunc-elim (λ _ → Π-level (λ _ → =-preserves-level Trunc-level)) $
-    λ a₁ → Trunc-elim (λ _ → =-preserves-level Trunc-level) $
+  Trunc-elim
+    λ a₁ → Trunc-elim
       λ a₂ → ap [_] (ab a₁ a₂)
 
 unTrunc-iso : ∀ {i} {A : Type i} (GS : GroupStructure A)
-  → (A-is-set : is-set A) → Trunc-group GS ≃ᴳ group A A-is-set GS
-unTrunc-iso _ A-is-set = ≃-to-≃ᴳ (unTrunc-equiv _ A-is-set)
-  (Trunc-elim (λ _ → Π-is-set λ _ → =-preserves-set A-is-set)
-    (λ a₁ → Trunc-elim (λ _ → =-preserves-set A-is-set)
-      (λ a₂ → idp)))
+  {{_ : is-set A}} → Trunc-group GS ≃ᴳ group A GS
+unTrunc-iso {i} _ = ≃-to-≃ᴳ {i} {i} (unTrunc-equiv _)
+  (Trunc-elim  (λ a₁ → Trunc-elim (λ a₂ → idp)))

--- a/core/lib/groups/Unit.agda
+++ b/core/lib/groups/Unit.agda
@@ -21,7 +21,7 @@ Unit-group-structure = record
   }
 
 Unit-group : Group lzero
-Unit-group = group _ Unit-is-set Unit-group-structure
+Unit-group = group _ Unit-group-structure
 
 0ᴳ = Unit-group
 

--- a/core/lib/modalities/Truncation.agda
+++ b/core/lib/modalities/Truncation.agda
@@ -14,6 +14,6 @@ Trunc-modality n = record {
   ◯ = Trunc n;
   ◯-is-local = Trunc-level;
   η = [_];
-  ◯-elim = Trunc-elim;
+  ◯-elim = λ f → Trunc-elim {{f}};
   ◯-elim-β = λ _ _ _ → idp;
   ◯-=-is-local = λ _ _ → =-preserves-level Trunc-level}

--- a/core/lib/types/Bool.agda
+++ b/core/lib/types/Bool.agda
@@ -50,4 +50,6 @@ abstract
   Bool-is-set : is-set Bool
   Bool-is-set = dec-eq-is-set Bool-has-dec-eq
 
-Bool-level = Bool-is-set
+instance
+  Bool-level : {n : ℕ₋₂} → has-level (S (S n)) Bool
+  Bool-level = set-has-level-SS Bool-is-set

--- a/core/lib/types/Choice.agda
+++ b/core/lib/types/Choice.agda
@@ -10,7 +10,7 @@ module lib.types.Choice where
 
 unchoose : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : A → Type j}
   → Trunc n (Π A B) → Π A (Trunc n ∘ B)
-unchoose = Trunc-rec (Π-level λ _ → Trunc-level) (λ f → [_] ∘ f)
+unchoose = Trunc-rec (λ f → [_] ∘ f)
 
 has-choice : ∀ {i} (n : ℕ₋₂) (A : Type i) j → Type (lmax i (lsucc j))
 has-choice {i} n A j = (B : A → Type j) → is-equiv (unchoose {n = n} {A} {B})
@@ -27,8 +27,7 @@ Empty-has-choice {n} B = is-eq to from to-from from-to where
     to-from _ = λ= λ{()}
 
     from-to : ∀ f → from (to f) == f
-    from-to = Trunc-elim (λ _ → =-preserves-level Trunc-level)
-      (λ _ → ap [_] (λ= λ{()}))
+    from-to = Trunc-elim (λ _ → ap [_] (λ= λ{()}))
 
 Unit-has-choice : ∀ {n} {j} → has-choice n Unit j
 Unit-has-choice {n} B = is-eq to from to-from from-to where
@@ -45,13 +44,11 @@ Unit-has-choice {n} B = is-eq to from to-from from-to where
     to-from f = λ= λ{unit →
       Trunc-elim
         {P = λ f-unit → to (Trunc-fmap Unit-elim' f-unit) unit == f-unit}
-        (λ _ → =-preserves-level Trunc-level)
         (λ _ → idp)
         (f unit)}
 
     from-to : ∀ f → from (to f) == f
-    from-to = Trunc-elim (λ _ → =-preserves-level Trunc-level)
-      (λ f → ap [_] (λ= λ{unit → idp}))
+    from-to = Trunc-elim (λ f → ap [_] (λ= λ{unit → idp}))
 
 Coprod-has-choice : ∀ {i j} {n} {A : Type i} {B : Type j} {k}
   → has-choice n A k → has-choice n B k
@@ -71,10 +68,8 @@ Coprod-has-choice {n = n} {A} {B} A-hc B-hc C = is-eq to from to-from from-to wh
     to-from-inl' : ∀ f a → to (from f) (inl a) == A-unchoose (A-unchoose.g (f ∘ inl)) a
     to-from-inl' f a = Trunc-elim
       {P = λ f-inl → to (Trunc-fmap2 Coprod-elim f-inl (B-unchoose.g (f ∘ inr))) (inl a) == A-unchoose f-inl a}
-      (λ _ → =-preserves-level Trunc-level)
       (λ f-inl → Trunc-elim
         {P = λ f-inr → to (Trunc-fmap2 Coprod-elim [ f-inl ] f-inr) (inl a) == [ f-inl a ]}
-        (λ _ → =-preserves-level Trunc-level)
         (λ f-inr → idp)
         (B-unchoose.g (f ∘ inr)))
       (A-unchoose.g (f ∘ inl))
@@ -85,10 +80,8 @@ Coprod-has-choice {n = n} {A} {B} A-hc B-hc C = is-eq to from to-from from-to wh
     to-from-inr' : ∀ f b → to (from f) (inr b) == B-unchoose (B-unchoose.g (f ∘ inr)) b
     to-from-inr' f b = Trunc-elim
       {P = λ f-inr → to (Trunc-fmap2 Coprod-elim (A-unchoose.g (f ∘ inl)) f-inr) (inr b) == B-unchoose f-inr b}
-      (λ _ → =-preserves-level Trunc-level)
       (λ f-inr → Trunc-elim
         {P = λ f-inl → to (Trunc-fmap2 Coprod-elim f-inl [ f-inr ]) (inr b) == [ f-inr b ]}
-        (λ _ → =-preserves-level Trunc-level)
         (λ f-inl → idp)
         (A-unchoose.g (f ∘ inl)))
       (B-unchoose.g (f ∘ inr))
@@ -100,7 +93,7 @@ Coprod-has-choice {n = n} {A} {B} A-hc B-hc C = is-eq to from to-from from-to wh
     to-from f = λ= λ{(inl a) → to-from-inl f a; (inr b) → to-from-inr f b}
 
     from-to : ∀ f → from (to f) == f
-    from-to = Trunc-elim (λ _ → =-preserves-level Trunc-level)
+    from-to = Trunc-elim
       (λ f →
         Trunc-fmap2 Coprod-elim (A-unchoose.g (λ a → [ f (inl a)])) (B-unchoose.g (λ b → [ f (inr b)]))
           =⟨ ap2 (Trunc-fmap2 Coprod-elim) (A-unchoose.g-f [ f ∘ inl ]) (B-unchoose.g-f [ f ∘ inr ]) ⟩
@@ -144,7 +137,6 @@ equiv-preserves-choice {n = n} {A} {B} (f , f-ise) A-hc C = is-eq to from to-fro
     to-from' g a =
       Trunc-elim
         {P = λ g-f → to (from' g-f) (f a) == A-unchoose g-f a}
-        (λ _ → =-preserves-level Trunc-level)
         (λ g-f' → ap [_] $ to-from'' g-f' a)
         (A-unchoose.g (g ∘ f))
 
@@ -166,7 +158,6 @@ equiv-preserves-choice {n = n} {A} {B} (f , f-ise) A-hc C = is-eq to from to-fro
     from-to : ∀ g → from (to g) == g
     from-to = Trunc-elim
       {P = λ g → from (to g) == g}
-      (λ _ → =-preserves-level Trunc-level)
       (λ g →
         from' (A-unchoose.g (λ a → [ g (f a) ]))
           =⟨ ap from' (A-unchoose.g-f [ (g ∘ f) ]) ⟩

--- a/core/lib/types/Circle.agda
+++ b/core/lib/types/Circle.agda
@@ -175,5 +175,6 @@ module S¹RecType {i} (A : Type i) (e : A ≃ A) where
   flattening-S¹ : Σ S¹ f == Wt
   flattening-S¹ = generic-S¹ ∙ ua FlatteningS¹.flattening-equiv
 
-S¹-conn : is-connected 0 S¹
-S¹-conn = Sphere-conn 1
+instance
+  S¹-conn : is-connected 0 S¹
+  S¹-conn = Sphere-conn 1

--- a/core/lib/types/Coproduct.agda
+++ b/core/lib/types/Coproduct.agda
@@ -68,15 +68,15 @@ module _ {i j} {A : Type i} {B : Type j} where
   instance
     ⊔-level : ∀ {n} → has-level (S (S n)) A → has-level (S (S n)) B
               → has-level (S (S n)) (Coprod A B)
-    ⊔-level {n} pA pB = has-level-make (⊔-level-aux pA pB) where
+    ⊔-level {n} pA pB = has-level-in (⊔-level-aux pA pB) where
       
       instance _ = pA; _ = pB
 
       ⊔-level-aux : has-level (S (S n)) A → has-level (S (S n)) B
               → has-level-aux (S (S n)) (Coprod A B)
       ⊔-level-aux _ _ (inl a₁) (inl a₂) = equiv-preserves-level (inl=inl-equiv a₁ a₂ ⁻¹)
-      ⊔-level-aux _ _ (inl a₁) (inr b₂) = has-level-make (λ p → Empty-rec (inl≠inr a₁ b₂ p))
-      ⊔-level-aux _ _ (inr b₁) (inl a₂) = has-level-make (λ p → Empty-rec (inr≠inl b₁ a₂ p))
+      ⊔-level-aux _ _ (inl a₁) (inr b₂) = has-level-in (λ p → Empty-rec (inl≠inr a₁ b₂ p))
+      ⊔-level-aux _ _ (inr b₁) (inl a₂) = has-level-in (λ p → Empty-rec (inr≠inl b₁ a₂ p))
       ⊔-level-aux _ _ (inr b₁) (inr b₂) = equiv-preserves-level ((inr=inr-equiv b₁ b₂)⁻¹)
 
   Coprod-level = ⊔-level

--- a/core/lib/types/Coproduct.agda
+++ b/core/lib/types/Coproduct.agda
@@ -65,14 +65,19 @@ module _ {i j} {A : Type i} {B : Type j} where
   inr≠inl : (b₁ : B) (a₂ : A) → (inr b₁ ≠ inl a₂)
   inr≠inl a₁ b₂ p = lower $ Coprod=-in p
 
-  ⊔-level : ∀ {n} → has-level (S (S n)) A → has-level (S (S n)) B
-            → has-level (S (S n)) (Coprod A B)
-  ⊔-level pA _ (inl a₁) (inl a₂) =
-    equiv-preserves-level (inl=inl-equiv a₁ a₂ ⁻¹) (pA a₁ a₂)
-  ⊔-level _ _ (inl a₁) (inr b₂) = λ p → Empty-rec (inl≠inr a₁ b₂ p)
-  ⊔-level _ _ (inr b₁) (inl a₂) = λ p → Empty-rec (inr≠inl b₁ a₂ p)
-  ⊔-level _ pB (inr b₁) (inr b₂) =
-    equiv-preserves-level ((inr=inr-equiv b₁ b₂)⁻¹) (pB b₁ b₂)
+  instance
+    ⊔-level : ∀ {n} → has-level (S (S n)) A → has-level (S (S n)) B
+              → has-level (S (S n)) (Coprod A B)
+    ⊔-level {n} pA pB = has-level-make (⊔-level-aux pA pB) where
+      
+      instance _ = pA; _ = pB
+
+      ⊔-level-aux : has-level (S (S n)) A → has-level (S (S n)) B
+              → has-level-aux (S (S n)) (Coprod A B)
+      ⊔-level-aux _ _ (inl a₁) (inl a₂) = equiv-preserves-level (inl=inl-equiv a₁ a₂ ⁻¹)
+      ⊔-level-aux _ _ (inl a₁) (inr b₂) = has-level-make (λ p → Empty-rec (inl≠inr a₁ b₂ p))
+      ⊔-level-aux _ _ (inr b₁) (inl a₂) = has-level-make (λ p → Empty-rec (inr≠inl b₁ a₂ p))
+      ⊔-level-aux _ _ (inr b₁) (inr b₂) = equiv-preserves-level ((inr=inr-equiv b₁ b₂)⁻¹)
 
   Coprod-level = ⊔-level
 

--- a/core/lib/types/Cover.agda
+++ b/core/lib/types/Cover.agda
@@ -20,6 +20,7 @@ record Cover (A : Type i) j : Type (lmax i (lsucc j)) where
   field
     Fiber : A → Type j
     Fiber-level : ∀ a → is-set (Fiber a)
+
   Fiber-is-set = Fiber-level
   TotalSpace = Σ A Fiber
 
@@ -39,7 +40,7 @@ module _ {A : Type i} {j} where
   -- Equality between covers.
   cover=' : {c₁ c₂ : Cover A j} → Fiber c₁ == Fiber c₂ → c₁ == c₂
   cover=' {cover f _} {cover .f _} idp = ap (cover f) $
-    prop-has-all-paths (Π-is-prop λ _ → is-set-is-prop) _ _
+    prop-has-all-paths _ _
 
   cover= : {c₁ c₂ : Cover A j} → (∀ a → Fiber c₁ a ≃ Fiber c₂ a)
     → c₁ == c₂
@@ -91,7 +92,7 @@ module _ (X : Ptd i)
              → (idp=p : idp == p)
              → idp == p↑
                [ (λ p → a↑ == a↑ [ F ↓ p ]) ↓ idp=p ]
-    idp=p↑ idp = prop-has-all-paths (F-level a _ _) _ _
+    idp=p↑ idp = prop-has-all-paths {{has-level-apply (F-level a) _ _}} _ _
 
     -- The injection map with some ends free (in order to apply J).
     from′ : ∀ {p : a == a} {p↑ : a↑ == a↑ [ F ↓ p ]}
@@ -113,7 +114,7 @@ module _ (X : Ptd i)
                 → from′ (to′ idp=p⇑) idp=snd=p⇑ == idp=p⇑
                   [ (λ p⇑ → idp == p⇑) ↓ ! (pair=-η p⇑) ]
     from′-to′ idp idp=snd=p⇑ = ap (from′ idp)
-      $ contr-has-all-paths (F-level a _ _ _ _) _ _
+      $ contr-has-all-paths {{has-level-apply (has-level-apply (F-level a) _ _) _ _}} _ _
 
     -- Injection is left-inverse to projection.
     from-to : ∀ p²⇑ → from (to p²⇑) == p²⇑
@@ -144,7 +145,7 @@ module _ {A : Type i} where
     → Fiber cov a₁ → a₁ =₀ a₂
     → Fiber cov a₂
   cover-trace cov a↑ p =
-    transport₀ (Fiber cov) (Fiber-is-set cov _) p a↑
+    transport₀ (Fiber cov) {{Fiber-is-set cov _}} p a↑
 
   abstract
     cover-trace-idp₀ : ∀ {j} (cov : Cover A j) {a₁}
@@ -158,7 +159,7 @@ module _ {A : Type i} where
       → (p : a₁ =₀ a₂)
       → cover-trace cov (cover-trace cov a↑ loop) p
       == cover-trace cov a↑ (loop ∙₀ p)
-    cover-paste cov a↑ loop p = ! $ transp₀-∙₀ (Fiber-is-set cov) loop p a↑
+    cover-paste cov a↑ loop p = ! $ transp₀-∙₀ {{Fiber-is-set cov _}} loop p a↑
 
 -- Path sets form a covering space
 module _ (X : Ptd i) where

--- a/core/lib/types/Cover.agda
+++ b/core/lib/types/Cover.agda
@@ -19,7 +19,7 @@ record Cover (A : Type i) j : Type (lmax i (lsucc j)) where
   constructor cover
   field
     Fiber : A → Type j
-    Fiber-level : ∀ a → is-set (Fiber a)
+    {{Fiber-level}} : ∀ {a} → is-set (Fiber a)
 
   Fiber-is-set = Fiber-level
   TotalSpace = Σ A Fiber
@@ -39,8 +39,8 @@ module _ {A : Type i} {j} where
 
   -- Equality between covers.
   cover=' : {c₁ c₂ : Cover A j} → Fiber c₁ == Fiber c₂ → c₁ == c₂
-  cover=' {cover f _} {cover .f _} idp = ap (cover f) $
-    prop-has-all-paths _ _
+  cover=' {cover f} {cover .f} idp = ap (λ (x : ∀ {a} → is-set (f a)) → cover f {{x}})
+    (prop-has-all-paths _ _)
 
   cover= : {c₁ c₂ : Cover A j} → (∀ a → Fiber c₁ a ≃ Fiber c₂ a)
     → c₁ == c₂
@@ -73,7 +73,6 @@ module _ (X : Ptd i)
   open Cover c
   private
     F = Cover.Fiber c
-    F-level = Cover.Fiber-level c
     A = de⊙ X
     a = pt⊙ X
 
@@ -92,7 +91,7 @@ module _ (X : Ptd i)
              → (idp=p : idp == p)
              → idp == p↑
                [ (λ p → a↑ == a↑ [ F ↓ p ]) ↓ idp=p ]
-    idp=p↑ idp = prop-has-all-paths {{has-level-apply (F-level a) _ _}} _ _
+    idp=p↑ idp = prop-has-all-paths _ _
 
     -- The injection map with some ends free (in order to apply J).
     from′ : ∀ {p : a == a} {p↑ : a↑ == a↑ [ F ↓ p ]}
@@ -114,7 +113,7 @@ module _ (X : Ptd i)
                 → from′ (to′ idp=p⇑) idp=snd=p⇑ == idp=p⇑
                   [ (λ p⇑ → idp == p⇑) ↓ ! (pair=-η p⇑) ]
     from′-to′ idp idp=snd=p⇑ = ap (from′ idp)
-      $ contr-has-all-paths {{has-level-apply (has-level-apply (F-level a) _ _) _ _}} _ _
+      $ contr-has-all-paths _ _
 
     -- Injection is left-inverse to projection.
     from-to : ∀ p²⇑ → from (to p²⇑) == p²⇑
@@ -145,7 +144,7 @@ module _ {A : Type i} where
     → Fiber cov a₁ → a₁ =₀ a₂
     → Fiber cov a₂
   cover-trace cov a↑ p =
-    transport₀ (Fiber cov) {{Fiber-is-set cov _}} p a↑
+    transport₀ (Fiber cov) p a↑
 
   abstract
     cover-trace-idp₀ : ∀ {j} (cov : Cover A j) {a₁}
@@ -159,19 +158,17 @@ module _ {A : Type i} where
       → (p : a₁ =₀ a₂)
       → cover-trace cov (cover-trace cov a↑ loop) p
       == cover-trace cov a↑ (loop ∙₀ p)
-    cover-paste cov a↑ loop p = ! $ transp₀-∙₀ {{Fiber-is-set cov _}} loop p a↑
+    cover-paste cov a↑ loop p = ! $ transp₀-∙₀ loop p a↑
 
 -- Path sets form a covering space
 module _ (X : Ptd i) where
   path-set-cover : Cover (de⊙ X) i
   path-set-cover = record
-    { Fiber = λ a → pt⊙ X =₀ a
-    ; Fiber-level = λ a → Trunc-level
-    }
+    { Fiber = λ a → pt⊙ X =₀ a }
 
 -- Cover morphisms
 CoverHom : ∀ {A : Type i} {j₁ j₂}
   → (cov1 : Cover A j₁)
   → (cov2 : Cover A j₂)
   → Type (lmax i (lmax j₁ j₂))
-CoverHom (cover F₁ _) (cover F₂ _) = ∀ a → F₁ a → F₂ a
+CoverHom (cover F₁) (cover F₂) = ∀ a → F₁ a → F₂ a

--- a/core/lib/types/EilenbergMacLane1.agda
+++ b/core/lib/types/EilenbergMacLane1.agda
@@ -101,7 +101,7 @@ module _ {G : Group i} where
     {- EM₁ is 0-connected -}
     instance
       EM₁-conn : is-connected 0 (EM₁ G)
-      EM₁-conn = has-level-make ([ embase ] , Trunc-elim
+      EM₁-conn = has-level-in ([ embase ] , Trunc-elim
         (EM₁-elim
           {P = λ x → [ embase ] == [ x ]}
           {{λ _ → raise-level _ (=-preserves-level Trunc-level)}}

--- a/core/lib/types/EilenbergMacLane1.agda
+++ b/core/lib/types/EilenbergMacLane1.agda
@@ -31,7 +31,12 @@ module _ {G : Group i} where
   embase = embase' G
   emloop = emloop' G
   emloop-comp = emloop-comp' G
-  EM₁-level = EM₁-level' G
+
+  instance
+    EM₁-level : {n : ℕ₋₂} → has-level (S (S (S n))) (EM₁ G)
+    EM₁-level {⟨-2⟩} = EM₁-level' G
+    EM₁-level {S n} = raise-level _ EM₁-level
+
 
   abstract
     -- This was in the original paper, but is actually derivable.
@@ -40,7 +45,7 @@ module _ {G : Group i} where
       ap emloop (! $ G.unit-r G.ident) ∙ emloop-comp G.ident G.ident
 
   module EM₁Elim {j} {P : EM₁ G → Type j}
-    (P-level : (x : EM₁ G) → has-level ⟨ 1 ⟩ (P x))
+    {{_ : (x : EM₁ G) → has-level ⟨ 1 ⟩ (P x)}}
     (embase* : P embase)
     (emloop* : (g : G.El) → embase* == embase* [ P ↓ emloop g ])
     (emloop-comp* : (g₁ g₂ : G.El) →
@@ -59,11 +64,11 @@ module _ {G : Group i} where
   open EM₁Elim public using () renaming (f to EM₁-elim)
 
   module EM₁Rec {j} {C : Type j}
-    (C-level : has-level ⟨ 1 ⟩ C) (embase* : C)
-    (hom* : G →ᴳ (Ω^S-group 0 ⊙[ C , embase* ] C-level)) where
+    {{_ : has-level ⟨ 1 ⟩ C}} (embase* : C)
+    (hom* : G →ᴳ (Ω^S-group 0 ⊙[ C , embase* ])) where
 
     private
-      module M = EM₁Elim {P = λ _ → C} (λ _ → C-level)
+      module M = EM₁Elim {P = λ _ → C}
         embase* (λ g → ↓-cst-in (GroupHom.f hom* g))
         (λ g₁ g₂ → ↓-cst-in2 (GroupHom.pres-comp hom* g₁ g₂)
                  ∙'ᵈ ↓-cst-in-∙ (emloop g₁) (emloop g₂)
@@ -94,11 +99,12 @@ module _ {G : Group i} where
         lemma = ! (emloop-comp (G.inv g) g) ∙ ap emloop (G.inv-l g) ∙ emloop-ident
 
     {- EM₁ is 0-connected -}
-    EM₁-conn : is-connected 0 (EM₁ G)
-    EM₁-conn = has-level-make ([ embase ] , Trunc-elim
-      (EM₁-elim
-        {P = λ x → [ embase ] == [ x ]}
-        (λ _ → raise-level _ (=-preserves-level Trunc-level))
-        idp
-        (λ _ → prop-has-all-paths-↓)
-        (λ _ _ → set-↓-has-all-paths-↓)))
+    instance
+      EM₁-conn : is-connected 0 (EM₁ G)
+      EM₁-conn = has-level-make ([ embase ] , Trunc-elim
+        (EM₁-elim
+          {P = λ x → [ embase ] == [ x ]}
+          {{λ _ → raise-level _ (=-preserves-level Trunc-level)}}
+          idp
+          (λ _ → prop-has-all-paths-↓)
+          (λ _ _ → set-↓-has-all-paths-↓)))

--- a/core/lib/types/EilenbergMacLane1.agda
+++ b/core/lib/types/EilenbergMacLane1.agda
@@ -95,10 +95,10 @@ module _ {G : Group i} where
 
     {- EM₁ is 0-connected -}
     EM₁-conn : is-connected 0 (EM₁ G)
-    EM₁-conn = ([ embase ] , Trunc-elim (λ _ → =-preserves-level Trunc-level)
+    EM₁-conn = has-level-make ([ embase ] , Trunc-elim
       (EM₁-elim
         {P = λ x → [ embase ] == [ x ]}
         (λ _ → raise-level _ (=-preserves-level Trunc-level))
         idp
-        (λ _ → prop-has-all-paths-↓ (Trunc-level {n = 0} _ _))
-        (λ _ _ → set-↓-has-all-paths-↓ (=-preserves-level Trunc-level))))
+        (λ _ → prop-has-all-paths-↓)
+        (λ _ _ → set-↓-has-all-paths-↓)))

--- a/core/lib/types/Empty.agda
+++ b/core/lib/types/Empty.agda
@@ -10,14 +10,16 @@ Empty-rec = Empty-elim
 ⊥-rec : ∀ {i} {A : Type i} → (⊥ → A)
 ⊥-rec = Empty-rec
 
-abstract
-  Empty-is-prop : is-prop Empty
-  Empty-is-prop = Empty-elim
+Empty-is-prop : is-prop Empty
+Empty-is-prop = has-level-make Empty-elim
 
-  Empty-is-set : is-set Empty
-  Empty-is-set = raise-level -1 Empty-is-prop
+instance
+  Empty-level : {n : ℕ₋₂} → has-level (S n) Empty
+  Empty-level = prop-has-level-S Empty-is-prop
 
-  Empty-level = Empty-is-prop
-  ⊥-is-prop = Empty-is-prop
-  ⊥-is-set = Empty-is-set
-  ⊥-level = Empty-level
+Empty-is-set : is-set Empty
+Empty-is-set = raise-level -1 Empty-is-prop
+
+⊥-is-prop = Empty-is-prop
+⊥-is-set = Empty-is-set
+⊥-level = Empty-level

--- a/core/lib/types/Empty.agda
+++ b/core/lib/types/Empty.agda
@@ -11,7 +11,7 @@ Empty-rec = Empty-elim
 ⊥-rec = Empty-rec
 
 Empty-is-prop : is-prop Empty
-Empty-is-prop = has-level-make Empty-elim
+Empty-is-prop = has-level-in Empty-elim
 
 instance
   Empty-level : {n : ℕ₋₂} → has-level (S n) Empty

--- a/core/lib/types/Fin.agda
+++ b/core/lib/types/Fin.agda
@@ -19,7 +19,7 @@ Fin-prop : ℕ → SubtypeProp ℕ lzero
 Fin-prop n = ((_< n) , λ _ → <-is-prop)
 
 Fin-is-set : {n : ℕ} → is-set (Fin n)
-Fin-is-set {n} = Subtype-level (Fin-prop n) ℕ-is-set
+Fin-is-set {n} = Subtype-level (Fin-prop n)
 
 Fin-has-dec-eq : {n : ℕ} → has-dec-eq (Fin n)
 Fin-has-dec-eq {n} = Subtype-has-dec-eq (Fin-prop n) ℕ-has-dec-eq

--- a/core/lib/types/Group.agda
+++ b/core/lib/types/Group.agda
@@ -192,10 +192,9 @@ record Group i : Type (lsucc i) where
   constructor group
   field
     El : Type i
-    El-level : has-level 0 El
+    {{El-level}} : has-level 0 El
     group-struct : GroupStructure El
   open GroupStructure group-struct public
-  El-is-set = El-level
 
 Group₀ : Type (lsucc lzero)
 Group₀ = Group lzero
@@ -236,9 +235,9 @@ is-trivialᴳ : ∀ {i} (G : Group i) → Type i
 is-trivialᴳ G = ∀ g → g == Group.ident G
 
 contr-is-trivialᴳ : ∀ {i} (G : Group i)
-  → is-contr (Group.El G) → is-trivialᴳ G
-contr-is-trivialᴳ G El-is-contr g =
-  contr-has-all-paths El-is-contr _ _
+  {{_ : is-contr (Group.El G)}} → is-trivialᴳ G
+contr-is-trivialᴳ G g =
+  contr-has-all-paths _ _
 
 {- group-structure= -}
 
@@ -246,25 +245,24 @@ module _ where
   open GroupStructure
 
   abstract
-    group-structure= : ∀ {i} {A : Type i} (pA : has-level 0 A)
+    group-structure= : ∀ {i} {A : Type i} {{_ : is-set A}}
       {id₁ id₂ : A} {inv₁ inv₂ : A → A} {comp₁ comp₂ : A → A → A}
       → ∀ {unit-l₁ unit-l₂ assoc₁ assoc₂ inv-l₁ inv-l₂}
       → (id₁ == id₂) → (inv₁ == inv₂) → (comp₁ == comp₂)
       → Path {A = GroupStructure A}
           (group-structure id₁ inv₁ comp₁ unit-l₁ assoc₁ inv-l₁)
           (group-structure id₂ inv₂ comp₂ unit-l₂ assoc₂ inv-l₂)
-    group-structure= pA {id₁ = id₁} {inv₁ = inv₁} {comp₁ = comp₁} idp idp idp =
+    group-structure= {id₁ = id₁} {inv₁ = inv₁} {comp₁ = comp₁} idp idp idp =
       ap3 (group-structure id₁ inv₁ comp₁)
-        (prop-has-all-paths (Π-level (λ _ → pA _ _)) _ _)
-        (prop-has-all-paths
-          (Π-level (λ _ → Π-level (λ _ → Π-level (λ _ → pA _ _)))) _ _)
-        (prop-has-all-paths (Π-level (λ _ → pA _ _)) _ _)
+        (prop-has-all-paths _ _)
+        (prop-has-all-paths _ _)
+        (prop-has-all-paths _ _)
 
     ↓-group-structure= : ∀ {i} {A B : Type i}
-      (A-level : has-level 0 A)
+      {{_ : has-level 0 A}}
       {GS : GroupStructure A} {HS : GroupStructure B} (p : A == B)
       → (ident GS == ident HS [ (λ C → C) ↓ p ])
       → (inv GS == inv HS [ (λ C → C → C) ↓ p ])
       → (comp GS == comp HS [ (λ C → C → C → C) ↓ p ])
       → GS == HS [ GroupStructure ↓ p ]
-    ↓-group-structure= A-level idp = group-structure= A-level
+    ↓-group-structure= idp = group-structure=

--- a/core/lib/types/GroupSet.agda
+++ b/core/lib/types/GroupSet.agda
@@ -13,7 +13,7 @@ module lib.types.GroupSet {i} where
 
   -- The right group action with respect to the group [grp].
   record GroupSetStructure (grp : Group i) {j} (El : Type j)
-    (_ : is-set El) : Type (lmax i j) where
+    {{_ : is-set El}} : Type (lmax i j) where
     constructor groupset-structure
     private
       module G = Group grp
@@ -29,21 +29,20 @@ module lib.types.GroupSet {i} where
     constructor groupset
     field
       El : Type j
-      El-level : is-set El
-      grpset-struct : GroupSetStructure grp El El-level
+      {{El-level}} : is-set El
+      grpset-struct : GroupSetStructure grp El
     open GroupSetStructure grpset-struct public
-    El-is-set = El-level
 
   -- A helper function to establish equivalence between two G-sets.
   -- Many data are just props and this function do the coversion for them
   -- for you.  You only need to show the non-trivial parts.
-  module _ {grp : Group i} {j} {El : Type j} {El-level : is-set El} where
+  module _ {grp : Group i} {j} {El : Type j} {{El-level : is-set El}} where
     private
       module G = Group grp
       module GS = GroupStructure G.group-struct
     open GroupSetStructure
     private
-      groupset-structure=' : ∀ {gss₁ gss₂ : GroupSetStructure grp El El-level}
+      groupset-structure=' : ∀ {gss₁ gss₂ : GroupSetStructure grp El}
         → (act= : act gss₁ == act gss₂)
         → unit-r gss₁ == unit-r gss₂
           [ (λ act → ∀ x → act x GS.ident == x) ↓ act= ]
@@ -54,14 +53,13 @@ module lib.types.GroupSet {i} where
       groupset-structure=' {groupset-structure _ _ _} {groupset-structure ._ ._ ._}
         idp idp idp = idp
 
-    groupset-structure= : ∀ {gss₁ gss₂ : GroupSetStructure grp El El-level}
+    groupset-structure= : ∀ {gss₁ gss₂ : GroupSetStructure grp El}
       → (∀ x g → act gss₁ x g == act gss₂ x g)
       → gss₁ == gss₂
     groupset-structure= act= = groupset-structure='
       (λ= λ x → λ= λ g → act= x g)
-      (prop-has-all-paths-↓ (Π-level λ _ → El-level _ _))
-      (prop-has-all-paths-↓
-        (Π-level λ _ → Π-level λ _ → Π-level λ _ → El-level _ _))
+      prop-has-all-paths-↓
+      prop-has-all-paths-↓ 
 
   module _ {grp : Group i} {j : ULevel} where
     private
@@ -73,9 +71,9 @@ module lib.types.GroupSet {i} where
         → (El= : El gs₁ == El gs₂)
         → (El-level : El-level gs₁ == El-level gs₂ [ is-set ↓ El= ])
         → grpset-struct gs₁ == grpset-struct gs₂
-          [ uncurry (GroupSetStructure grp) ↓ pair= El= El-level ]
+          [ uncurry (λ a b → GroupSetStructure grp a {{b}}) ↓ pair= El= El-level ]
         → gs₁ == gs₂
-      groupset='' {groupset _ _ _} {groupset ._ ._ ._} idp idp idp = idp
+      groupset='' {groupset _ _} {groupset ._ ._} idp idp idp = idp
 
       groupset=' : ∀ {gs₁ gs₂ : GroupSet grp j}
         → (El= : El gs₁ == El gs₂)
@@ -83,7 +81,7 @@ module lib.types.GroupSet {i} where
         → (∀ {x₁} {x₂} (p : x₁ == x₂ [ idf _ ↓ El= ]) g
             → act gs₁ x₁ g == act gs₂ x₂ g [ idf _ ↓ El= ])
         → gs₁ == gs₂
-      groupset=' {groupset _ _ _} {groupset ._ ._ _} idp idp act= =
+      groupset=' {groupset _ _} {groupset ._ _} idp idp act= =
         groupset='' idp idp (groupset-structure= λ x g → act= idp g)
 
     groupset= : ∀ {gs₁ gs₂ : GroupSet grp j}
@@ -95,7 +93,7 @@ module lib.types.GroupSet {i} where
     groupset= El≃ act= =
       groupset='
         (ua El≃)
-        (prop-has-all-paths-↓ is-set-is-prop)
+        prop-has-all-paths-↓
         (λ x= g → ↓-idf-ua-in El≃ $ act= (↓-idf-ua-out El≃ x=) g)
 
   -- The GroupSet homomorphism.
@@ -123,8 +121,7 @@ module lib.types.GroupSet {i} where
   groupset-hom= {gset₂ = gset₂} f= =
     groupset-hom='
       (λ= f=)
-      (prop-has-all-paths-↓ $
-        Π-level λ _ → Π-level λ _ → GroupSet.El-level gset₂ _ _)
+      prop-has-all-paths-↓ where
 
   group-to-group-set : ∀ (grp : Group i) → GroupSet grp i
   group-to-group-set grp = record {

--- a/core/lib/types/Int.agda
+++ b/core/lib/types/Int.agda
@@ -130,7 +130,10 @@ abstract
   ℤ-is-set : is-set ℤ
   ℤ-is-set = dec-eq-is-set ℤ-has-dec-eq
 
-ℤ-level = ℤ-is-set
+  instance
+    ℤ-level : {n : ℕ₋₂} → has-level (S (S n)) ℤ
+    ℤ-level {⟨-2⟩} = ℤ-is-set
+    ℤ-level {n = S n} = raise-level (S (S n)) ℤ-level
 
 {-
   ℤ is also a group!

--- a/core/lib/types/IteratedSuspension.agda
+++ b/core/lib/types/IteratedSuspension.agda
@@ -62,9 +62,10 @@ Sphere : (n : ℕ) → Type₀
 Sphere n = de⊙ (⊙Sphere n)
 
 abstract
-  Sphere-conn : ∀ (n : ℕ) → is-connected ⟨ n ⟩₋₁ (Sphere n)
-  Sphere-conn 0 = inhab-conn true
-  Sphere-conn (S n) = Susp-conn (Sphere-conn n)
+  instance
+    Sphere-conn : ∀ (n : ℕ) → is-connected ⟨ n ⟩₋₁ (Sphere n)
+    Sphere-conn 0 = inhab-conn true
+    Sphere-conn (S n) = Susp-conn (Sphere-conn n)
 
 -- favonia: [S¹] has its own elim rules in Circle.agda.
 ⊙S⁰ = ⊙Sphere 0

--- a/core/lib/types/IteratedSuspension.agda
+++ b/core/lib/types/IteratedSuspension.agda
@@ -15,9 +15,9 @@ module lib.types.IteratedSuspension where
 
 abstract
   ⊙Susp^-conn : ∀ {i} (n : ℕ) {X : Ptd i} {m : ℕ₋₂}
-    → is-connected m (de⊙ X) → is-connected (⟨ n ⟩₋₂ +2+ m) (de⊙ (⊙Susp^ n X))
-  ⊙Susp^-conn O cX = cX
-  ⊙Susp^-conn (S n) cX = Susp-conn (⊙Susp^-conn n cX)
+    {{_ : is-connected m (de⊙ X)}} → is-connected (⟨ n ⟩₋₂ +2+ m) (de⊙ (⊙Susp^ n X))
+  ⊙Susp^-conn O = ⟨⟩
+  ⊙Susp^-conn (S n) = Susp-conn (⊙Susp^-conn n)
 
 ⊙Susp^-+ : ∀ {i} (m n : ℕ) {X : Ptd i}
   → ⊙Susp^ m (⊙Susp^ n X) == ⊙Susp^ (m + n) X

--- a/core/lib/types/Lift.agda
+++ b/core/lib/types/Lift.agda
@@ -18,9 +18,10 @@ lift-equiv = equiv lift lower (λ _ → idp) (λ _ → idp)
 
 -- [lower-equiv] is in Equivalences.agda
 
-Lift-level : ∀ {i j} {A : Type i} {n : ℕ₋₂} →
-  has-level n A → has-level n (Lift {j = j} A)
-Lift-level = equiv-preserves-level lift-equiv
+instance
+  Lift-level : ∀ {i j} {A : Type i} {n : ℕ₋₂}
+    → has-level n A → has-level n (Lift {j = j} A)
+  Lift-level p = equiv-preserves-level lift-equiv {{p}}
 
 ⊙lift-equiv : ∀ {i j} {X : Ptd i} → X ⊙≃ ⊙Lift {j = j} X
 ⊙lift-equiv = (⊙lift , snd lift-equiv)

--- a/core/lib/types/LoopSpace.agda
+++ b/core/lib/types/LoopSpace.agda
@@ -255,8 +255,8 @@ module _ {i j} {X : Ptd i} {Y : Ptd j} where
   → (has-level (⟨ n ⟩₋₂ +2+ m) (de⊙ X) → has-level m (Ω^ n X))
 Ω^-level m O X pX = pX
 Ω^-level m (S n) X pX =
-  Ω^-level (S m) n X
-    (transport (λ k → has-level k (de⊙ X)) (! (+2+-βr ⟨ n ⟩₋₂ m)) pX)
+  has-level-apply (Ω^-level (S m) n X
+    (transport (λ k → has-level k (de⊙ X)) (! (+2+-βr ⟨ n ⟩₋₂ m)) pX))
     (idp^ n) (idp^ n)
 
 Ω^-conn : ∀ {i} (m : ℕ₋₂) (n : ℕ) (X : Ptd i)

--- a/core/lib/types/Modality.agda
+++ b/core/lib/types/Modality.agda
@@ -145,7 +145,7 @@ module lib.types.Modality where
       → is-◯-connected A → is-◯-connected B → is-◯-equiv f
 
     equiv-preserves-◯-conn : {A B : Type ℓ} → A ≃ B → is-◯-connected A → is-◯-connected B
-    equiv-preserves-◯-conn e c = equiv-preserves-level (◯-emap e) c
+    equiv-preserves-◯-conn e c = equiv-preserves-level (◯-emap e) {{c}}
 
     total-◯-equiv : {A : Type ℓ} {P Q : A → Type ℓ} (φ : ∀ a → P a → Q a) → 
                      (∀ a → is-◯-equiv (φ a)) → is-◯-equiv (Σ-fmap-r φ)
@@ -167,12 +167,12 @@ module lib.types.Modality where
                 helper-β t b = ◯-rec-β (snd (P b)) (λ x → transport (fst ∘ P) (snd x) (t (fst x)))
 
                 g : Π A (fst ∘ P ∘ h) → Π B (fst ∘ P)
-                g t b = helper t b (fst (c b))
+                g t b = helper t b (contr-center (c b))
 
                 f-g : ∀ t → f (g t) == t
                 f-g t = λ= $ λ a → transport
                   (λ r → ◯-rec (snd (P (h a))) _ r == t a)
-                  (! (snd (c (h a)) (η (a , idp))))
+                  (! (contr-path (c (h a)) (η (a , idp))))
                   (◯-rec-β (snd (P (h a))) _ (a , idp))
 
                 g-f : ∀ k → g (f k) == k
@@ -180,16 +180,16 @@ module lib.types.Modality where
                   ◯-elim {A = hfiber h b}
                          (λ r → =-preserves-local (snd (P b)) {g (f k) b})
                          (λ r → lemma₁ (fst r) b (snd r))
-                         (fst (c b))
+                         (contr-center (c b))
 
                     where lemma₀ : (a : A) → (b : B) → (p : h a == b) →
                                  helper (k ∘ h) b (η (a , p)) == k b
                           lemma₀ a .(h a) idp = helper-β (k ∘ h) (h a) (a , idp)
 
                           lemma₁ : (a : A) → (b : B) → (p : h a == b) →
-                                 helper (k ∘ h) b (fst (c b)) == k b
+                                 helper (k ∘ h) b (contr-center (c b)) == k b
                           lemma₁ a b p = transport! (λ r → helper (k ∘ h) b r == k b)
-                            (snd (c b) (η (a , p))) (lemma₀ a b p)
+                            (contr-path (c b) (η (a , p))) (lemma₀ a b p)
 
       ◯-extend : Π A (fst ∘ P ∘ h) → Π B (fst ∘ P)
       ◯-extend = is-equiv.g pre∘-◯-conn-is-equiv

--- a/core/lib/types/Nat.agda
+++ b/core/lib/types/Nat.agda
@@ -64,10 +64,13 @@ abstract
   ℕ-has-dec-eq (S n) (S m) | inl p = inl (ap S p)
   ℕ-has-dec-eq (S n) (S m) | inr ¬p = inr (λ p → ¬p (ℕ-S-is-inj n m p))
 
-  ℕ-is-set : is-set ℕ
-  ℕ-is-set = dec-eq-is-set ℕ-has-dec-eq
+ℕ-is-set : is-set ℕ
+ℕ-is-set = dec-eq-is-set ℕ-has-dec-eq
 
-ℕ-level = ℕ-is-set
+instance
+  ℕ-level : {n : ℕ₋₂} → has-level (S (S n)) ℕ
+  ℕ-level {⟨-2⟩} = ℕ-is-set
+  ℕ-level {n = S n} = raise-level (S (S n)) ℕ-level
 
 {- Inequalities -}
 infix 40 _<_ _≤_
@@ -170,7 +173,7 @@ abstract
     <-has-all-paths' : {m n₁ n₂ : ℕ} (eqn : n₁ == n₂) (lt₁ : m < n₁) (lt₂ : m < n₂)
       → PathOver (λ n → m < n) eqn lt₁ lt₂
     <-has-all-paths' eqn ltS ltS = transport (λ eqn₁ → PathOver (_<_ _) eqn₁ ltS ltS)
-      (prop-has-all-paths (ℕ-is-set _ _) idp eqn) idp
+      (prop-has-all-paths idp eqn) idp
     <-has-all-paths' idp ltS (ltSR lt₂) = ⊥-rec (<-to-≠ lt₂ idp)
     <-has-all-paths' idp (ltSR lt₁) ltS = ⊥-rec (<-to-≠ lt₁ idp)
     <-has-all-paths' idp (ltSR lt₁) (ltSR lt₂) = ap ltSR (<-has-all-paths' idp lt₁ lt₂)
@@ -180,13 +183,14 @@ abstract
 
   ≤-has-all-paths : {m n : ℕ} → has-all-paths (m ≤ n)
   ≤-has-all-paths = λ{
-    (inl eq₁) (inl eq₂) → ap inl (prop-has-all-paths (ℕ-is-set _ _) eq₁ eq₂);
+    (inl eq₁) (inl eq₂) → ap inl (prop-has-all-paths eq₁ eq₂);
     (inl eq)  (inr lt)  → ⊥-rec (<-to-≠ lt eq);
     (inr lt)  (inl eq)  → ⊥-rec (<-to-≠ lt eq);
     (inr lt₁) (inr lt₂) → ap inr (<-has-all-paths lt₁ lt₂)}
 
-  ≤-is-prop : {m n : ℕ} → is-prop (m ≤ n)
-  ≤-is-prop = all-paths-is-prop ≤-has-all-paths
+  instance
+    ≤-is-prop : {m n : ℕ} → is-prop (m ≤ n)
+    ≤-is-prop = all-paths-is-prop ≤-has-all-paths
 
 <-+-l : {m n : ℕ} (k : ℕ) → m < n → (k + m) < (k + n)
 <-+-l O lt = lt

--- a/core/lib/types/NatColim.agda
+++ b/core/lib/types/NatColim.agda
@@ -116,7 +116,7 @@ ncolim-conn : ∀ {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n)) (
 ncolim-conn {D = D} d ⟨-2⟩ = -2-conn (ℕColim d)
 ncolim-conn {D = D} d (S m) {{cD}} =
   Trunc-rec
-    (λ x → has-level-make ([ ncin O x ] ,
+    (λ x → has-level-in ([ ncin O x ] ,
             (Trunc-elim $
               λ c → ap [_] (nc-match-=-base d x c) ∙ nc-match-=-point x c)))
     (contr-center (cD O))

--- a/core/lib/types/NatColim.agda
+++ b/core/lib/types/NatColim.agda
@@ -111,21 +111,21 @@ module _ {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n)) where
 {- If all Dₙ are m-connected, then the colim is m-connected -}
 
 ncolim-conn : ∀ {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n)) (m : ℕ₋₂)
-  → ((n : ℕ) → is-connected m (D n))
+  {{_ : {n : ℕ} → is-connected m (D n)}}
   → is-connected m (ℕColim d)
-ncolim-conn {D = D} d ⟨-2⟩ cD = -2-conn (ℕColim d)
-ncolim-conn {D = D} d (S m) cD =
-  Trunc-rec (prop-has-level-S is-contr-is-prop)
-    (λ x → ([ ncin O x ] ,
-            (Trunc-elim (λ _ → =-preserves-level Trunc-level) $
+ncolim-conn {D = D} d ⟨-2⟩ = -2-conn (ℕColim d)
+ncolim-conn {D = D} d (S m) {{cD}} =
+  Trunc-rec
+    (λ x → has-level-make ([ ncin O x ] ,
+            (Trunc-elim $
               λ c → ap [_] (nc-match-=-base d x c) ∙ nc-match-=-point x c)))
-    (fst (cD O))
+    (contr-center (cD {O}))
   where
   nc-match-=-point : (x : D O) (c : ℕColim d)
     → [_] {n = S m} (nc-match d x c) == [ c ]
   nc-match-=-point x = ℕColimElim.f d
     (λ n y → ap (Trunc-fmap (ncin n))
-                (contr-has-all-paths (cD n) [ nc-lift d n x ] [ y ]))
+                (contr-has-all-paths [ nc-lift d n x ] [ y ]))
       (λ n y → ↓-='-from-square $
         (ap-∘ [_] (nc-match d x) (ncglue n y)
          ∙ ap (ap [_]) (ℕCMatch.ncglue-β d x n y))
@@ -134,25 +134,25 @@ ncolim-conn {D = D} d (S m) cD =
         ∙h⊡
         square-symmetry
           (natural-square
-            (Trunc-elim (λ _ → =-preserves-level Trunc-level)
+            (Trunc-elim
                (λ c → ap [_] (nc-raise-= d c)))
             (ap (Trunc-fmap (ncin n))
-                (contr-has-all-paths (cD n) [ nc-lift d n x ] [ y ])))
+                (contr-has-all-paths [ nc-lift d n x ] [ y ])))
         ⊡h∙
         ∘-ap (Trunc-fmap (nc-raise d)) (Trunc-fmap (ncin n))
-          (contr-has-all-paths (cD n) [ nc-lift d n x ] [ y ])
+          (contr-has-all-paths [ nc-lift d n x ] [ y ])
         ⊡h∙
         vert-degen-path
           (natural-square
             (λ t → Trunc-fmap-∘ (nc-raise d) (ncin n) t
                    ∙ ! (Trunc-fmap-∘ (ncin (S n)) (d n) t))
-            (contr-has-all-paths (cD n) [ nc-lift d n x ] [ y ]))
+            (contr-has-all-paths [ nc-lift d n x ] [ y ]))
         ⊡h∙
         ap-∘ (Trunc-fmap (ncin (S n))) (Trunc-fmap (d n))
-             (contr-has-all-paths (cD n) [ nc-lift d n x ] [ y ])
+             (contr-has-all-paths [ nc-lift d n x ] [ y ])
         ⊡h∙
         ap (ap (Trunc-fmap (ncin (S n))))
-           (contr-has-all-paths (=-preserves-level (cD (S n))) _ _))
+           (contr-has-all-paths _ _))
 
 {- Type of finite tuples -}
 

--- a/core/lib/types/NatColim.agda
+++ b/core/lib/types/NatColim.agda
@@ -111,7 +111,7 @@ module _ {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n)) where
 {- If all Dₙ are m-connected, then the colim is m-connected -}
 
 ncolim-conn : ∀ {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n)) (m : ℕ₋₂)
-  {{_ : {n : ℕ} → is-connected m (D n)}}
+  {{_ : (n : ℕ) → is-connected m (D n)}}
   → is-connected m (ℕColim d)
 ncolim-conn {D = D} d ⟨-2⟩ = -2-conn (ℕColim d)
 ncolim-conn {D = D} d (S m) {{cD}} =
@@ -119,8 +119,10 @@ ncolim-conn {D = D} d (S m) {{cD}} =
     (λ x → has-level-make ([ ncin O x ] ,
             (Trunc-elim $
               λ c → ap [_] (nc-match-=-base d x c) ∙ nc-match-=-point x c)))
-    (contr-center (cD {O}))
+    (contr-center (cD O))
   where
+  instance f = λ {n} → cD n
+
   nc-match-=-point : (x : D O) (c : ℕColim d)
     → [_] {n = S m} (nc-match d x c) == [ c ]
   nc-match-=-point x = ℕColimElim.f d

--- a/core/lib/types/PathSet.agda
+++ b/core/lib/types/PathSet.agda
@@ -30,14 +30,14 @@ idp₀ = [ idp ]
 
 ap₀ : ∀ {i j} {A : Type i} {B : Type j} {x y : A} (f : A → B)
   → x =₀ y → f x =₀ f y
-ap₀ f = Trunc-rec Trunc-level ([_] ∘ ap f)
+ap₀ f = Trunc-rec ([_] ∘ ap f)
 
-coe₀ : ∀ {i} {A B : Type i} (_ : is-set B) (p : A =₀ B) → A → B
-coe₀ B-level = Trunc-rec (→-is-set B-level) coe
+coe₀ : ∀ {i} {A B : Type i} {{_ : is-set B}} (p : A =₀ B) → A → B
+coe₀ = Trunc-rec coe
 
 transport₀ : ∀ {i j} {A : Type i} (B : A → Type j) {x y : A}
-  (B-level : is-set (B y)) (p : x =₀ y) → (B x → B y)
-transport₀ B B-level p = coe₀ B-level (ap₀ B p)
+  {{_ : is-set (B y)}} (p : x =₀ y) → (B x → B y)
+transport₀ B p = coe₀ (ap₀ B p)
 
 module _ {i} {A : Type i} where
 
@@ -45,122 +45,92 @@ module _ {i} {A : Type i} where
     ∙₀=∙₀' : ∀ {x y z : A} (p : x =₀ y) (q : y =₀ z)
       → p ∙₀ q == p ∙₀' q
     ∙₀=∙₀' = Trunc-elim
-      (λ _ → Π-is-set λ _ → =-preserves-set Trunc-level)
       (λ p → Trunc-elim
-        (λ _ → =-preserves-set Trunc-level)
         (λ q → ap [_] $ ∙=∙' p q))
 
     ∙₀'=∙₀ : ∀ {x y z : A} (p : x =₀ y) (q : y =₀ z)
       → p ∙₀' q == p ∙₀ q
     ∙₀'=∙₀ = Trunc-elim
-      (λ _ → Π-is-set λ _ → =-preserves-set Trunc-level)
       (λ p → Trunc-elim
-        (λ _ → =-preserves-set Trunc-level)
         (λ q → ap [_] $ ∙'=∙ p q))
 
     ∙₀-unit-r : ∀ {x y : A} (q : x =₀ y) → (q ∙₀ idp₀) == q
     ∙₀-unit-r = Trunc-elim
-      (λ _ →  =-preserves-set Trunc-level)
       (λ p → ap [_] $ ∙-unit-r p)
 
     ∙₀-unit-l : ∀ {x y : A} (q : x =₀ y) → (idp₀ ∙₀ q) == q
     ∙₀-unit-l = Trunc-elim
-      (λ _ →  =-preserves-set Trunc-level)
       (λ _ → idp)
 
     ∙₀'-unit-r : ∀ {x y : A} (q : x =₀ y) → (q ∙₀' idp₀) == q
     ∙₀'-unit-r = Trunc-elim
-      (λ _ →  =-preserves-set Trunc-level)
       (λ _ → idp)
 
     ∙₀'-unit-l : ∀ {x y : A} (q : x =₀ y) → (idp₀ ∙₀' q) == q
     ∙₀'-unit-l = Trunc-elim
-      (λ _ →  =-preserves-set Trunc-level)
       (λ p → ap [_] $ ∙'-unit-l p)
 
     ∙₀-assoc : {x y z t : A} (p : x =₀ y) (q : y =₀ z) (r : z =₀ t)
       → (p ∙₀ q) ∙₀ r == p ∙₀ (q ∙₀ r)
     ∙₀-assoc = Trunc-elim
-      (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set Trunc-level)
       (λ p → Trunc-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set Trunc-level)
         (λ q → Trunc-elim
-          (λ _ → =-preserves-set Trunc-level)
           (λ r → ap [_] $ ∙-assoc p q r)))
 
     ∙₀'-assoc : {x y z t : A} (p : x =₀ y) (q : y =₀ z) (r : z =₀ t)
       → (p ∙₀' q) ∙₀' r == p ∙₀' (q ∙₀' r)
     ∙₀'-assoc = Trunc-elim
-      (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set Trunc-level)
       (λ p → Trunc-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set Trunc-level)
         (λ q → Trunc-elim
-          (λ _ → =-preserves-set Trunc-level)
           (λ r → ap [_] $ ∙'-assoc p q r)))
 
     !₀-inv-l : {x y : A} (p : x =₀ y) → (!₀ p) ∙₀ p == idp₀
     !₀-inv-l = Trunc-elim
-      (λ _ →  =-preserves-set Trunc-level)
       (λ p → ap [_] $ !-inv-l p)
 
     !₀-inv-r : {x y : A} (p : x =₀ y) → p ∙₀ (!₀ p) == idp₀
     !₀-inv-r = Trunc-elim
-      (λ _ →  =-preserves-set Trunc-level)
       (λ p → ap [_] $ !-inv-r p)
 
     ∙₀-ap₀ : ∀ {j} {B : Type j} (f : A → B) {x y z : A} (p : x =₀ y) (q : y =₀ z)
       → ap₀ f p ∙₀ ap₀ f q == ap₀ f (p ∙₀ q)
     ∙₀-ap₀ f = Trunc-elim
-      (λ _ → Π-is-set λ _ → =-preserves-set Trunc-level)
       (λ p → Trunc-elim
-        (λ _ → =-preserves-set Trunc-level)
         (λ q → ap [_] $ ∙-ap f p q))
 
     ap₀-∘ : ∀ {j k} {B : Type j} {C : Type k} (g : B → C) (f : A → B)
       {x y : A} (p : x =₀ y) → ap₀ (g ∘ f) p == ap₀ g (ap₀ f p)
     ap₀-∘ f g = Trunc-elim
-      (λ _ → =-preserves-set Trunc-level)
       (λ p → ap [_] $ ap-∘ f g p)
 
-    coe₀-∙₀ : {B C : Type i} (B-level : is-set B) (C-level : is-set C)
+    coe₀-∙₀ : {B C : Type i} {{_ : is-set B}} {{_ : is-set C}}
       → (p : A =₀ B) (q : B =₀ C) (a : A)
-      → coe₀ C-level (p ∙₀ q) a == coe₀ C-level q (coe₀ B-level p a)
-    coe₀-∙₀ B-level C-level = Trunc-elim
-      (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set C-level)
+      → coe₀ (p ∙₀ q) a == coe₀ q (coe₀ p a)
+    coe₀-∙₀ = Trunc-elim
       (λ p → Trunc-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set C-level)
         (λ q a → coe-∙ p q a))
 
     transp₀-∙₀ : ∀ {j} {B : A → Type j}
-      → (B-level : ∀ a → is-set (B a))
+      → {{_ : ∀ {a} → is-set (B a)}}
       → {x y z : A} (p : x =₀ y) (q : y =₀ z) (b : B x)
-      → transport₀ B (B-level _) (p ∙₀ q) b
-      == transport₀ B (B-level _) q (transport₀ B (B-level _) p b)
-    transp₀-∙₀ B-level = Trunc-elim
-      (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set $ B-level _)
-      (λ p → Trunc-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set $ B-level _)
-        (λ q b → transp-∙ p q b))
+      → transport₀ B (p ∙₀ q) b
+      == transport₀ B q (transport₀ B p b)
+    transp₀-∙₀ = Trunc-elim (λ p → Trunc-elim (λ q b → transp-∙ p q b))
 
     transp₀-∙₀' : ∀ {j} {B : A → Type j}
-      → (B-level : ∀ a → is-set (B a))
+      → {{_ : ∀ {a} → is-set (B a)}}
       → {x y z : A} (p : x =₀ y) (q : y =₀ z) (b : B x)
-      → transport₀ B (B-level _) (p ∙₀' q) b
-      == transport₀ B (B-level _) q (transport₀ B (B-level _) p b)
-    transp₀-∙₀' B-level = Trunc-elim
-      (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set $ B-level _)
-      (λ p → Trunc-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set $ B-level _)
-        (λ q b → transp-∙' p q b))
+      → transport₀ B (p ∙₀' q) b
+      == transport₀ B q (transport₀ B p b)
+    transp₀-∙₀' = Trunc-elim (λ p → Trunc-elim (λ q b → transp-∙' p q b))
 
 -- favonia: one should rethink about this part
 -- it is using transp, not following the overall trend to favor PathOver
 module _ {i} {A : Type i} where
   transp₀-cst=₀idf : {a b c : A} (p : b =₀ c) (q : a =₀ b)
-    → transport₀ (a =₀_) Trunc-level p q == q ∙₀' p
+    → transport₀ (a =₀_) p q == q ∙₀' p
   transp₀-cst=₀idf {a = a} {b} = Trunc-elim
-    {P = λ p → ∀ q → transport₀ (a =₀_) Trunc-level p q == q ∙₀' p}
-    (λ p → Π-level λ q → =-preserves-set Trunc-level)
+    {P = λ p → ∀ q → transport₀ (a =₀_) p q == q ∙₀' p}
     (λ p q → lemma p q)
     where
       lemma : ∀ {c : A} (p : b == c) (q : a =₀ b)
@@ -168,10 +138,9 @@ module _ {i} {A : Type i} where
       lemma idp q = ! (∙₀'-unit-r q)
 
   transp₀-idf=₀cst : {a b c : A} (p : a =₀ b) (q : a =₀ c)
-    → transport₀ (_=₀ c) Trunc-level p q == !₀ p ∙₀ q
+    → transport₀ (_=₀ c) p q == !₀ p ∙₀ q
   transp₀-idf=₀cst {a = a} {c = c} = Trunc-elim
-    {P = λ p → ∀ q → transport₀ (_=₀ c) Trunc-level p q == !₀ p ∙₀ q}
-    (λ p → Π-level λ q → =-preserves-set Trunc-level)
+    {P = λ p → ∀ q → transport₀ (_=₀ c) p q == !₀ p ∙₀ q}
     (λ p q → lemma p q)
     where
       lemma : ∀ {b} (p : a == b) (q : a =₀ c)

--- a/core/lib/types/Pi.agda
+++ b/core/lib/types/Pi.agda
@@ -10,9 +10,9 @@ module lib.types.Pi where
 instance
   Π-level : ∀ {i j} {A : Type i} {B : A → Type j} {n : ℕ₋₂}
     → ((x : A) → has-level n (B x)) → has-level n (Π A B)
-  Π-level {n = ⟨-2⟩} p = has-level-make ((λ x → contr-center (p x)) , lemma)
+  Π-level {n = ⟨-2⟩} p = has-level-in ((λ x → contr-center (p x)) , lemma)
     where abstract lemma = λ f → λ= (λ x → contr-path (p x) (f x))
-  Π-level {n = S n} p = has-level-make lemma where
+  Π-level {n = S n} p = has-level-in lemma where
     abstract
       lemma = λ f g →
         equiv-preserves-level λ=-equiv {{Π-level (λ x → has-level-apply (p x) (f x) (g x))}}

--- a/core/lib/types/Pi.agda
+++ b/core/lib/types/Pi.agda
@@ -7,44 +7,15 @@ open import lib.types.Paths
 
 module lib.types.Pi where
 
-Π-level : ∀ {i j} {A : Type i} {B : A → Type j} {n : ℕ₋₂}
-  → (((x : A) → has-level n (B x)) → has-level n (Π A B))
-Π-level {n = ⟨-2⟩} p = (λ x → fst (p x)) , lemma
-  where abstract lemma = λ f → λ= (λ x → snd (p x) (f x))
-Π-level {n = S n} p = lemma where
-  abstract
-    lemma = λ f g →
-      equiv-preserves-level λ=-equiv
-        (Π-level λ x → p x (f x) (g x))
-
-module _ {i j} {A : Type i} {B : A → Type j} where
-  abstract
-    Π-is-prop : ((x : A) → is-prop (B x)) → is-prop (Π A B)
-    Π-is-prop = Π-level
-
-    Π-is-set : ((x : A) → is-set (B x)) → is-set (Π A B)
-    Π-is-set = Π-level
-
-module _ {i j} {A : Type i} {B : Type j} where
-  →-level : {n : ℕ₋₂} → (has-level n B → has-level n (A → B))
-  →-level p = Π-level (λ _ → p)
-
-  abstract
-    →-is-set : is-set B → is-set (A → B)
-    →-is-set = →-level
-
-    →-is-prop : is-prop B → is-prop (A → B)
-    →-is-prop = →-level
-
-module _ {i} {A : Type i} where
-  abstract
-    ¬-is-prop : is-prop (¬ A)
-    ¬-is-prop = →-is-prop ⊥-is-prop
-
-module _ {i j} {X : Ptd i} {Y : Ptd j} where
-  abstract
-    ⊙→-level : {n : ℕ₋₂} → has-level n (de⊙ Y) → has-level n (X ⊙→ Y)
-    ⊙→-level pY = Σ-level (→-level pY) (λ _ → =-preserves-level pY)
+instance
+  Π-level : ∀ {i j} {A : Type i} {B : A → Type j} {n : ℕ₋₂}
+    → ((x : A) → has-level n (B x)) → has-level n (Π A B)
+  Π-level {n = ⟨-2⟩} p = has-level-make ((λ x → contr-center (p x)) , lemma)
+    where abstract lemma = λ f → λ= (λ x → contr-path (p x) (f x))
+  Π-level {n = S n} p = has-level-make lemma where
+    abstract
+      lemma = λ f g →
+        equiv-preserves-level λ=-equiv {{Π-level (λ x → has-level-apply (p x) (f x) (g x))}}
 
 
 {- Equivalences in a Π-type -}

--- a/core/lib/types/Pi.agda
+++ b/core/lib/types/Pi.agda
@@ -17,6 +17,17 @@ instance
       lemma = λ f g →
         equiv-preserves-level λ=-equiv {{Π-level (λ x → has-level-apply (p x) (f x) (g x))}}
 
+  Πi-level : ∀ {i j} {A : Type i} {B : A → Type j} {n : ℕ₋₂}
+    → ((x : A) → has-level n (B x)) → has-level n ({x : A} → B x)
+  Πi-level {A = A} {B} p = equiv-preserves-level e {{Π-level p}}  where
+
+    e : Π A B ≃ ({x : A} → B x)
+    fst e f {x} = f x
+    is-equiv.g (snd e) f x = f
+    is-equiv.f-g (snd e) _ = idp
+    is-equiv.g-f (snd e) _ = idp
+    is-equiv.adj (snd e) _ = idp
+
 
 {- Equivalences in a Π-type -}
 Π-emap-l : ∀ {i j k} {A : Type i} {B : Type j} (P : B → Type k)

--- a/core/lib/types/Pullback.agda
+++ b/core/lib/types/Pullback.agda
@@ -66,8 +66,8 @@ module _ {i j k} (D : Cospan {i} {j} {k}) where
 module _ {i j k} (n : ℕ₋₂) {D : Cospan {i} {j} {k}} where
   open Cospan D
 
-  pullback-level : has-level n A → has-level n B → has-level n C
-    → has-level n (Pullback D)
-  pullback-level pA pB pC =
-    equiv-preserves-level ((pullback-decomp-equiv D)⁻¹) $
-      Σ-level (×-level pA pB) (λ _ → =-preserves-level pC)
+  instance
+    pullback-level : has-level n A → has-level n B → has-level n C
+      → has-level n (Pullback D)
+    pullback-level pA pB pC =
+      equiv-preserves-level ((pullback-decomp-equiv D)⁻¹) where instance _ = pA; _ = pB; _ = pC

--- a/core/lib/types/SetQuotient.agda
+++ b/core/lib/types/SetQuotient.agda
@@ -15,12 +15,10 @@ module _ {R : Rel A j} where
   postulate  -- HIT
     q[_] : (a : A) → SetQuot R
     quot-rel : {a₁ a₂ : A} → R a₁ a₂ → q[ a₁ ] == q[ a₂ ]
-    SetQuot-level : is-set (SetQuot R)
-
-  SetQuot-is-set = SetQuot-level
+    instance SetQuot-level : is-set (SetQuot R)
 
   module SetQuotElim {k} {P : SetQuot R → Type k}
-    (p : (x : SetQuot R) → is-set (P x)) (q[_]* : (a : A) → P q[ a ])
+    {{p : {x : SetQuot R} → is-set (P x)}} (q[_]* : (a : A) → P q[ a ])
     (rel* : ∀ {a₁ a₂} (r : R a₁ a₂) → q[ a₁ ]* == q[ a₂ ]* [ P ↓ quot-rel r ]) where
 
     postulate  -- HIT
@@ -33,11 +31,11 @@ module _ {R : Rel A j} where
 
   open SetQuotElim public using () renaming (f to SetQuot-elim)
 
-  module SetQuotRec {k} {B : Type k} (p : is-set B)
+  module SetQuotRec {k} {B : Type k} {{_ : is-set B}}
     (q[_]* : A → B) (rel* : ∀ {a₁ a₂} (r : R a₁ a₂) → q[ a₁ ]* == q[ a₂ ]*) where
 
     private
-      module M = SetQuotElim (λ x → p) q[_]* (λ {a₁ a₂} r → ↓-cst-in (rel* r))
+      module M = SetQuotElim q[_]* (λ {a₁ a₂} r → ↓-cst-in (rel* r))
 
     f : SetQuot R → B
     f = M.f
@@ -47,7 +45,7 @@ module _ {R : Rel A j} where
   -- If [R] is an equivalence relation, then [quot-rel] is an equivalence.
 
 module _ {R : Rel A j}
-  (R-is-prop : ∀ {a b} → is-prop (R a b))
+  {{R-is-prop : ∀ {a b} → is-prop (R a b)}}
   (R-is-refl : is-refl R) (R-is-sym : is-sym R)
   (R-is-trans : is-trans R) where
 
@@ -56,29 +54,29 @@ module _ {R : Rel A j}
     Q = SetQuot R
 
     R'-over-quot : Q → Q → hProp j
-    R'-over-quot = SetQuot-rec (→-is-set $ hProp-is-set j)
-      (λ a → SetQuot-rec (hProp-is-set j)
+    R'-over-quot = SetQuot-rec
+      (λ a → SetQuot-rec
         (λ b → R a b , R-is-prop)
         (nType=-out ∘ lemma-a))
       (λ ra₁a₂ → λ= $ SetQuot-elim
-        (λ _ → raise-level -1 $ hProp-is-set j _ _)
+        {{raise-level -1 $ (has-level-apply (hProp-is-set j) _ _)}}
         (λ _ → nType=-out $ lemma-b ra₁a₂)
-        (λ _ → prop-has-all-paths-↓ $ hProp-is-set j _ _))
+        (λ _ → prop-has-all-paths-↓))
       where
         abstract
           lemma-a : ∀ {a b₁ b₂} → R b₁ b₂ → R a b₁ == R a b₂
           lemma-a rb₁b₂ = ua $ equiv
             (λ rab₁ → R-is-trans rab₁ rb₁b₂)
             (λ rab₂ → R-is-trans rab₂ (R-is-sym rb₁b₂))
-            (λ _ → prop-has-all-paths R-is-prop _ _)
-            (λ _ → prop-has-all-paths R-is-prop _ _)
+            (λ _ → prop-has-all-paths _ _)
+            (λ _ → prop-has-all-paths _ _)
 
           lemma-b : ∀ {a₁ a₂ b} → R a₁ a₂ → R a₁ b == R a₂ b
           lemma-b ra₁a₂ = ua $ equiv
             (λ ra₁b → R-is-trans (R-is-sym ra₁a₂) ra₁b)
             (λ ra₂b → R-is-trans ra₁a₂ ra₂b)
-            (λ _ → prop-has-all-paths R-is-prop _ _)
-            (λ _ → prop-has-all-paths R-is-prop _ _)
+            (λ _ → prop-has-all-paths _ _)
+            (λ _ → prop-has-all-paths _ _)
 
     R-over-quot : Q → Q → Type j
     R-over-quot q₁ q₂ = fst (R'-over-quot q₁ q₂)
@@ -89,9 +87,9 @@ module _ {R : Rel A j}
 
       R-over-quot-is-refl : (q : Q) → R-over-quot q q
       R-over-quot-is-refl = SetQuot-elim
-        (λ q → raise-level -1 (R-over-quot-is-prop {q} {q}))
+        {{λ {q} → raise-level -1 (R-over-quot-is-prop {q} {q})}}
         (λ a → R-is-refl a)
-        (λ _ → prop-has-all-paths-↓ R-is-prop)
+        (λ _ → prop-has-all-paths-↓)
 
       path-to-R-over-quot : {q₁ q₂ : Q} → q₁ == q₂ → R-over-quot q₁ q₂
       path-to-R-over-quot {q} idp = R-over-quot-is-refl q
@@ -99,5 +97,5 @@ module _ {R : Rel A j}
   quot-rel-equiv : ∀ {a₁ a₂ : A} → R a₁ a₂ ≃ (q[ a₁ ] == q[ a₂ ])
   quot-rel-equiv {a₁} {a₂} = equiv
     quot-rel (path-to-R-over-quot {q[ a₁ ]} {q[ a₂ ]})
-    (λ _ → prop-has-all-paths (SetQuot-is-set _ _) _ _)
-    (λ _ → prop-has-all-paths R-is-prop _ _)
+    (λ _ → prop-has-all-paths _ _)
+    (λ _ → prop-has-all-paths _ _)

--- a/core/lib/types/SetQuotient.agda
+++ b/core/lib/types/SetQuotient.agda
@@ -15,7 +15,7 @@ module _ {R : Rel A j} where
   postulate  -- HIT
     q[_] : (a : A) → SetQuot R
     quot-rel : {a₁ a₂ : A} → R a₁ a₂ → q[ a₁ ] == q[ a₂ ]
-    instance SetQuot-level : is-set (SetQuot R)
+    instance SetQuot-is-set : is-set (SetQuot R)
 
   module SetQuotElim {k} {P : SetQuot R → Type k}
     {{p : {x : SetQuot R} → is-set (P x)}} (q[_]* : (a : A) → P q[ a ])

--- a/core/lib/types/Sigma.agda
+++ b/core/lib/types/Sigma.agda
@@ -146,9 +146,9 @@ instance
   Σ-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {P : A → Type j}
     → has-level n A → ((x : A) → has-level n (P x))
       → has-level n (Σ A P)
-  Σ-level {n = ⟨-2⟩} p q = has-level-make ((contr-center p , (contr-center (q (contr-center p)))) , lemma)
+  Σ-level {n = ⟨-2⟩} p q = has-level-in ((contr-center p , (contr-center (q (contr-center p)))) , lemma)
     where abstract lemma = λ y → pair= (contr-path p _) (from-transp! _ _ (contr-path (q _) _))
-  Σ-level {n = S n} p q = has-level-make lemma where
+  Σ-level {n = S n} p q = has-level-in lemma where
     abstract
       lemma = λ x y → equiv-preserves-level (=Σ-econv x y)
         {{Σ-level (has-level-apply p _ _) (λ _ →

--- a/core/lib/types/Sigma.agda
+++ b/core/lib/types/Sigma.agda
@@ -154,6 +154,10 @@ instance
         {{Σ-level (has-level-apply p _ _) (λ _ →
           equiv-preserves-level ((to-transp-equiv _ _)⁻¹) {{has-level-apply (q _) _ _}})}}
 
+×-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j}
+  → (has-level n A → has-level n B → has-level n (A × B))
+×-level pA pB = Σ-level pA (λ x → pB)
+
 -- Equivalences in a Σ-type
 
 Σ-fmap-l : ∀ {i j k} {A : Type i} {B : Type j} (P : B → Type k)

--- a/core/lib/types/Sigma.agda
+++ b/core/lib/types/Sigma.agda
@@ -142,20 +142,17 @@ module _ {i j} {A : Type i} {B : A → Type j} where
   (q : B == B' [ (λ X → (X → Type j)) ↓ p ]) → Σ A B == Σ A' B'
 Σ= idp idp = idp
 
-Σ-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {P : A → Type j}
-  → (has-level n A → ((x : A) → has-level n (P x))
-    → has-level n (Σ A P))
-Σ-level {n = ⟨-2⟩} p q = (fst p , (fst (q (fst p)))) , lemma
-  where abstract lemma = λ y → pair= (snd p _) (from-transp! _ _ (snd (q _) _))
-Σ-level {n = S n} p q = lemma where
-  abstract
-    lemma = λ x y → equiv-preserves-level (=Σ-econv x y)
-      (Σ-level (p _ _) λ _ →
-        equiv-preserves-level ((to-transp-equiv _ _)⁻¹) (q _ _ _))
-
-×-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j}
-  → (has-level n A → has-level n B → has-level n (A × B))
-×-level pA pB = Σ-level pA (λ x → pB)
+instance
+  Σ-level : ∀ {i j} {n : ℕ₋₂} {A : Type i} {P : A → Type j}
+    → has-level n A → ((x : A) → has-level n (P x))
+      → has-level n (Σ A P)
+  Σ-level {n = ⟨-2⟩} p q = has-level-make ((contr-center p , (contr-center (q (contr-center p)))) , lemma)
+    where abstract lemma = λ y → pair= (contr-path p _) (from-transp! _ _ (contr-path (q _) _))
+  Σ-level {n = S n} p q = has-level-make lemma where
+    abstract
+      lemma = λ x y → equiv-preserves-level (=Σ-econv x y)
+        {{Σ-level (has-level-apply p _ _) (λ _ →
+          equiv-preserves-level ((to-transp-equiv _ _)⁻¹) {{has-level-apply (q _) _ _}})}}
 
 -- Equivalences in a Σ-type
 

--- a/core/lib/types/Suspension.agda
+++ b/core/lib/types/Suspension.agda
@@ -217,7 +217,7 @@ abstract
             {P = λ y → idp ==
               Trunc-rec (λ a → ap [_] (merid a)) y
               [ (λ z → [ north ] == [ z ]) ↓ (merid x) ]}
-            {{λ _ → ↓-preserves-level}}
+            {{λ _ → ↓-preserves-level ⟨⟩}}
             (λ x' → ↓-cst=app-in (∙'-unit-l _ ∙ mers-eq n x x'))
             (contr-center cA))))
     where

--- a/core/lib/types/Suspension.agda
+++ b/core/lib/types/Suspension.agda
@@ -206,30 +206,30 @@ module _ {i j} (X : Ptd i) where
 abstract
   Susp-conn : ∀ {i} {A : Type i} {n : ℕ₋₂}
     → is-connected n A → is-connected (S n) (Susp A)
-  Susp-conn {A = A} {n = n} cA =
+  Susp-conn {A = A} {n = n} cA = has-level-make
     ([ north ] ,
-     Trunc-elim (λ _ → =-preserves-level Trunc-level)
+     Trunc-elim
        (Susp-elim
          idp
-         (Trunc-rec (Trunc-level {n = S n} _ _)
-                    (λ a → ap [_] (merid a))
-                    (fst cA))
+         (Trunc-rec (λ a → ap [_] (merid a))
+                    (contr-center cA))
          (λ x → Trunc-elim
             {P = λ y → idp ==
-              Trunc-rec (Trunc-level {n = S n} _ _) (λ a → ap [_] (merid a)) y
+              Trunc-rec (λ a → ap [_] (merid a)) y
               [ (λ z → [ north ] == [ z ]) ↓ (merid x) ]}
-            (λ _ → ↓-preserves-level (Trunc-level {n = S n} _ _))
-            (λ x' → ↓-cst=app-in (∙'-unit-l _ ∙ mers-eq n cA x x'))
-            (fst cA))))
+            {{λ _ → ↓-preserves-level}}
+            (λ x' → ↓-cst=app-in (∙'-unit-l _ ∙ mers-eq n x x'))
+            (contr-center cA))))
     where
+    instance _ = cA
+
     mers-eq : ∀ {i} {A : Type i} (n : ℕ₋₂)
-      → is-connected n A → (x x' : A)
+      {{_ : is-connected n A}} → (x x' : A)
       → ap ([_] {n = S n}) (merid x)
-        == Trunc-rec (Trunc-level {n = S n} _ _)
-                     (λ a → ap [_] (merid a)) [ x' ]
-    mers-eq ⟨-2⟩ cA x x' = contr-has-all-paths (Trunc-level {n = -1} _ _) _ _
-    mers-eq {A = A} (S n) cA x x' =
-      conn-extend (pointed-conn-out A x cA)
+        == Trunc-rec {{has-level-apply (Trunc-level {n = S n}) _ _}} (λ a → ap [_] (merid a)) [ x' ]
+    mers-eq ⟨-2⟩ x x' = contr-has-all-paths _ _
+    mers-eq {A = A} (S n) x x' =
+      conn-extend (pointed-conn-out A x)
         (λ y → ((ap [_] (merid x) == ap [_] (merid y)) ,
-                Trunc-level {n = S (S n)} _ _ _ _))
+                has-level-apply (has-level-apply (Trunc-level {n = S (S n)}) _ _) _ _))
         (λ _ → idp) x'

--- a/core/lib/types/Suspension.agda
+++ b/core/lib/types/Suspension.agda
@@ -206,7 +206,7 @@ module _ {i j} (X : Ptd i) where
 abstract
   Susp-conn : ∀ {i} {A : Type i} {n : ℕ₋₂}
     → is-connected n A → is-connected (S n) (Susp A)
-  Susp-conn {A = A} {n = n} cA = has-level-make
+  Susp-conn {A = A} {n = n} cA = has-level-in
     ([ north ] ,
      Trunc-elim
        (Susp-elim

--- a/core/lib/types/Truncation.agda
+++ b/core/lib/types/Truncation.agda
@@ -120,10 +120,10 @@ abstract
 
 Trunc-preserves-level : ∀ {i} {A : Type i} {n : ℕ₋₂} (m : ℕ₋₂)
  → has-level n A → has-level n (Trunc m A)
-Trunc-preserves-level {n = ⟨-2⟩} _ p = has-level-make
+Trunc-preserves-level {n = ⟨-2⟩} _ p = has-level-in
   ([ contr-center p ] , Trunc-elim (λ a → ap [_] (contr-path p a)))
 Trunc-preserves-level ⟨-2⟩ _ = contr-has-level Trunc-level
-Trunc-preserves-level {n = (S n)} (S m) c = has-level-make (λ t₁ t₂ →
+Trunc-preserves-level {n = (S n)} (S m) c = has-level-in (λ t₁ t₂ →
   Trunc-elim
     {{λ s₁ → prop-has-level-S {A = has-level n (s₁ == t₂)} has-level-is-prop}}
     (λ a₁ → Trunc-elim

--- a/core/lib/types/Truncation.agda
+++ b/core/lib/types/Truncation.agda
@@ -13,10 +13,10 @@ module _ {i} where
   postulate  -- HIT
     Trunc : (n : ℕ₋₂) (A : Type i) → Type i
     [_] : {n : ℕ₋₂} {A : Type i} → A → Trunc n A
-    Trunc-level : {n : ℕ₋₂} {A : Type i} → has-level n (Trunc n A)
+    instance Trunc-level : {n : ℕ₋₂} {A : Type i} → has-level n (Trunc n A)
 
   module TruncElim {n : ℕ₋₂} {A : Type i} {j} {P : Trunc n A → Type j}
-    (p : (x : Trunc n A) → has-level n (P x)) (d : (a : A) → P [ a ]) where
+    {{p : (x : Trunc n A) → has-level n (P x)}} (d : (a : A) → P [ a ]) where
 
     postulate  -- HIT
       f : Π (Trunc n A) P
@@ -25,11 +25,11 @@ module _ {i} where
 
 open TruncElim public renaming (f to Trunc-elim)
 
-module TruncRec {i j} {n : ℕ₋₂} {A : Type i} {B : Type j} (p : has-level n B)
+module TruncRec {i j} {n : ℕ₋₂} {A : Type i} {B : Type j} {{p : has-level n B}}
   (d : A → B) where
 
   private
-    module M = TruncElim (λ x → p) d
+    module M = TruncElim {{λ x → p}} d
 
   f : Trunc n A → B
   f = M.f
@@ -38,14 +38,13 @@ open TruncRec public renaming (f to Trunc-rec)
 
 module TruncRecType {i j} {n : ℕ₋₂} {A : Type i} (d : A → n -Type j) where
 
-  open TruncRec (n -Type-level j) d public
+  open TruncRec {{n -Type-level j}} d public
 
   flattening-Trunc : Σ (Trunc (S n) A) (fst ∘ f) ≃ Trunc (S n) (Σ A (fst ∘ d))
   flattening-Trunc = equiv to from to-from from-to where
 
     to-aux : (x : Trunc (S n) A) → (fst (f x) → Trunc (S n) (Σ A (fst ∘ d)))
-    to-aux = Trunc-elim (λ _ → →-level Trunc-level)
-                        (λ a b → [ (a , b) ])
+    to-aux = Trunc-elim (λ a b → [ (a , b) ])
 
     to : Σ (Trunc (S n) A) (fst ∘ f) → Trunc (S n) (Σ A (fst ∘ d))
     to (x , y) = to-aux x y
@@ -54,15 +53,14 @@ module TruncRecType {i j} {n : ℕ₋₂} {A : Type i} (d : A → n -Type j) whe
     from-aux (a , b) = ([ a ] , b)
 
     from : Trunc (S n) (Σ A (fst ∘ d)) → Σ (Trunc (S n) A) (fst ∘ f)
-    from = Trunc-rec (Σ-level Trunc-level (λ x → raise-level _ (snd (f x))))
-                     from-aux
+    from = Trunc-rec {{Σ-level ⟨⟩ (λ x → raise-level _ (snd (f x)))}}
+                     from-aux  where
 
     to-from : (x : Trunc (S n) (Σ A (fst ∘ d))) → to (from x) == x
-    to-from = Trunc-elim (λ _ → =-preserves-level Trunc-level)
-                         (λ _ → idp)
+    to-from = Trunc-elim (λ _ → idp)
 
     from-to-aux : (a : Trunc (S n) A) (b : fst (f a)) → from (to-aux a b) == (a , b)
-    from-to-aux = Trunc-elim (λ _ → Π-level (λ _ → =-preserves-level (Σ-level Trunc-level (λ x → raise-level _ (snd (f x))))))
+    from-to-aux = Trunc-elim {{λ _ → Π-level (λ _ → =-preserves-level (Σ-level ⟨⟩ (λ x → raise-level _ (snd (f x)))))}}
                              (λ a b → idp)
 
     from-to : (x : Σ (Trunc (S n) A) (fst ∘ f)) → from (to x) == x
@@ -76,16 +74,13 @@ module TruncRecType {i j} {n : ℕ₋₂} {A : Type i} (d : A → n -Type j) whe
 module _ {i} {n : ℕ₋₂} {A : Type i} where
 
   Trunc= : (a b : Trunc (S n) A) → n -Type i
-  Trunc= = Trunc-elim (λ _ → →-level (n -Type-level i))
-      (λ a → Trunc-elim (λ _ → n -Type-level i)
-      ((λ b → (Trunc n (a == b) , Trunc-level))))
-
+  Trunc= = Trunc-elim (λ a → Trunc-elim ((λ b → (Trunc n (a == b) , Trunc-level))))
 
   Trunc=-equiv : (a b : Trunc (S n) A) → (a == b) ≃ fst (Trunc= a b)
   Trunc=-equiv a b = equiv (to a b) (from a b) (to-from a b) (from-to a b) where
 
     to-aux : (a : Trunc (S n) A) → fst (Trunc= a a)
-    to-aux = Trunc-elim (λ x → raise-level _ (snd (Trunc= x x)))
+    to-aux = Trunc-elim {{λ x → raise-level _ (snd (Trunc= x x))}}
                         (λ a → [ idp ])
 
     to : (a b : Trunc (S n) A) → (a == b → fst (Trunc= a b))
@@ -95,22 +90,19 @@ module _ {i} {n : ℕ₋₂} {A : Type i} where
     from-aux a .a idp = idp
 
     from : (a b : Trunc (S n) A) → (fst (Trunc= a b) → a == b)
-    from = Trunc-elim (λ _ → Π-level (λ _ → →-level (=-preserves-level Trunc-level)))
-           (λ a → Trunc-elim (λ _ → →-level (=-preserves-level Trunc-level))
-           (λ b → Trunc-rec (Trunc-level {n = S n} _ _)
-           (from-aux a b)))
+    from = Trunc-elim (λ a → Trunc-elim (λ b → Trunc-rec (from-aux a b)))
 
     to-from-aux : (a b : A) → (p : a == b) → to _ _ (from-aux a b p) == [ p ]
     to-from-aux a .a idp = idp
 
     to-from : (a b : Trunc (S n) A) (x : fst (Trunc= a b)) → to a b (from a b x) == x
-    to-from = Trunc-elim (λ x → Π-level (λ y → Π-level (λ _ → =-preserves-level (raise-level _ (snd (Trunc= x y))))))
-              (λ a → Trunc-elim (λ x → Π-level (λ _ → raise-level _ (=-preserves-level (snd (Trunc= [ a ] x)))))
-              (λ b → Trunc-elim (λ _ → =-preserves-level Trunc-level)
+    to-from = Trunc-elim {{λ x → Π-level (λ y → Π-level (λ _ → =-preserves-level (raise-level _ (snd (Trunc= x y)))))}}
+              (λ a → Trunc-elim {{λ x → Π-level (λ _ → =-preserves-level (raise-level _ (snd (Trunc= [ a ] x))))}}
+              (λ b → Trunc-elim
               (to-from-aux a b)))
 
     from-to-aux : (a : Trunc (S n) A) → from a a (to-aux a) == idp
-    from-to-aux = Trunc-elim (λ x → =-preserves-level (=-preserves-level Trunc-level)) (λ _ → idp)
+    from-to-aux = Trunc-elim (λ _ → idp)
 
     from-to : (a b : Trunc (S n) A) (p : a == b) → from a b (to a b p) == p
     from-to a .a idp = from-to-aux a
@@ -121,67 +113,65 @@ module _ {i} {n : ℕ₋₂} {A : Type i} where
 
 abstract
   Trunc-rec-is-equiv : ∀ {i j} (n : ℕ₋₂) (A : Type i) (B : Type j)
-    (p : has-level n B) → is-equiv (Trunc-rec p :> ((A → B) → (Trunc n A → B)))
-  Trunc-rec-is-equiv n A B p = is-eq _ (λ f → f ∘ [_])
-    (λ f → λ= (Trunc-elim (λ _ → =-preserves-level p) (λ a → idp))) (λ f → idp)
+    {{p : has-level n B}} → is-equiv (Trunc-rec {{p}} :> ((A → B) → (Trunc n A → B)))
+  Trunc-rec-is-equiv n A B {{p}} = is-eq _ (λ f → f ∘ [_])
+    (λ f → λ= (Trunc-elim (λ a → idp))) (λ f → idp)
 
 
 Trunc-preserves-level : ∀ {i} {A : Type i} {n : ℕ₋₂} (m : ℕ₋₂)
  → has-level n A → has-level n (Trunc m A)
-Trunc-preserves-level {n = ⟨-2⟩} _ (a₀ , p) =
-  ([ a₀ ] , Trunc-elim (λ _ → =-preserves-level Trunc-level)
-              (λ a → ap [_] (p a)))
+Trunc-preserves-level {n = ⟨-2⟩} _ p = has-level-make
+  ([ contr-center p ] , Trunc-elim (λ a → ap [_] (contr-path p a)))
 Trunc-preserves-level ⟨-2⟩ _ = contr-has-level Trunc-level
-Trunc-preserves-level {n = (S n)} (S m) c = λ t₁ t₂ →
+Trunc-preserves-level {n = (S n)} (S m) c = has-level-make (λ t₁ t₂ →
   Trunc-elim
-    (λ s₁ → prop-has-level-S {A = has-level n (s₁ == t₂)} has-level-is-prop)
+    {{λ s₁ → prop-has-level-S {A = has-level n (s₁ == t₂)} has-level-is-prop}}
     (λ a₁ → Trunc-elim
-      (λ s₂ → prop-has-level-S {A = has-level n ([ a₁ ] == s₂)} has-level-is-prop)
+      {{λ s₂ → prop-has-level-S {A = has-level n ([ a₁ ] == s₂)} has-level-is-prop}}
       (λ a₂ → equiv-preserves-level
       ((Trunc=-equiv [ a₁ ] [ a₂ ])⁻¹)
-               (Trunc-preserves-level {n = n} m (c a₁ a₂)))
+               {{Trunc-preserves-level {n = n} m (has-level-apply c a₁ a₂)}})
               t₂)
-    t₁
+    t₁)
 
 {- an n-type is equivalent to its n-truncation -}
 unTrunc-equiv : ∀ {i} {n : ℕ₋₂} (A : Type i)
-  → has-level n A → Trunc n A ≃ A
-unTrunc-equiv A nA = equiv f [_] (λ _ → idp) g-f where
-  f = Trunc-rec nA (idf _)
-  g-f = Trunc-elim (λ _ → =-preserves-level Trunc-level) (λ _ → idp)
+  {{_ : has-level n A}} → Trunc n A ≃ A
+unTrunc-equiv A = equiv f [_] (λ _ → idp) g-f where
+  f = Trunc-rec (idf _)
+  g-f = Trunc-elim (λ _ → idp)
 
 ⊙unTrunc-equiv : ∀ {i} {n : ℕ₋₂} (X : Ptd i)
-  → has-level n (de⊙ X) → ⊙Trunc n X ⊙≃ X
-⊙unTrunc-equiv {n = n} X nX = ≃-to-⊙≃ (unTrunc-equiv (de⊙ X) nX) idp
+  {{_ : has-level n (de⊙ X)}} → ⊙Trunc n X ⊙≃ X
+⊙unTrunc-equiv {n = n} X = ≃-to-⊙≃ (unTrunc-equiv (de⊙ X)) idp
 
 -- Equivalence associated to the universal property
 Trunc-extend-equiv : ∀ {i j} (n : ℕ₋₂) (A : Type i) (B : Type j)
-  (p : has-level n B) → (A → B) ≃ (Trunc n A → B)
-Trunc-extend-equiv n A B p = (Trunc-rec p , Trunc-rec-is-equiv n A B p)
+  {{p : has-level n B}} → (A → B) ≃ (Trunc n A → B)
+Trunc-extend-equiv n A B = (Trunc-rec , Trunc-rec-is-equiv n A B)
 
 Trunc-fmap : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j} → ((A → B) → (Trunc n A → Trunc n B))
-Trunc-fmap f = Trunc-rec Trunc-level ([_] ∘ f)
+Trunc-fmap f = Trunc-rec ([_] ∘ f)
 
 Trunc-fmap2 : ∀ {i j k} {n : ℕ₋₂} {A : Type i} {B : Type j} {C : Type k}
   → ((A → B → C) → (Trunc n A → Trunc n B → Trunc n C))
-Trunc-fmap2 f = Trunc-rec (Π-level (λ _ → Trunc-level)) (λ a → Trunc-fmap (f a))
+Trunc-fmap2 f = Trunc-rec (λ a → Trunc-fmap (f a))
 
 -- XXX What is the naming convention?
 Trunc-fpmap : ∀ {i j} {n : ℕ₋₂} {A : Type i} {B : Type j} {f g : A → B} (h : (a : A) → f a == g a)
   → ((a : Trunc n A) → Trunc-fmap f a == Trunc-fmap g a)
-Trunc-fpmap h = Trunc-elim (λ _ → =-preserves-level Trunc-level)
-                (ap [_] ∘ h)
+Trunc-fpmap h = Trunc-elim (ap [_] ∘ h)
 
 Trunc-fmap-idf : ∀ {i} {n : ℕ₋₂} {A : Type i}
   → ∀ x → Trunc-fmap {n = n} (idf A) x == x
 Trunc-fmap-idf =
-  Trunc-elim (λ _ → =-preserves-level Trunc-level) (λ _ → idp)
+  Trunc-elim (λ _ → idp)
 
 Trunc-fmap-∘ : ∀ {i j k} {n : ℕ₋₂} {A : Type i} {B : Type j} {C : Type k}
   → (g : B → C) → (f : A → B)
   → ∀ x → Trunc-fmap {n = n} g (Trunc-fmap f x) == Trunc-fmap (g ∘ f) x
 Trunc-fmap-∘ g f =
-  Trunc-elim (λ _ → =-preserves-level Trunc-level) (λ _ → idp)
+  Trunc-elim (λ _ → idp)
 
 {- Pushing concatentation through Trunc= -}
 module _ {i} {n : ℕ₋₂} {A : Type i} where
@@ -191,11 +181,11 @@ module _ {i} {n : ℕ₋₂} {A : Type i} where
     → fst (Trunc= ta tb) → fst (Trunc= tb tc) → fst (Trunc= ta tc)
   Trunc=-∙ {ta = ta} {tb = tb} {tc = tc} =
     Trunc-elim {P = λ ta → C ta tb tc}
-      (λ ta → level ta tb tc)
+      {{λ ta → level ta tb tc}}
       (λ a → Trunc-elim {P = λ tb → C [ a ] tb tc}
-         (λ tb → level [ a ] tb tc)
+         {{λ tb → level [ a ] tb tc}}
          (λ b → Trunc-elim {P = λ tc → C [ a ] [ b ] tc}
-                  (λ tc → level [ a ] [ b ] tc)
+                  {{λ tc → level [ a ] [ b ] tc}}
                   (λ c → Trunc-fmap2 _∙_)
                   tc)
          tb)
@@ -217,7 +207,7 @@ module _ {i} {n : ℕ₋₂} {A : Type i} where
        {P = λ x → –> (Trunc=-equiv x x) idp
                == Trunc=-∙ {ta = x} (–> (Trunc=-equiv x x) idp)
                                     (–> (Trunc=-equiv x x) idp)}
-       (λ x → raise-level _ $ =-preserves-level (snd (Trunc= x x)))
+       {{λ x → raise-level _ $ =-preserves-level (snd (Trunc= x x))}}
        (λ a → idp)
        x
 
@@ -231,12 +221,10 @@ module _ {i j} (n : ℕ₋₂) {A : Type i} {B : Type j} where
     g = Trunc-fmap (is-equiv.g ie)
 
     f-g : ∀ tb → f (g tb) == tb
-    f-g = Trunc-elim (λ _ → =-preserves-level Trunc-level)
-            (ap [_] ∘ is-equiv.f-g ie)
+    f-g = Trunc-elim (ap [_] ∘ is-equiv.f-g ie)
 
     g-f : ∀ ta → g (f ta) == ta
-    g-f = Trunc-elim (λ _ → =-preserves-level Trunc-level)
-            (ap [_] ∘ is-equiv.g-f ie)
+    g-f = Trunc-elim (ap [_] ∘ is-equiv.g-f ie)
 
   Trunc-emap : A ≃ B → Trunc n A ≃ Trunc n B
   Trunc-emap (f , f-ie) = Trunc-fmap f , Trunc-isemap f-ie
@@ -249,16 +237,17 @@ transport-Trunc _ idp _ = idp
 Trunc-fuse : ∀ {i} (A : Type i) (m n : ℕ₋₂)
   → Trunc m (Trunc n A) ≃ Trunc (minT m n) A
 Trunc-fuse A m n = equiv
-  (Trunc-rec (raise-level-≤T (minT≤l m n) Trunc-level)
-    (Trunc-rec (raise-level-≤T (minT≤r m n) Trunc-level)
+  (Trunc-rec {{raise-level-≤T (minT≤l m n) Trunc-level}}
+    (Trunc-rec {{raise-level-≤T (minT≤r m n) Trunc-level}}
       [_]))
-  (Trunc-rec l ([_] ∘ [_]))
-  (Trunc-elim (λ _ → =-preserves-level Trunc-level) (λ _ → idp))
-  (Trunc-elim (λ _ → =-preserves-level Trunc-level)
-     (Trunc-elim
-       (λ _ → =-preserves-level (Trunc-preserves-level _ Trunc-level))
+  (Trunc-rec ([_] ∘ [_]))
+  (Trunc-elim (λ _ → idp))
+  (Trunc-elim (Trunc-elim
+       {{λ _ → =-preserves-level (Trunc-preserves-level _ Trunc-level)}}
        (λ _ → idp)))
-  where l : has-level (minT m n) (Trunc m (Trunc n A))
+  where
+      instance 
+        l : has-level (minT m n) (Trunc m (Trunc n A))
         l with (minT-out m n)
         l | inl p = transport (λ k → has-level k (Trunc m (Trunc n A)))
                               (! p) Trunc-level
@@ -269,14 +258,12 @@ Trunc-fuse A m n = equiv
 Trunc-fuse-≤ : ∀ {i} (A : Type i) {m n : ℕ₋₂} (m≤n : m ≤T n)
   → Trunc m (Trunc n A) ≃ Trunc m A
 Trunc-fuse-≤ A m≤n = equiv
-  (Trunc-rec Trunc-level
-    (Trunc-rec (raise-level-≤T m≤n Trunc-level)
+  (Trunc-rec (Trunc-rec {{raise-level-≤T m≤n Trunc-level}}
       [_]))
-  (Trunc-rec Trunc-level ([_] ∘ [_]))
-  (Trunc-elim (λ _ → =-preserves-level Trunc-level) (λ _ → idp))
-  (Trunc-elim (λ _ → =-preserves-level Trunc-level)
-     (Trunc-elim
-       (λ _ → =-preserves-level (Trunc-preserves-level _ Trunc-level))
+  (Trunc-rec ([_] ∘ [_]))
+  (Trunc-elim (λ _ → idp))
+  (Trunc-elim (Trunc-elim
+       {{λ _ → =-preserves-level (Trunc-preserves-level _ Trunc-level)}}
        (λ _ → idp)))
 
 {- Truncating a binary product is equivalent to truncating its components -}
@@ -285,23 +272,16 @@ Trunc-×-econv : ∀ {i} {j} (n : ℕ₋₂) (A : Type i) (B : Type j)
 Trunc-×-econv n A B = equiv f g f-g g-f
   where
   f : Trunc n (A × B) → Trunc n A × Trunc n B
-  f = Trunc-rec (×-level Trunc-level Trunc-level)
-        (λ {(a , b) → [ a ] , [ b ]})
+  f = Trunc-rec (λ {(a , b) → [ a ] , [ b ]})
 
   g : Trunc n A × Trunc n B → Trunc n (A × B)
-  g (ta , tb) = Trunc-rec Trunc-level
-                  (λ a → Trunc-rec Trunc-level
-                    (λ b → [ a , b ])
-                  tb)
-                ta
+  g (ta , tb) = Trunc-rec (λ a → Trunc-rec (λ b → [ a , b ]) tb) ta
 
   f-g : ∀ p → f (g p) == p
   f-g (ta , tb) = Trunc-elim
     {P = λ ta → f (g (ta , tb)) == (ta , tb)}
-    (λ _ → =-preserves-level (×-level Trunc-level Trunc-level))
     (λ a → Trunc-elim
       {P = λ tb → f (g ([ a ] , tb)) == ([ a ] , tb)}
-      (λ _ → =-preserves-level (×-level Trunc-level Trunc-level))
       (λ b → idp)
       tb)
     ta
@@ -309,7 +289,6 @@ Trunc-×-econv n A B = equiv f g f-g g-f
   g-f : ∀ tab → g (f tab) == tab
   g-f = Trunc-elim
     {P = λ tab → g (f tab) == tab}
-    (λ _ → =-preserves-level Trunc-level)
     (λ ab → idp)
 
 Trunc-×-conv : ∀ {i} {j} (n : ℕ₋₂) (A : Type i) (B : Type j)

--- a/core/lib/types/Unit.agda
+++ b/core/lib/types/Unit.agda
@@ -13,5 +13,5 @@ pattern tt = unit
 -- Unit is contractible
 instance
   Unit-level : {n : ℕ₋₂} → has-level n Unit
-  Unit-level {n = ⟨-2⟩} = has-level-make (unit , λ y → idp)
+  Unit-level {n = ⟨-2⟩} = has-level-in (unit , λ y → idp)
   Unit-level {n = S n} = raise-level n Unit-level

--- a/core/lib/types/Unit.agda
+++ b/core/lib/types/Unit.agda
@@ -10,19 +10,8 @@ pattern tt = unit
 ⊙Unit : Ptd₀
 ⊙Unit = ⊙[ Unit , unit ]
 
-abstract
-  -- Unit is contractible
-  Unit-is-contr : is-contr Unit
-  Unit-is-contr = (unit , λ y → idp)
-
-  Unit-is-prop : is-prop Unit
-  Unit-is-prop = raise-level -2 Unit-is-contr
-
-  Unit-is-set : is-set Unit
-  Unit-is-set = raise-level -1 Unit-is-prop
-
-  Unit-level = Unit-is-contr
-  ⊤-is-contr = Unit-is-contr
-  ⊤-level = Unit-is-contr
-  ⊤-is-prop = Unit-is-prop
-  ⊤-is-set = Unit-is-set
+-- Unit is contractible
+instance
+  Unit-level : {n : ℕ₋₂} → has-level n Unit
+  Unit-level {n = ⟨-2⟩} = has-level-make (unit , λ y → idp)
+  Unit-level {n = S n} = raise-level n Unit-level

--- a/theorems/cohomology/DisjointlyPointedSet.agda
+++ b/theorems/cohomology/DisjointlyPointedSet.agda
@@ -41,7 +41,7 @@ module cohomology.DisjointlyPointedSet {i} (OT : OrdinaryTheory i) where
             in* (x , pt≠x) false with dec x
             in* (x , pt≠x) false | inl pt=x = ⊥-rec (pt≠x pt=x)
             in* (x , pt≠x) false | inr pt≠'x =
-              ap (λ ¬p → bwin (x , ¬p) false) $ prop-has-all-paths ¬-is-prop pt≠'x pt≠x
+              ap (λ ¬p → bwin (x , ¬p) false) $ prop-has-all-paths pt≠'x pt≠x
 
             glue* : (wp : MinusPoint X)
               → base* == in* wp true [ (λ x → from (to x) == x) ↓ bwglue wp ]

--- a/theorems/cohomology/EMModel.agda
+++ b/theorems/cohomology/EMModel.agda
@@ -21,11 +21,11 @@ module _ {i} (G : AbGroup i) where
     E-spectrum (pos n) = spectrum n
     E-spectrum (negsucc O) = ≃-to-⊙≃ {X = ⊙Ω (E 0)}
       (equiv (λ _ → _) (λ _ → idp)
-             (λ _ → idp) (prop-has-all-paths (EM-level _ _ _) _))
+             (λ _ → idp) (prop-has-all-paths _))
       idp
     E-spectrum (negsucc (S n)) = ≃-to-⊙≃ {X = ⊙Ω (E (negsucc n))}
       (equiv (λ _ → _) (λ _ → idp)
-             (λ _ → idp) (prop-has-all-paths (Lift-level Unit-is-set _ _) _))
+             (λ _ → idp) (prop-has-all-paths {{=-preserves-level ⟨⟩}} _))
       idp
 
   EM-Cohomology : CohomologyTheory i
@@ -36,22 +36,23 @@ module _ {i} (G : AbGroup i) where
   EM-dimension : {n : ℤ} → n ≠ 0 → is-trivialᴳ (C n (⊙Lift ⊙S⁰))
   EM-dimension {pos O} neq = ⊥-rec (neq idp)
   EM-dimension {pos (S n)} _ =
-    contr-is-trivialᴳ (C (pos (S n)) (⊙Lift ⊙S⁰)) $
-      connected-at-level-is-contr
-        (Trunc-level {n = 0})
-        (Trunc-preserves-conn 0
-          (equiv-preserves-conn
+    contr-is-trivialᴳ (C (pos (S n)) (⊙Lift ⊙S⁰))
+      {{connected-at-level-is-contr
+        {{⟨⟩}}
+        {{Trunc-preserves-conn $
+           equiv-preserves-conn
             (pre⊙∘-equiv ⊙lower-equiv ∘e ⊙Bool→-equiv-idf _ ⁻¹)
-            (path-conn (connected-≤T (⟨⟩-monotone-≤ (≤-ap-S (O≤ n)))
-                                     (EM-conn (S n))))))
+            {{path-conn (connected-≤T (⟨⟩-monotone-≤ (≤-ap-S (O≤ n)))
+                                     )}}}}}}
   EM-dimension {negsucc O} _ =
-    contr-is-trivialᴳ (C (negsucc O) (⊙Lift ⊙S⁰)) $
-      Trunc-preserves-level 0 $ ⊙→-level $
-        inhab-prop-is-contr idp (EM-level O _ _)
+    contr-is-trivialᴳ (C (negsucc O) (⊙Lift ⊙S⁰))
+      {{Trunc-preserves-level 0 (Σ-level (Π-level λ _ →
+        inhab-prop-is-contr idp) ⟨⟩)}}
+
   EM-dimension {negsucc (S n)} _ =
-    contr-is-trivialᴳ (C (negsucc (S n)) (⊙Lift ⊙S⁰)) $
-      Trunc-preserves-level 0 $ ⊙→-level $
-        Lift-level Unit-is-prop _ _
+    contr-is-trivialᴳ (C (negsucc (S n)) (⊙Lift ⊙S⁰))
+      {{Trunc-preserves-level 0 (Σ-level (Π-level λ _ →
+        =-preserves-level ⟨⟩) λ _ → =-preserves-level (=-preserves-level ⟨⟩))}}
 
   EM-Ordinary : OrdinaryTheory i
   EM-Ordinary = ordinary-theory EM-Cohomology EM-dimension

--- a/theorems/cohomology/SpectrumModel.agda
+++ b/theorems/cohomology/SpectrumModel.agda
@@ -149,7 +149,7 @@ module SpectrumModel where
         → im-propᴳ (C-fmap n (⊙cfcod' f)) ⊆ᴳ ker-propᴳ (C-fmap n f)
       C-im-sub-ker f =
         im-sub-ker-in (C-fmap n (⊙cfcod' f)) (C-fmap n f) $
-          Trunc-elim (λ _ → =-preserves-level (Trunc-level {n = 0}))
+          Trunc-elim
             (ap [_] ∘ im-sub-ker-lemma n f)
 
     abstract
@@ -157,8 +157,8 @@ module SpectrumModel where
         → ker-propᴳ (C-fmap n f) ⊆ᴳ im-propᴳ (C-fmap n (⊙cfcod' f))
       C-ker-sub-im f =
         Trunc-elim
-          (λ _ → Π-level (λ _ → raise-level _ Trunc-level))
-          (λ h tp → Trunc-rec Trunc-level (lemma h) (–> (Trunc=-equiv _ _) tp))
+          {{λ _ → Π-level (λ _ → raise-level _ Trunc-level)}}
+          (λ h tp → Trunc-rec (lemma h) (–> (Trunc=-equiv _ _) tp))
         where
         lemma : (h : uCEl n Y) → h ⊙∘ f == ⊙cst
           → Trunc -1 (Σ (CEl n (⊙Cofiber f))
@@ -177,7 +177,7 @@ module SpectrumModel where
     where
 
     into : CEl n (⊙BigWedge X) → Trunc 0 (Π A (uCEl n ∘ X))
-    into = Trunc-rec Trunc-level (λ H → [ (λ a → H ⊙∘ ⊙bwin a) ])
+    into = Trunc-rec (λ H → [ (λ a → H ⊙∘ ⊙bwin a) ])
 
     module Out' (K : Π A (uCEl n ∘ X)) = BigWedgeRec
       idp
@@ -185,11 +185,10 @@ module SpectrumModel where
       (! ∘ snd ∘ K)
 
     out : Trunc 0 (Π A (uCEl n ∘ X)) → CEl n (⊙BigWedge X)
-    out = Trunc-rec Trunc-level (λ K → [ Out'.f K , idp ])
+    out = Trunc-rec (λ K → [ Out'.f K , idp ])
 
     into-out : ∀ y → into (out y) == y
     into-out = Trunc-elim
-      (λ _ → =-preserves-level Trunc-level)
       (λ K → ap [_] (λ= (λ a → pair= idp $
         ap (Out'.f K) (! (bwglue a)) ∙ idp
           =⟨ ∙-unit-r _ ⟩
@@ -204,7 +203,6 @@ module SpectrumModel where
     out-into : ∀ x → out (into x) == x
     out-into = Trunc-elim
       {P = λ tH → out (into tH) == tH}
-      (λ _ → =-preserves-level Trunc-level)
       (λ {(h , hpt) → ap [_] $ ⊙λ=' (out-into-fst (h , hpt)) (↓-idf=cst-in (! (!-inv-l hpt)))})
       where
       lemma : ∀ {i j} {A : Type i} {B : Type j} (f : A → B)
@@ -228,7 +226,6 @@ module SpectrumModel where
       C-additive : is-equiv (GroupHom.f (Πᴳ-fanout (C-fmap n ∘ ⊙bwin {X = X})))
       C-additive = transport is-equiv
         (λ= $ Trunc-elim
-          (λ _ → =-preserves-level $ Π-level $ λ _ → Trunc-level)
           (λ _ → idp))
         ((ac (uCEl n ∘ X)) ∘ise (is-eq into out into-out out-into))
 

--- a/theorems/cohomology/SuspAdjointLoopIso.agda
+++ b/theorems/cohomology/SuspAdjointLoopIso.agda
@@ -59,5 +59,4 @@ module SuspAdjointLoopIso {i} where
       → fst (iso X Z) ∘ᴳ Trunc-⊙→Ω-group-fmap-dom (⊙Susp-fmap f) Z
         == Trunc-⊙→Ω-group-fmap-dom f (⊙Ω Z) ∘ᴳ fst (iso Y Z)
     nat-dom f Z = group-hom= $ λ= $ Trunc-elim
-      (λ _ → =-preserves-level Trunc-level)
       (λ g → ap [_] (! (A.nat-dom f (⊙Ω Z) g)))

--- a/theorems/cohomology/WithCoefficients.agda
+++ b/theorems/cohomology/WithCoefficients.agda
@@ -77,16 +77,14 @@ Trunc-⊙→Ω-group-emap-dom F Z =
 
 Trunc-⊙→Ω-group-fmap-dom-idf : ∀ {i j} {X : Ptd i} (Y : Ptd j)
   → Trunc-⊙→Ω-group-fmap-dom (⊙idf X) Y == idhom (Trunc-⊙→Ω-group X Y)
-Trunc-⊙→Ω-group-fmap-dom-idf Y = group-hom= $ λ= $ Trunc-elim
-  (λ _ → =-preserves-level Trunc-level) (λ _ → idp)
+Trunc-⊙→Ω-group-fmap-dom-idf Y = group-hom= $ λ= $ Trunc-elim (λ _ → idp)
 
 Trunc-⊙→Ω-group-fmap-dom-∘ : ∀ {i j k l} {X : Ptd i} {Y : Ptd j} {Z : Ptd k}
   (g : Y ⊙→ Z) (f : X ⊙→ Y) (W : Ptd l)
   → Trunc-⊙→Ω-group-fmap-dom (g ⊙∘ f) W
     == Trunc-⊙→Ω-group-fmap-dom f W ∘ᴳ Trunc-⊙→Ω-group-fmap-dom g W
 Trunc-⊙→Ω-group-fmap-dom-∘ g f W = group-hom= $ λ= $
-  Trunc-elim (λ _ → =-preserves-level Trunc-level)
-    (λ h → ap [_] (! (⊙λ= $ ⊙∘-assoc h g f)))
+  Trunc-elim (λ h → ap [_] (! (⊙λ= $ ⊙∘-assoc h g f)))
 
 ⊙→Ω-group-structure-fmap-codom : ∀ {i j k} (X : Ptd i) {Y : Ptd j} {Z : Ptd k}
   → Y ⊙→ Z → (⊙→Ω-group-structure X Y →ᴳˢ ⊙→Ω-group-structure X Z)
@@ -128,7 +126,6 @@ Trunc-⊙→Ω-group-fmap-nat : ∀ {i₀ i₁ j₀ j₁}
   →  Trunc-⊙→Ω-group-fmap-dom   F  Y₁ ∘ᴳ Trunc-⊙→Ω-group-fmap-codom X₁ G
   == Trunc-⊙→Ω-group-fmap-codom X₀ G  ∘ᴳ Trunc-⊙→Ω-group-fmap-dom   F  Y₀
 Trunc-⊙→Ω-group-fmap-nat F G = group-hom= $ λ= $ Trunc-elim
-  (λ _ → =-preserves-level Trunc-level)
   (λ k → ap [_] $ ⊙λ= $ ⊙∘-assoc (⊙Ω-fmap G) k F)
 
 {- Not used.

--- a/theorems/cw/DegreeBySquashing.agda
+++ b/theorems/cw/DegreeBySquashing.agda
@@ -41,7 +41,7 @@ module cw.DegreeBySquashing {i} where
 
     degree-map' : ℤ-group →ᴳ ℤ-group
     degree-map' = –>ᴳ (πS-SphereS-iso-ℤ n)
-               ∘ᴳ Trunc-rec →ᴳ-level (πS-fmap n)
+               ∘ᴳ Trunc-rec (πS-fmap n)
                     (⊙SphereS-endo-in n [ degree-map ])
                ∘ᴳ <–ᴳ (πS-SphereS-iso-ℤ n)
 

--- a/theorems/cw/cohomology/CellularChainComplex.agda
+++ b/theorems/cw/cohomology/CellularChainComplex.agda
@@ -68,13 +68,13 @@ module cw.cohomology.CellularChainComplex {i : ULevel} where
         == ap (λ m≤n → cw-take m≤n (cw-init skel)) (≤-has-all-paths (≤-trans lteS (inr Sm<n)) (inr m<n))
       path-lemma₀ skel m<n Sm<n =
         ap (λ m≤Sn → cw-take m≤Sn skel) (≤-has-all-paths (≤-trans lteS (lteSR (inr Sm<n))) (lteSR (inr m<n)))
-          =⟨ ap (ap (λ m≤Sn → cw-take m≤Sn skel)) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ m≤Sn → cw-take m≤Sn skel)) (contr-has-all-paths _ _) ⟩
         ap (λ m≤Sn → cw-take m≤Sn skel) (ap (lteSR ∘ inr) (<-has-all-paths (<-trans ltS Sm<n) m<n))
           =⟨ ∘-ap (λ m≤Sn → cw-take m≤Sn skel) (lteSR ∘ inr) _ ⟩
         ap (λ Sm<n → cw-take (lteSR (inr Sm<n)) skel) (<-has-all-paths (<-trans ltS Sm<n) m<n)
           =⟨ ap-∘ (λ m≤n → cw-take m≤n (cw-init skel)) inr _ ⟩
         ap (λ m≤n → cw-take m≤n (cw-init skel)) (ap inr (<-has-all-paths (<-trans ltS Sm<n) m<n))
-          =⟨ ap (ap (λ m≤n → cw-take m≤n (cw-init skel))) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ m≤n → cw-take m≤n (cw-init skel))) (contr-has-all-paths _ _) ⟩
         ap (λ m≤n → cw-take m≤n (cw-init skel)) (≤-has-all-paths (≤-trans lteS (inr Sm<n)) (inr m<n))
           =∎
 
@@ -83,9 +83,9 @@ module cw.cohomology.CellularChainComplex {i : ULevel} where
         == ap (λ n≤Sn → cw-take n≤Sn (cw-init skel)) (≤-has-all-paths lteS lteS)
       path-lemma₁ skel =
         ap (λ n≤SSn → cw-take n≤SSn skel) (≤-has-all-paths (lteSR lteS) (lteSR lteS))
-          =⟨ ap (ap (λ n≤SSn → cw-take n≤SSn skel)) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ n≤SSn → cw-take n≤SSn skel)) (contr-has-all-paths _ _) ⟩
         idp
-          =⟨ ap (ap (λ n≤Sn → cw-take n≤Sn (cw-init skel))) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ n≤Sn → cw-take n≤Sn (cw-init skel))) (contr-has-all-paths _ _) ⟩
         ap (λ n≤Sn → cw-take n≤Sn (cw-init skel)) (≤-has-all-paths lteS lteS)
           =∎
 
@@ -93,7 +93,7 @@ module cw.cohomology.CellularChainComplex {i : ULevel} where
         → ap (λ n≤Sn → cw-take n≤Sn skel) (≤-has-all-paths lteS lteS) == idp
       path-lemma₂ skel =
         ap (λ n≤Sn → cw-take n≤Sn skel) (≤-has-all-paths lteS lteS)
-          =⟨ ap (ap (λ n≤Sn → cw-take n≤Sn skel)) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ n≤Sn → cw-take n≤Sn skel)) (contr-has-all-paths _ _) ⟩
         idp
           =∎
 

--- a/theorems/cw/cohomology/ReconstructedCochainComplex.agda
+++ b/theorems/cw/cohomology/ReconstructedCochainComplex.agda
@@ -83,13 +83,13 @@ module cw.cohomology.ReconstructedCochainComplex {i : ULevel} (OT : OrdinaryTheo
         == ap (λ m≤n → ⊙cw-take m≤n (⊙cw-init ⊙skel)) (≤-has-all-paths (≤-trans lteS (inr Sm<n)) (inr m<n))
       path-lemma₀ ⊙skel m<n Sm<n =
         ap (λ m≤Sn → ⊙cw-take m≤Sn ⊙skel) (≤-has-all-paths (≤-trans lteS (lteSR (inr Sm<n))) (lteSR (inr m<n)))
-          =⟨ ap (ap (λ m≤Sn → ⊙cw-take m≤Sn ⊙skel)) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ m≤Sn → ⊙cw-take m≤Sn ⊙skel)) (contr-has-all-paths _ _) ⟩
         ap (λ m≤Sn → ⊙cw-take m≤Sn ⊙skel) (ap (lteSR ∘ inr) (<-has-all-paths (<-trans ltS Sm<n) m<n))
           =⟨ ∘-ap (λ m≤Sn → ⊙cw-take m≤Sn ⊙skel) (lteSR ∘ inr) _ ⟩
         ap (λ Sm<n → ⊙cw-take (lteSR (inr Sm<n)) ⊙skel) (<-has-all-paths (<-trans ltS Sm<n) m<n)
           =⟨ ap-∘ (λ m≤n → ⊙cw-take m≤n (⊙cw-init ⊙skel)) inr _ ⟩
         ap (λ m≤n → ⊙cw-take m≤n (⊙cw-init ⊙skel)) (ap inr (<-has-all-paths (<-trans ltS Sm<n) m<n))
-          =⟨ ap (ap (λ m≤n → ⊙cw-take m≤n (⊙cw-init ⊙skel))) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ m≤n → ⊙cw-take m≤n (⊙cw-init ⊙skel))) (contr-has-all-paths _ _) ⟩
         ap (λ m≤n → ⊙cw-take m≤n (⊙cw-init ⊙skel)) (≤-has-all-paths (≤-trans lteS (inr Sm<n)) (inr m<n))
           =∎
 
@@ -99,9 +99,9 @@ module cw.cohomology.ReconstructedCochainComplex {i : ULevel} (OT : OrdinaryTheo
         == ap (λ n≤Sn → ⊙cw-take n≤Sn (⊙cw-init ⊙skel)) (≤-has-all-paths lteS lteS)
       path-lemma₁ ⊙skel =
         ap (λ n≤SSn → ⊙cw-take n≤SSn ⊙skel) (≤-has-all-paths (lteSR lteS) (lteSR lteS))
-          =⟨ ap (ap (λ n≤SSn → ⊙cw-take n≤SSn ⊙skel)) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ n≤SSn → ⊙cw-take n≤SSn ⊙skel)) (contr-has-all-paths _ _) ⟩
         idp
-          =⟨ ap (ap (λ n≤Sn → ⊙cw-take n≤Sn (⊙cw-init ⊙skel))) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ n≤Sn → ⊙cw-take n≤Sn (⊙cw-init ⊙skel))) (contr-has-all-paths _ _) ⟩
         ap (λ n≤Sn → ⊙cw-take n≤Sn (⊙cw-init ⊙skel)) (≤-has-all-paths lteS lteS)
           =∎
 
@@ -110,7 +110,7 @@ module cw.cohomology.ReconstructedCochainComplex {i : ULevel} (OT : OrdinaryTheo
         → ap (λ n≤Sn → ⊙cw-take n≤Sn ⊙skel) (≤-has-all-paths lteS lteS) == idp
       path-lemma₂ ⊙skel =
         ap (λ n≤Sn → ⊙cw-take n≤Sn ⊙skel) (≤-has-all-paths lteS lteS)
-          =⟨ ap (ap (λ n≤Sn → ⊙cw-take n≤Sn ⊙skel)) (contr-has-all-paths (≤-is-prop _ _) _ _) ⟩
+          =⟨ ap (ap (λ n≤Sn → ⊙cw-take n≤Sn ⊙skel)) (contr-has-all-paths _ _) ⟩
         idp
           =∎
 

--- a/theorems/cw/cohomology/ReconstructedFirstCohomologyGroup.agda
+++ b/theorems/cw/cohomology/ReconstructedFirstCohomologyGroup.agda
@@ -21,7 +21,7 @@ module cw.cohomology.ReconstructedFirstCohomologyGroup {i : ULevel} (OT : Ordina
 
   private
     ≤-dec-has-all-paths : {m n : ℕ} → has-all-paths (Dec (m ≤ n))
-    ≤-dec-has-all-paths = prop-has-all-paths (Dec-level ≤-is-prop)
+    ≤-dec-has-all-paths = prop-has-all-paths
 
   private
     abstract

--- a/theorems/cw/cohomology/ReconstructedHigherCohomologyGroups.agda
+++ b/theorems/cw/cohomology/ReconstructedHigherCohomologyGroups.agda
@@ -19,7 +19,7 @@ module cw.cohomology.ReconstructedHigherCohomologyGroups {i : ULevel} (OT : Ordi
 
   private
     ≤-dec-has-all-paths : {m n : ℕ} → has-all-paths (Dec (m ≤ n))
-    ≤-dec-has-all-paths = prop-has-all-paths (Dec-level ≤-is-prop)
+    ≤-dec-has-all-paths = prop-has-all-paths
 
   private
     abstract

--- a/theorems/cw/cohomology/ReconstructedZerothCohomologyGroup.agda
+++ b/theorems/cw/cohomology/ReconstructedZerothCohomologyGroup.agda
@@ -18,7 +18,7 @@ module cw.cohomology.ReconstructedZerothCohomologyGroup {i : ULevel} (OT : Ordin
 
   private
     ≤-dec-has-all-paths : {m n : ℕ} → has-all-paths (Dec (m ≤ n))
-    ≤-dec-has-all-paths = prop-has-all-paths (Dec-level ≤-is-prop)
+    ≤-dec-has-all-paths = prop-has-all-paths
 
   private
     abstract

--- a/theorems/cw/examples/Unit.agda
+++ b/theorems/cw/examples/Unit.agda
@@ -6,7 +6,7 @@ open import cw.CW
 module cw.examples.Unit where
 
 cw-unit-skel : Skeleton {lzero} 0
-cw-unit-skel = Unit , Unit-is-set
+cw-unit-skel = Unit , ⟨⟩
 CWUnit = ⟦ cw-unit-skel ⟧
 
 CWUnit-equiv-Unit : CWUnit ≃ Unit

--- a/theorems/groups/CoefficientExtensionality.agda
+++ b/theorems/groups/CoefficientExtensionality.agda
@@ -68,7 +68,7 @@ module _ (dec : has-dec-eq A) where
         ∙ ℤ+-unit-l (Word-coef w a)
 
   FormalSum-coef : FormalSum A → (A → ℤ)
-  FormalSum-coef = FormalSum-rec (→-is-set ℤ-is-set) Word-coef (λ r → λ= $ FormalSum-coef-rel r)
+  FormalSum-coef = FormalSum-rec Word-coef (λ r → λ= $ FormalSum-coef-rel r)
 
   -- Theorem : if coef w a == 0 then FormalSumRel w nil
 
@@ -235,12 +235,10 @@ module _ (dec : has-dec-eq A) where
       → (∀ a → FormalSum-coef fs₁ a == FormalSum-coef fs₂ a)
       → fs₁ == fs₂
     FormalSum-coef-ext = FormalSum-elim
-      (λ fs₁ → Π-is-set λ fs₂ → →-is-set $ =-preserves-set FormalSum-is-set)
       (λ w₁ → FormalSum-elim
-        (λ fs₂ → →-is-set $ =-preserves-set FormalSum-is-set)
         (λ w₂ → FormalSum-coef-ext' w₁ w₂)
-        (λ _ → prop-has-all-paths-↓ (→-is-prop $ FormalSum-is-set _ _)))
-      (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → →-is-prop $ FormalSum-is-set _ _))
+        (λ _ → prop-has-all-paths-↓))
+      (λ _ → prop-has-all-paths-↓)
 
   has-finite-support : (A → ℤ) → Type i
   has-finite-support f = Σ (FormalSum A) λ fs → ∀ a → f a == FormalSum-coef fs a
@@ -252,4 +250,4 @@ module _ {dec : has-dec-eq A} where
     has-finite-support-is-prop f = all-paths-is-prop
       λ{(fs₁ , match₁) (fs₂ , match₂) → pair=
         (FormalSum-coef-ext dec fs₁ fs₂ λ a → ! (match₁ a) ∙ match₂ a)
-        (prop-has-all-paths-↓ $ Π-is-prop λ _ → ℤ-is-set _ _)}
+        prop-has-all-paths-↓}

--- a/theorems/groups/Cokernel.agda
+++ b/theorems/groups/Cokernel.agda
@@ -30,34 +30,31 @@ module groups.Cokernel {i j}
       ident = q[ H.ident ]
 
       inv : coker-El → coker-El
-      inv = SetQuot-rec SetQuot-level inv' inv-rel
+      inv = SetQuot-rec inv' inv-rel
         where
           inv' : H.El → coker-El
           inv' h = q[ H.inv h ]
 
           abstract
             inv-rel : ∀ {h₁ h₂} → coker-rel h₁ h₂ → inv' h₁ == inv' h₂
-            inv-rel {h₁} {h₂} = Trunc-rec (SetQuot-level _ _)
+            inv-rel {h₁} {h₂} = Trunc-rec
               λ{(g , φg=h₁h₂⁻¹) → quot-rel
                 [ G.inv g , φ.pres-inv g ∙ ap H.inv φg=h₁h₂⁻¹
                           ∙ H.inv-diff h₁ h₂ ∙ H.comm h₂ (H.inv h₁)
                           ∙ ap (H.comp (H.inv h₁)) (! (H.inv-inv h₂)) ]}
 
       comp : coker-El → coker-El → coker-El
-      comp = SetQuot-rec level comp' comp-rel where
-        abstract
-          level : is-set (coker-El → coker-El)
-          level = →-is-set SetQuot-level
+      comp = SetQuot-rec comp' comp-rel where
 
         comp' : H.El → coker-El → coker-El
-        comp' h₁ = SetQuot-rec SetQuot-level comp'' comp'-rel where
+        comp' h₁ = SetQuot-rec comp'' comp'-rel where
 
           comp'' : H.El → coker-El
           comp'' h₂ = q[ H.comp h₁ h₂ ]
 
           abstract
             comp'-rel : ∀ {h₂ h₂'} → coker-rel h₂ h₂' → comp'' h₂ == comp'' h₂'
-            comp'-rel {h₂} {h₂'} = Trunc-rec (SetQuot-level _ _)
+            comp'-rel {h₂} {h₂'} = Trunc-rec
               λ{(g , φg=h₂h₂'⁻¹) → quot-rel
                 [ g , ! ( ap (H.comp (H.comp h₁ h₂)) (H.inv-comp h₁ h₂')
                         ∙ H.assoc h₁ h₂ (H.comp (H.inv h₂') (H.inv h₁))
@@ -69,8 +66,8 @@ module groups.Cokernel {i j}
 
         abstract
           comp-rel : ∀ {h₁ h₁'} → coker-rel h₁ h₁' → comp' h₁ == comp' h₁'
-          comp-rel {h₁} {h₁'} = Trunc-rec (level _ _)
-            λ{(g , φg=h₁h₁'⁻¹) → λ= $ SetQuot-elim (λ _ → =-preserves-set SetQuot-level)
+          comp-rel {h₁} {h₁'} = Trunc-rec
+            λ{(g , φg=h₁h₁'⁻¹) → λ= $ SetQuot-elim
               (λ h₂ → quot-rel
                   [ g , ! ( ap (H.comp (H.comp h₁ h₂)) (H.inv-comp h₁' h₂)
                           ∙ H.assoc h₁ h₂ (H.comp (H.inv h₂) (H.inv h₁'))
@@ -78,35 +75,30 @@ module groups.Cokernel {i j}
                                           ∙ ap (λ h → H.comp h (H.inv h₁')) (H.inv-r h₂)
                                           ∙ H.unit-l (H.inv h₁'))
                           ∙ ! φg=h₁h₁'⁻¹ )])
-              (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))}
+              (λ _ → prop-has-all-paths-↓)}
 
       abstract
         unit-l : ∀ cok → comp ident cok == cok
         unit-l = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (λ h → ap q[_] $ H.unit-l h)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓)
 
         assoc : ∀ cok₁ cok₂ cok₃ → comp (comp cok₁ cok₂) cok₃ == comp cok₁ (comp cok₂ cok₃)
         assoc = SetQuot-elim
-          (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
           (λ h₁ → SetQuot-elim
-            (λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
             (λ h₂ → SetQuot-elim
-              (λ _ → =-preserves-set SetQuot-level)
               (λ h₃ → ap q[_] $ H.assoc h₁ h₂ h₃)
-              (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _)))
-            (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → SetQuot-level _ _)))
-          (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → Π-is-prop λ _ → SetQuot-level _ _))
+              (λ _ → prop-has-all-paths-↓))
+            (λ _ → prop-has-all-paths-↓))
+          (λ _ → prop-has-all-paths-↓)
 
         inv-l : ∀ cok → comp (inv cok) cok == ident
         inv-l = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (λ h → ap q[_] $ H.inv-l h)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓)
 
   Coker : Group (lmax i j)
-  Coker = group _ SetQuot-level coker-struct
+  Coker = group _ coker-struct
 
   module Coker = Group Coker
 
@@ -118,9 +110,7 @@ module groups.Cokernel {i j}
       to-pres-comp : preserves-comp Coker.comp
         (QuotGroup.comp (im-npropᴳ φ H-ab)) (idf _)
       to-pres-comp = SetQuot-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
         (λ _ → SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (λ _ → idp)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _)))
-        (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓)

--- a/theorems/groups/Exactness.agda
+++ b/theorems/groups/Exactness.agda
@@ -24,7 +24,7 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
     φ-const-implies-ψ-is-inj : (∀ g →  φ.f g == H.ident) → is-injᴳ ψ
     φ-const-implies-ψ-is-inj φ-is-const =
       has-trivial-ker-is-injᴳ ψ λ h ψh=0 →
-        Trunc-rec (H.El-is-set _ _)
+        Trunc-rec
           (λ{(g , φg=h) → ! φg=h ∙ φ-is-const g})
           (E.ker-sub-im h ψh=0)
 
@@ -44,7 +44,7 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
 
         module From (k : Ker.El ψ)
           = ConstExt {A = hfiber φ.f (fst k)} {B = G.El}
-              G.El-is-set (λ hf → fst hf)
+              (λ hf → fst hf)
               (λ hf₁ hf₂ → φ-is-inj _ _ (snd hf₁ ∙ ! (snd hf₂)))
 
         from : Ker.El ψ → G.El
@@ -54,7 +54,6 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
         to-from k = Ker.El=-out ψ $
           Trunc-elim
             {P = λ hf → φ.f (From.ext k hf) == fst k}
-            (λ _ → H.El-is-set _ _)
             (λ{(g , p) → p})
             (uncurry E.ker-sub-im k)
 
@@ -79,16 +78,14 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
           ! (ψ.pres-diff h₁ h₂) ∙ E.im-sub-ker (H.diff h₁ h₂) h₁h₂⁻¹-in-im
 
       f : Cok.El → K.El
-      f = SetQuot-rec K.El-is-set ψ.f f-rel
+      f = SetQuot-rec ψ.f f-rel
       abstract
         pres-comp : ∀ h₁ h₂ → f (Cok.comp h₁ h₂) == K.comp (f h₁) (f h₂)
         pres-comp = SetQuot-elim
-          (λ _ → Π-is-set λ _ → =-preserves-set K.El-is-set)
           (λ h₁ → SetQuot-elim
-            (λ _ → =-preserves-set K.El-is-set)
             (λ h₂ → ψ.pres-comp h₁ h₂)
-            (λ _ → prop-has-all-paths-↓ (K.El-is-set _ _)))
-          (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → K.El-is-set _ _))
+            (λ _ → prop-has-all-paths-↓))
+          (λ _ → prop-has-all-paths-↓)
 
   abstract
     ψ-surj-implies-coker-to-K-is-equiv : (H-is-abelian : is-abelian H)
@@ -103,7 +100,7 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
 
         module From (k : K.El)
           = ConstExt {A = hfiber ψ.f k} {B = Cok.El}
-              Cok.El-is-set (λ hf → q[ fst hf ])
+              (λ hf → q[ fst hf ])
               (λ{(h₁ , p₁) (h₂ , p₂) → quot-rel $
                 E.ker-sub-im (H.diff h₁ h₂) $
                   ψ.pres-diff h₁ h₂ ∙ ap2 K.diff p₁ p₂ ∙ K.inv-r k})
@@ -114,15 +111,13 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
         to-from : ∀ k → to (from k) == k
         to-from k = Trunc-elim
           {P = λ hf → to (From.ext k hf) == k}
-          (λ _ → K.El-is-set _ _)
           (λ{(h , p) → p})
           (ψ-is-surj k)
 
         from-to : ∀ c → from (to c) == c
         from-to = SetQuot-elim
-          (λ _ → =-preserves-set Cok.El-is-set)
           (λ h → From.ext-is-const (ψ.f h) (ψ-is-surj (ψ.f h)) [ h , idp ])
-          (λ _ → prop-has-all-paths-↓ (Cok.El-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
   ψ-surj-implies-coker-iso-K : (H-is-abelian : is-abelian H)
     → is-surjᴳ ψ → Coker φ H-is-abelian ≃ᴳ K
@@ -177,7 +172,7 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
           h =∎
 
         ker-part-imχ : (im : Im.El χ) → GroupHom.f ker-part (fst im) == Ker.ident ψ
-        ker-part-imχ (h , s) = Trunc-rec (Ker.El-level ψ _ _)
+        ker-part-imχ (h , s) = Trunc-rec
           (λ {(k , p) → Ker.El=-out ψ $
             H.comp h (H.inv (χ.f (ψ.f h)))
               =⟨ ! p |in-ctx (λ w → H.comp w (H.inv (χ.f (ψ.f w)))) ⟩
@@ -197,7 +192,7 @@ module Exact {i j k} {G : Group i} {H : Group j} {K : Group k}
         im-part-kerψ (h , p) = Im.El=-out χ (ap χ.f p ∙ χ.pres-ident)
 
         im-part-imχ : (im : Im.El χ) → GroupHom.f im-part (fst im) == im
-        im-part-imχ (h , s) = Trunc-rec (Im.El-level χ _ _)
+        im-part-imχ (h , s) = Trunc-rec {{has-level-apply (Im.El-level χ) _ _}}
             (λ {(k , p) → Im.El=-out χ $
               χ.f (ψ.f h)        =⟨ ! p |in-ctx (χ.f ∘ ψ.f) ⟩
               χ.f (ψ.f (χ.f k))  =⟨ χ-inv-r k |in-ctx χ.f ⟩
@@ -330,7 +325,7 @@ abstract
   equiv-preserves-exact {K₀ = K₀} {K₁} {φ₀ = φ₀} {ψ₀} {φ₁} {ψ₁} {ξG} {ξH} {ξK}
     (comm-sqrᴳ φ□) (comm-sqrᴳ ψ□) ξG-is-equiv ξH-is-equiv ξK-is-equiv exact₀
     = record {
-      im-sub-ker = λ h₁ → Trunc-rec (SubgroupProp.level (ker-propᴳ ψ₁) h₁)
+      im-sub-ker = λ h₁ → Trunc-rec
         (λ{(g₁ , φ₁g₁=h₁) →
           ψ₁.f h₁
             =⟨ ap ψ₁.f $ ! $ ξH.f-g h₁ ⟩
@@ -349,7 +344,7 @@ abstract
           Group.ident K₁
             =∎});
       ker-sub-im = λ h₁ ψ₁h₁=0 →
-        Trunc-rec (SubgroupProp.level (im-propᴳ φ₁) h₁)
+        Trunc-rec
           (λ{(g₀ , φ₀g₀=ξH⁻¹h₁) → [ ξG.f g₀ ,_ $
             φ₁.f (ξG.f g₀)
               =⟨ ! $ φ□ g₀ ⟩

--- a/theorems/groups/Image.agda
+++ b/theorems/groups/Image.agda
@@ -9,13 +9,13 @@ module _ {i j k} {G : Group i} {H : Group j}
 
   abstract
     im-sub-im-∘ : is-surjᴳ ψ → im-propᴳ φ ⊆ᴳ im-propᴳ (φ ∘ᴳ ψ)
-    im-sub-im-∘ ψ-is-surj k = Trunc-rec Trunc-level
-      (λ{(h , φh=k) → Trunc-rec Trunc-level
+    im-sub-im-∘ ψ-is-surj k = Trunc-rec
+      (λ{(h , φh=k) → Trunc-rec
         (λ{(g , ψg=h) → [ g , ap (GroupHom.f φ) ψg=h ∙ φh=k ]})
         (ψ-is-surj h)})
 
     im-∘-sub-im : im-propᴳ (φ ∘ᴳ ψ) ⊆ᴳ im-propᴳ φ
-    im-∘-sub-im k = Trunc-rec Trunc-level
+    im-∘-sub-im k = Trunc-rec
       (λ{(g , φψg=k) → [ GroupHom.f ψ g , φψg=k ]})
 
   im-iso-im-pre∘ : is-surjᴳ ψ → Im φ ≃ᴳ Im (φ ∘ᴳ ψ)

--- a/theorems/groups/KernelCstImage.agda
+++ b/theorems/groups/KernelCstImage.agda
@@ -12,31 +12,29 @@ module groups.KernelCstImage {i j k}
   Ker-cst-quot-Im : Ker/Im ≃ᴳ Coker
   Ker-cst-quot-Im = ≃-to-≃ᴳ (equiv to from to-from from-to) to-pres-comp where
     to : Ker/Im.El → Coker.El
-    to = SetQuot-rec SetQuot-level to' quot-rel where
+    to = SetQuot-rec to' quot-rel where
       to' : Ker.El (cst-hom {G = H} {H = K}) → Coker.El
       to' ker = q[ fst ker ]
 
     from : Coker.El → Ker/Im.El
-    from = SetQuot-rec SetQuot-level from' quot-rel where
+    from = SetQuot-rec from' quot-rel where
       from' : Group.El H → Ker/Im.El
       from' h = q[ h , idp ]
 
     abstract
       to-from : ∀ cok → to (from cok) == cok
-      to-from = SetQuot-elim (λ _ → =-preserves-set SetQuot-level)
+      to-from = SetQuot-elim
         (λ _ → idp)
-        (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+        (λ _ → prop-has-all-paths-↓)
 
       from-to : ∀ ker → from (to ker) == ker
-      from-to = SetQuot-elim (λ _ → =-preserves-set SetQuot-level)
+      from-to = SetQuot-elim
         (λ _ → ap q[_] $ ker-El=-out idp)
-        (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+        (λ _ → prop-has-all-paths-↓)
 
       to-pres-comp : preserves-comp Ker/Im.comp Coker.comp to
       to-pres-comp = SetQuot-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
         (λ _ → SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (λ _ → idp)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _)))
-        (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓)

--- a/theorems/groups/KernelCstImageCst.agda
+++ b/theorems/groups/KernelCstImageCst.agda
@@ -14,13 +14,13 @@ module groups.KernelCstImageCst {i j k}
   Ker-cst-quot-Im-cst : Ker/Im ≃ᴳ H
   Ker-cst-quot-Im-cst = ≃-to-≃ᴳ (equiv to from to-from from-to) to-pres-comp where
     to : Ker/Im.El → H.El
-    to = SetQuot-rec H.El-level to' to-rel where
+    to = SetQuot-rec to' to-rel where
       to' : Ker.El (cst-hom {G = H} {H = K}) → H.El
       to' ker = fst ker
 
       abstract
         to-rel : ∀ {h₁ h₂} → ker/im-rel' h₁ h₂ → h₁ == h₂
-        to-rel {h₁} {h₂} = Trunc-rec (H.El-level _ _)
+        to-rel {h₁} {h₂} = Trunc-rec
           λ{(_ , 0=h₁h₂⁻¹) → H.zero-diff-same h₁ h₂ (! 0=h₁h₂⁻¹)}
 
     from : H.El → Ker/Im.El
@@ -31,15 +31,13 @@ module groups.KernelCstImageCst {i j k}
       to-from h = idp
 
       from-to : ∀ k/i → from (to k/i) == k/i
-      from-to = SetQuot-elim (λ _ → =-preserves-set SetQuot-level)
+      from-to = SetQuot-elim
         (λ _ → ap q[_] $ ker-El=-out idp)
-        (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+        (λ _ → prop-has-all-paths-↓)
 
       to-pres-comp : preserves-comp Ker/Im.comp H.comp to
       to-pres-comp = SetQuot-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set H.El-level)
         (λ _ → SetQuot-elim
-          (λ _ → =-preserves-set H.El-level)
           (λ _ → idp)
-          (λ _ → prop-has-all-paths-↓ (H.El-level _ _)))
-        (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → H.El-level _ _))
+          (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓)

--- a/theorems/groups/KernelImage.agda
+++ b/theorems/groups/KernelImage.agda
@@ -22,9 +22,7 @@ module groups.KernelImage {i j k}
     ker-El = Σ H.El (λ h → ψ.f h == K.ident)
 
     ker-subtype : SubtypeProp H.El k
-    ker-subtype = (λ h → ψ.f h == K.ident) , level
-      where abstract level : ∀ h → is-prop (ψ.f h == K.ident)
-                     level h = K.El-is-set _ _
+    ker-subtype = (λ h → ψ.f h == K.ident) , ⟨⟩
 
   ker-El=-out = Subtype=-out ker-subtype
 
@@ -46,7 +44,7 @@ module groups.KernelImage {i j k}
         where abstract lemma = ψ.pres-ident
 
       inv : ker/im-El → ker/im-El
-      inv = SetQuot-rec SetQuot-level inv' inv-rel
+      inv = SetQuot-rec inv' inv-rel
         where
           inv' : ker-El → ker/im-El
           inv' (h , ψh=0) = q[ H.inv h , lemma ]
@@ -54,20 +52,17 @@ module groups.KernelImage {i j k}
 
           abstract
             inv-rel : ∀ {ker₁ ker₂} → ker/im-rel ker₁ ker₂ → inv' ker₁ == inv' ker₂
-            inv-rel {h₁ , _} {h₂ , _} = Trunc-rec (SetQuot-level _ _)
+            inv-rel {h₁ , _} {h₂ , _} = Trunc-rec
               λ{(g , φg=h₁h₂⁻¹) → quot-rel
                 [ G.inv g , φ.pres-inv g ∙ ap H.inv φg=h₁h₂⁻¹
                           ∙ H.inv-diff h₁ h₂ ∙ H.comm h₂ (H.inv h₁)
                           ∙ ap (H.comp (H.inv h₁)) (! (H.inv-inv h₂)) ]}
 
       comp : ker/im-El → ker/im-El → ker/im-El
-      comp = SetQuot-rec level comp' comp-rel where
-        abstract
-          level : is-set (ker/im-El → ker/im-El)
-          level = →-is-set SetQuot-level
+      comp = SetQuot-rec comp' comp-rel where
 
         comp' : ker-El → ker/im-El → ker/im-El
-        comp' (h₁ , ψh₁=0) = SetQuot-rec SetQuot-level comp'' comp'-rel where
+        comp' (h₁ , ψh₁=0) = SetQuot-rec comp'' comp'-rel where
 
           comp'' : ker-El → ker/im-El
           comp'' (h₂ , ψh₂=0) = q[ H.comp h₁ h₂ , lemma ]
@@ -76,7 +71,7 @@ module groups.KernelImage {i j k}
 
           abstract
             comp'-rel : ∀ {ker₂ ker₂'} → ker/im-rel ker₂ ker₂' → comp'' ker₂ == comp'' ker₂'
-            comp'-rel {h₂ , _} {h₂' , _} = Trunc-rec (SetQuot-level _ _)
+            comp'-rel {h₂ , _} {h₂' , _} = Trunc-rec
               λ{(g , φg=h₂h₂'⁻¹) → quot-rel
                 [ g , ! ( ap (H.comp (H.comp h₁ h₂)) (H.inv-comp h₁ h₂')
                         ∙ H.assoc h₁ h₂ (H.comp (H.inv h₂') (H.inv h₁))
@@ -88,8 +83,8 @@ module groups.KernelImage {i j k}
 
         abstract
           comp-rel : ∀ {ker₁ ker₁'} → ker/im-rel ker₁ ker₁' → comp' ker₁ == comp' ker₁'
-          comp-rel {h₁ , _} {h₁' , _} = Trunc-rec (level _ _)
-            λ{(g , φg=h₁h₁'⁻¹) → λ= $ SetQuot-elim (λ _ → =-preserves-set SetQuot-level)
+          comp-rel {h₁ , _} {h₁' , _} = Trunc-rec
+            λ{(g , φg=h₁h₁'⁻¹) → λ= $ SetQuot-elim
               (λ{(h₂ , _) → quot-rel
                   [ g , ! ( ap (H.comp (H.comp h₁ h₂)) (H.inv-comp h₁' h₂)
                           ∙ H.assoc h₁ h₂ (H.comp (H.inv h₂) (H.inv h₁'))
@@ -97,35 +92,30 @@ module groups.KernelImage {i j k}
                                           ∙ ap (λ h → H.comp h (H.inv h₁')) (H.inv-r h₂)
                                           ∙ H.unit-l (H.inv h₁'))
                           ∙ ! φg=h₁h₁'⁻¹ )]})
-              (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))}
+              (λ _ → prop-has-all-paths-↓)}
 
       abstract
         unit-l : ∀ k/i → comp ident k/i == k/i
         unit-l = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (λ{(h , _) → ap q[_] $ ker-El=-out (H.unit-l h)})
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓)
 
         assoc : ∀ k/i₁ k/i₂ k/i₃ → comp (comp k/i₁ k/i₂) k/i₃ == comp k/i₁ (comp k/i₂ k/i₃)
         assoc = SetQuot-elim
-          (λ _ → Π-is-set λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
           (λ{(h₁ , _) → SetQuot-elim
-            (λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
             (λ{(h₂ , _) → SetQuot-elim
-              (λ _ → =-preserves-set SetQuot-level)
               (λ{(h₃ , _) → ap q[_] $ ker-El=-out (H.assoc h₁ h₂ h₃)})
-              (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))})
-            (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → SetQuot-level _ _))})
-          (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → Π-is-prop λ _ → SetQuot-level _ _))
+              (λ _ → prop-has-all-paths-↓)})
+            (λ _ → prop-has-all-paths-↓)})
+          (λ _ → prop-has-all-paths-↓)
 
         inv-l : ∀ k/i → comp (inv k/i) k/i == ident
         inv-l = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (λ{(h , _) → ap q[_] $ ker-El=-out (H.inv-l h)})
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓)
 
   Ker/Im : Group (lmax i (lmax j k))
-  Ker/Im = group _ SetQuot-level ker/im-struct
+  Ker/Im = group _ ker/im-struct
 
   module Ker/Im = Group Ker/Im
 
@@ -137,9 +127,7 @@ module groups.KernelImage {i j k}
       to-pres-comp : preserves-comp Ker/Im.comp
         (QuotGroup.comp (quot-of-sub (ker-propᴳ ψ) (im-npropᴳ φ H-ab))) (idf _)
       to-pres-comp = SetQuot-elim
-        (λ _ → Π-is-set λ _ → =-preserves-set SetQuot-level)
         (λ _ → SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-level)
           (λ _ → ap q[_] $ ker-El=-out idp)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-level _ _)))
-        (λ _ → prop-has-all-paths-↓ (Π-is-prop λ _ → SetQuot-level _ _))
+          (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓)

--- a/theorems/groups/KernelSndImageInl.agda
+++ b/theorems/groups/KernelSndImageInl.agda
@@ -38,21 +38,20 @@ module groups.KernelSndImageInl {i j k}
       from' ((g , h) , h-in-ker) = h , ! (φ-snd-β (g , h)) ∙ h-in-ker
 
       from-rel : ∀ {gh₁ gh₂} → ker/im-rel gh₁ gh₂ → from' gh₁ == from' gh₂
-      from-rel {gh₁} {gh₂} = Trunc-rec (Ker.El-is-set φ _ _)
+      from-rel {gh₁} {gh₂} = Trunc-rec
         (λ{(g , inl-g=h₁h₂⁻¹) → Ker.El=-out φ
           (H.zero-diff-same (snd (fst gh₁)) (snd (fst gh₂)) (! (snd×= inl-g=h₁h₂⁻¹)))})
 
     from : Ker/Im.El → Ker.El φ
-    from = SetQuot-rec (Ker.El-is-set φ) from' from-rel
+    from = SetQuot-rec from' from-rel
 
     abstract
       to-from : ∀ g → to (from g) == g
       to-from = SetQuot-elim
         {P = λ g → to (from g) == g}
-        (λ _ → =-preserves-set Ker/Im.El-is-set)
         (λ{((g , h) , h-in-ker) → quot-rel
           [ G.inv g , ap2 _,_ (! (G.unit-l (G.inv g))) (! (H.inv-r h)) ]})
-        (λ _ → prop-has-all-paths-↓ (Ker/Im.El-is-set _ _))
+        (λ _ → prop-has-all-paths-↓)
 
       from-to : ∀ g → from (to g) == g
       from-to _ = Ker.El=-out φ idp

--- a/theorems/groups/ProductRepr.agda
+++ b/theorems/groups/ProductRepr.agda
@@ -32,7 +32,7 @@ module groups.ProductRepr {i j}
     module j₂ = GroupHom j₂
 
   fanout-has-trivial-ker : has-trivial-kerᴳ (×ᴳ-fanout j₁ j₂)
-  fanout-has-trivial-ker g q = Trunc-rec (G.El-level _ _)
+  fanout-has-trivial-ker g q = Trunc-rec
       (lemma g (fst×= q))
       (ker-sub-im ex₁ g (snd×= q))
     where

--- a/theorems/groups/PropQuotUniqueFactorization.agda
+++ b/theorems/groups/PropQuotUniqueFactorization.agda
@@ -49,7 +49,7 @@ module groups.PropQuotUniqueFactorization
           quot-relᴳ {P = P/Q-prop} $ <– (quot-relᴳ-equiv {P = Q}) $
             ! (φ-comm h₁) ∙ ap φ₂.f (r₁ ∙ ! r₂) ∙ φ-comm h₂
 
-      module HToP/Q = ConstExt P/Q.El-is-set
+      module HToP/Q = ConstExt
         H-to-P/Q-f' H-to-P/Q-f'-const
 
       H-to-P/Q-f : Trunc -1 (hfiber φ₁.f k) → P/Q.El
@@ -65,10 +65,7 @@ module groups.PropQuotUniqueFactorization
         → (hf₂ : Trunc -1 (hfiber φ₁.f k₂))
         → H-to-P/Q-f (H.comp k₁ k₂) hf₁₂ == P/Q.comp (H-to-P/Q-f k₁ hf₁) (H-to-P/Q-f k₂ hf₂)
       H-to-P/Q-f-comp k₁ k₂ hf₁₂ = Trunc-elim
-        (λ hf₁ → Π-is-prop λ hf₂ →
-          P/Q.El-is-set _ (P/Q.comp (H-to-P/Q-f k₁ hf₁) (H-to-P/Q-f k₂ hf₂)))
         (λ{(p₁ , r₁) → Trunc-elim
-          (λ hf₂ → P/Q.El-is-set _ (P/Q.comp q[ p₁ ] (H-to-P/Q-f k₂ hf₂)))
           (λ{(p₂ , r₂) → H-to-P/Q-f-is-const (H.comp k₁ k₂)
               hf₁₂ [ P.comp p₁ p₂ , φ₁.pres-comp p₁ p₂ ∙ ap2 H.comp r₁ r₂ ]})})
 
@@ -84,19 +81,19 @@ module groups.PropQuotUniqueFactorization
     to = λ k → H-to-P/Q-f k (φ₁-is-surj k)
 
     from : P/Q.El → H.El
-    from = SetQuot-rec H.El-is-set
+    from = SetQuot-rec
       (λ p → φ₁.f p)
       (λ {p₁} {p₂} q'p₁p₂⁻¹ → φ₂-is-inj (φ₁.f p₁) (φ₁.f p₂) $
         φ-comm p₁ ∙ quot-relᴳ {P = Q} q'p₁p₂⁻¹ ∙ ! (φ-comm p₂))
 
     abstract
       to-from : ∀ p/q → to (from p/q) == p/q
-      to-from = SetQuot-elim (λ p/q → raise-level -1 $ P/Q.El-is-set _ p/q)
+      to-from = SetQuot-elim
         (λ p → H-to-P/Q-f-is-const (φ₁.f p) (φ₁-is-surj (φ₁.f p)) [ p , idp ])
-        (λ _ → prop-has-all-paths-↓ $ P/Q.El-is-set _ _)
+        (λ _ → prop-has-all-paths-↓)
 
       from-to' : ∀ k (hf : Trunc -1 (hfiber φ₁.f k)) → from (H-to-P/Q-f k hf) == k
-      from-to' k = Trunc-elim (λ hf → H.El-is-set (from (H-to-P/Q-f k hf)) k) (λ{(p , r) → r})
+      from-to' k = Trunc-elim (λ{(p , r) → r})
 
       from-to : ∀ k → from (to k) == k
       from-to k = from-to' k (φ₁-is-surj k)

--- a/theorems/groups/ReducedWord.agda
+++ b/theorems/groups/ReducedWord.agda
@@ -37,15 +37,16 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
   Word-has-dec-eq (x :: v) (y :: w) | inl x=y | inr v≠w = inr $ v≠w ∘ snd ∘ List=-in
   Word-has-dec-eq (x :: v) (y :: w) | inr x≠y = inr $ x≠y ∘ fst ∘ List=-in
 
-  Word-is-set : is-set (Word A)
-  Word-is-set = dec-eq-is-set Word-has-dec-eq
+  instance
+    Word-is-set : is-set (Word A)
+    Word-is-set = dec-eq-is-set Word-has-dec-eq
 
   is-reduced-is-prop : {w : Word A} → is-prop (is-reduced w)
-  is-reduced-is-prop {nil}                 = Lift-level Unit-is-prop
-  is-reduced-is-prop {x    :: nil}         = Lift-level Unit-is-prop
+  is-reduced-is-prop {nil}                 = ⟨⟩
+  is-reduced-is-prop {x    :: nil}         = ⟨⟩
   is-reduced-is-prop {inl x :: inl y :: l} = is-reduced-is-prop {inl y :: l}
-  is-reduced-is-prop {inl x :: inr y :: l} = ×-level (→-is-prop (λ x₁ → λ ())) (is-reduced-is-prop {inr y :: l})
-  is-reduced-is-prop {inr x :: inl y :: l} = ×-level (→-is-prop (λ x₁ → λ ())) (is-reduced-is-prop {inl y :: l})
+  is-reduced-is-prop {inl x :: inr y :: l} = ⟨⟩ where instance _ = is-reduced-is-prop {inr y :: l}
+  is-reduced-is-prop {inr x :: inl y :: l} = ⟨⟩ where instance _ = is-reduced-is-prop {inl y :: l}
   is-reduced-is-prop {inr x :: inr y :: l} = is-reduced-is-prop {inr y :: l}
 
   is-reduced-prop : SubtypeProp (Word A) i
@@ -56,8 +57,9 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
   ReducedWord : Type i
   ReducedWord = Subtype is-reduced-prop
 
-  ReducedWord-is-set : is-set ReducedWord
-  ReducedWord-is-set = Subtype-level is-reduced-prop Word-is-set
+  instance
+    ReducedWord-is-set : is-set ReducedWord
+    ReducedWord-is-set = Subtype-level is-reduced-prop where instance _ = is-reduced-is-prop
 
   -- Identifications in [ReducedWord].
 
@@ -258,7 +260,7 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
     }
 
   ReducedWord-group : Group i
-  ReducedWord-group = group _ ReducedWord-is-set ReducedWord-group-struct
+  ReducedWord-group = group _ ReducedWord-group-struct
 
   private
     abstract
@@ -298,7 +300,7 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
     to = GroupHom.f ReducedWord-to-FreeGroup
 
     from : QuotWord A → ReducedWord
-    from = QuotWord-rec ReducedWord-is-set reduce reduce-emap
+    from = QuotWord-rec reduce reduce-emap
 
     abstract
       QuotWordRel-reduce : ∀ w
@@ -309,9 +311,9 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
         uncurry (QuotWordRel-cons x) (reduce w)
 
       to-from : ∀ qw → to (from qw) == qw
-      to-from = QuotWord-elim (λ _ → =-preserves-set QuotWord-is-set)
+      to-from = QuotWord-elim
         (λ w → ! $ quot-rel $ QuotWordRel-reduce w)
-        (λ _ → prop-has-all-paths-↓ (QuotWord-is-set _ _))
+        (λ _ → prop-has-all-paths-↓)
 
       from-to : ∀ rw → from (to rw) == rw
       from-to = Group.unit-r ReducedWord-group

--- a/theorems/homotopy/AnyUniversalCoverIsPathSet.agda
+++ b/theorems/homotopy/AnyUniversalCoverIsPathSet.agda
@@ -8,7 +8,7 @@ private
   a₁ = pt X
 
 path-set-is-universal : is-universal (path-set-cover X)
-path-set-is-universal = has-level-make ([ pt X , idp₀ ] ,
+path-set-is-universal = has-level-in ([ pt X , idp₀ ] ,
   Trunc-elim
     {P = λ xp₀ → [ pt X , idp₀ ] == xp₀}
     (λ{(x , p₀) → Trunc-elim

--- a/theorems/homotopy/AnyUniversalCoverIsPathSet.agda
+++ b/theorems/homotopy/AnyUniversalCoverIsPathSet.agda
@@ -8,15 +8,13 @@ private
   a₁ = pt X
 
 path-set-is-universal : is-universal (path-set-cover X)
-path-set-is-universal = [ pt X , idp₀ ] ,
+path-set-is-universal = has-level-make ([ pt X , idp₀ ] ,
   Trunc-elim
     {P = λ xp₀ → [ pt X , idp₀ ] == xp₀}
-    (λ xp₀ → =-preserves-level Trunc-level)
     (λ{(x , p₀) → Trunc-elim
       {P = λ p₀ → [ pt X , idp₀ ] == [ x , p₀ ]}
-      (λ p₀ → Trunc-level {n = 1} [ pt X , idp₀ ] [ x , p₀ ])
       (λ p → ap [_] $ pair= p (lemma p))
-      p₀ })
+      p₀ }))
   where
     lemma : ∀ {x} (p : pt X == x) → idp₀ == [ p ] [ (pt X =₀_) ↓ p ]
     lemma idp = idp
@@ -24,13 +22,14 @@ path-set-is-universal = [ pt X , idp₀ ] ,
 module _ {j} (univ-cov : ⊙UniversalCover X j) where
   private
     module univ-cov = ⊙UniversalCover univ-cov
+    instance _ = univ-cov.is-univ
 
     -- One-to-one mapping between the universal cover
     -- and the truncated path spaces from one point.
 
     [path] : ∀ (a⇑₁ a⇑₂ : univ-cov.TotalSpace) → a⇑₁ =₀ a⇑₂
     [path] a⇑₁ a⇑₂ = –> (Trunc=-equiv [ a⇑₁ ] [ a⇑₂ ])
-      (contr-has-all-paths univ-cov.is-univ [ a⇑₁ ] [ a⇑₂ ])
+      (contr-has-all-paths [ a⇑₁ ] [ a⇑₂ ])
 
     abstract
       [path]-has-all-paths :
@@ -38,7 +37,7 @@ module _ {j} (univ-cov : ⊙UniversalCover X j) where
         → has-all-paths (a⇑₁ =₀ a⇑₂)
       [path]-has-all-paths {a⇑₁} {a⇑₂} =
         transport has-all-paths (ua (Trunc=-equiv [ a⇑₁ ] [ a⇑₂ ])) $
-          contr-has-all-paths (raise-level -2 univ-cov.is-univ [ a⇑₁ ] [ a⇑₂ ])
+          contr-has-all-paths {{has-level-apply (raise-level -2 univ-cov.is-univ) [ a⇑₁ ] [ a⇑₂ ]}}
 
     to : ∀ {a₂} → univ-cov.Fiber a₂ → a₁ =₀ a₂
     to {a₂} a⇑₂ = ap₀ fst ([path] (a₁ , univ-cov.pt) (a₂ , a⇑₂))
@@ -49,7 +48,6 @@ module _ {j} (univ-cov : ⊙UniversalCover X j) where
     abstract
       to-from : ∀ {a₂} (p : a₁ =₀ a₂) → to (from p) == p
       to-from = Trunc-elim
-        (λ _ → =-preserves-set Trunc-level)
         (λ p → lemma p)
         where
           lemma : ∀ {a₂} (p : a₁ == a₂) → to (from [ p ]) == [ p ]
@@ -64,10 +62,10 @@ module _ {j} (univ-cov : ⊙UniversalCover X j) where
 
       from-to : ∀ {a₂} (a⇑₂ : univ-cov.Fiber a₂) → from (to a⇑₂) == a⇑₂
       from-to {a₂} a⇑₂ = Trunc-elim
-        (λ p → =-preserves-set
+        {{λ p → =-preserves-level
                 {x = from (ap₀ fst p)}
                 {y = a⇑₂}
-                (univ-cov.Fiber-is-set a₂))
+                univ-cov.Fiber-is-set}}
         (λ p → to-transp $ snd= p)
         ([path] (a₁ , univ-cov.pt) (a₂ , a⇑₂))
 

--- a/theorems/homotopy/BlakersMassey.agda
+++ b/theorems/homotopy/BlakersMassey.agda
@@ -157,7 +157,7 @@ module _ {a₀} {b₀} (q₀₀ : Q a₀ b₀) where
 
   -- Finish the lemma.
   code-contr : ∀ {b₁} (r : bmleft a₀ == bmright b₁) → is-contr (Trunc (m +2+ n) (hfiber bmglue r))
-  code-contr r = has-level-make (code-center r , Trunc-elim (code-coh r))
+  code-contr r = has-level-in (code-center r , Trunc-elim (code-coh r))
 
 -- The final theorem.
 -- It is sufficient to find some [q₀₀].

--- a/theorems/homotopy/BlakersMassey.agda
+++ b/theorems/homotopy/BlakersMassey.agda
@@ -81,14 +81,14 @@ module _ {a₀} {b₀} (q₀₀ : Q a₀ b₀) where
   -- Part of the decomposed [coe (coerce-path r)]
   code-bmleft-template-diag : ∀ {p} (r : bmleft a₀ == p)
     → code-bmleft a₀ idp → code-bmleft-template a₀ r r
-  code-bmleft-template-diag r = Trunc-rec Trunc-level
+  code-bmleft-template-diag r = Trunc-rec
     λ {(q₀₀' , shift) →
       [ q₀₀' , ! (∙'-assoc (bmglue q₀₀) (! (bmglue q₀₀')) r) ∙ ap (_∙' r) shift ∙' ∙'-unit-l r ]}
 
   abstract
     code-bmleft-template-diag-idp : ∀ x → code-bmleft-template-diag idp x == x
     code-bmleft-template-diag-idp =
-      Trunc-elim (λ _ → =-preserves-level Trunc-level)
+      Trunc-elim
         λ{(q₁₀ , shift) → ap (λ p → [ q₁₀ , p ]) (ap-idf shift)}
 
   -- Here shows the use of two templates.  It will be super painful
@@ -157,13 +157,11 @@ module _ {a₀} {b₀} (q₀₀ : Q a₀ b₀) where
 
   -- Finish the lemma.
   code-contr : ∀ {b₁} (r : bmleft a₀ == bmright b₁) → is-contr (Trunc (m +2+ n) (hfiber bmglue r))
-  code-contr r = code-center r , Trunc-elim
-    (λ _ → =-preserves-level Trunc-level) (code-coh r)
+  code-contr r = has-level-make (code-center r , Trunc-elim (code-coh r))
 
 -- The final theorem.
 -- It is sufficient to find some [q₀₀].
 blakers-massey : ∀ {a₀ b₀} → has-conn-fibers (m +2+ n) (bmglue {a₀} {b₀})
 blakers-massey {a₀} r = Trunc-rec
-  (prop-has-level-S is-connected-is-prop)
   (λ{(_ , q₀₀) → code-contr q₀₀ r})
-  (fst (f-conn a₀))
+  (contr-center (f-conn a₀))

--- a/theorems/homotopy/CircleCover.agda
+++ b/theorems/homotopy/CircleCover.agda
@@ -8,19 +8,18 @@ record S¹Cover : Type (lsucc j) where
   constructor s¹cover
   field
     El : Type j
-    El-level : is-set El
+    {{El-level}} : is-set El
     El-auto : El ≃ El
 
 S¹cover-to-S¹-cover : S¹Cover → Cover S¹ j
 S¹cover-to-S¹-cover sc = record {
   Fiber = S¹-rec El (ua El-auto);
-  Fiber-level = S¹-elim El-level (prop-has-all-paths-↓ is-set-is-prop)}
+  Fiber-level = λ {a} → S¹-elim {P = λ a → is-set (S¹-rec El (ua El-auto) a)} El-level prop-has-all-paths-↓ a}
   where open S¹Cover sc
 
 S¹-cover-to-S¹cover : Cover S¹ j → S¹Cover
 S¹-cover-to-S¹cover c = record {
   El = Fiber base;
-  El-level = Fiber-level base;
   El-auto = coe-equiv (ap Fiber loop)}
   where open Cover c
 
@@ -39,7 +38,7 @@ S¹cover-equiv-S¹-cover = equiv to from to-from from-to where
         =∎
     where open Cover c
   from-to : ∀ sc → from (to sc) == sc
-  from-to sc = ap (λ eq → s¹cover El El-level eq) $
+  from-to sc = ap (λ eq → s¹cover El eq) $
     coe-equiv (ap (S¹-rec El (ua El-auto)) loop)
       =⟨ ap coe-equiv $ S¹Rec.loop-β _ _ ⟩
     coe-equiv (ua El-auto)

--- a/theorems/homotopy/ConstantToSetExtendsToProp.agda
+++ b/theorems/homotopy/ConstantToSetExtendsToProp.agda
@@ -3,7 +3,7 @@
 open import HoTT
 
 module homotopy.ConstantToSetExtendsToProp {i j}
-  {A : Type i} {B : Type j} (B-is-set : is-set B)
+  {A : Type i} {B : Type j} {{_ : is-set B}}
   (f : A → B) (f-is-const : ∀ a₁ a₂ → f a₁ == f a₂) where
 
   private
@@ -12,29 +12,28 @@ module homotopy.ConstantToSetExtendsToProp {i j}
     abstract
       Skel-has-all-paths : has-all-paths Skel
       Skel-has-all-paths =
-        SetQuot-elim (λ _ → Π-is-set λ _ → =-preserves-set SetQuot-is-set)
+        SetQuot-elim
           (λ a₁ →
             SetQuot-elim {P = λ s₂ → q[ a₁ ] == s₂}
-              (λ _ → =-preserves-set SetQuot-is-set)
               (λ _ → quot-rel _)
-              (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _)))
+              (λ _ → prop-has-all-paths-↓))
           (λ {a₁ a₂} _ → ↓-Π-cst-app-in λ s₂ →
-              prop-has-all-paths-↓ (SetQuot-is-set _ _))
+              prop-has-all-paths-↓)
 
-    Skel-is-prop : is-prop Skel
-    Skel-is-prop = all-paths-is-prop Skel-has-all-paths
+    instance
+      Skel-is-prop : is-prop Skel
+      Skel-is-prop = all-paths-is-prop Skel-has-all-paths
 
     Skel-lift : Skel → B
-    Skel-lift = SetQuot-rec B-is-set f (λ {a₁ a₂} _ → f-is-const a₁ a₂)
+    Skel-lift = SetQuot-rec f (λ {a₁ a₂} _ → f-is-const a₁ a₂)
 
   ext : Trunc -1 A → B
-  ext = Skel-lift ∘ Trunc-rec Skel-is-prop q[_]
+  ext = Skel-lift ∘ Trunc-rec q[_]
 
   abstract
     ext-is-const : ∀ a₁ a₂ → ext a₁ == ext a₂
     ext-is-const = Trunc-elim
-      (λ a₁ → Π-is-prop λ a₂ → B-is-set _ _)
-      (λ a₁ → Trunc-elim (λ a₂ → B-is-set _ _)
+      (λ a₁ → Trunc-elim
         (λ a₂ → f-is-const a₁ a₂))
 
   private

--- a/theorems/homotopy/DisjointlyPointedSet.agda
+++ b/theorems/homotopy/DisjointlyPointedSet.agda
@@ -47,7 +47,7 @@ module _ {i} where
           sep-unite (inl _) | inr ¬p = ⊥-rec (¬p idp)
           sep-unite (inr (x , ¬p)) with dec x
           sep-unite (inr (x , ¬p)) | inl p   = ⊥-rec (¬p p)
-          sep-unite (inr (x , ¬p)) | inr ¬p' = ap inr $ pair= idp (prop-has-all-paths ¬-is-prop ¬p' ¬p)
+          sep-unite (inr (x , ¬p)) | inr ¬p' = ap inr $ pair= idp (prop-has-all-paths ¬p' ¬p)
 
           unite-sep : ∀ x → unite-pt X (sep x) == x
           unite-sep x with dec x
@@ -109,14 +109,12 @@ module _ {i j k} n (A : Type i) (B : Type j) where
               from-to f = λ= λ{
                 (inl a) → Trunc-elim
                   {P = λ t → [ lift tt ] == t}
-                  (λ _ → =-preserves-level Trunc-level)
                   (λ _ → idp) (f (inl a));
                 (inr b) → idp}
 
           lemma₃ : ∀ f → –> lemma₂ (unchoose (<– (Trunc-emap n lemma₁) f)) == unchoose f
           lemma₃ = Trunc-elim
             {P = λ f → –> lemma₂ (unchoose (<– (Trunc-emap n lemma₁) f)) == unchoose f}
-            (λ _ → =-preserves-level (Π-level λ _ → Trunc-level))
             (λ f → λ= λ b → idp)
 
 module _ {i j} n {X : Ptd i} (X-sep : has-disjoint-pt X) where

--- a/theorems/homotopy/EM1HSpace.agda
+++ b/theorems/homotopy/EM1HSpace.agda
@@ -13,10 +13,10 @@ module EM₁HSpace {i} (G : AbGroup i) where
   mult-loop : (g : G.El) (x : EM₁ G.grp) → x == x
   mult-loop g = EM₁-elim
     {P = λ x → x == x}
-    (λ _ → =-preserves-level EM₁-level)
+    
     (emloop g)
     loop'
-    (λ _ _ → set-↓-has-all-paths-↓ (EM₁-level embase embase))
+    (λ _ _ → set-↓-has-all-paths-↓)
     where
     abstract
       loop' : (g' : G.El) → emloop' G.grp g == emloop g [ (λ x → x == x) ↓ emloop g' ]
@@ -28,7 +28,7 @@ module EM₁HSpace {i} (G : AbGroup i) where
         emloop g' ∙' emloop g    ∎
 
   mult-hom : GroupHom G.grp
-    (Ω^S-group 0 ⊙[ (EM₁ G.grp → EM₁ G.grp) , (λ x → x) ] (Π-level (λ _ → EM₁-level)))
+    (Ω^S-group 0 ⊙[ (EM₁ G.grp → EM₁ G.grp) , (λ x → x) ])
   mult-hom = record {f = f; pres-comp = pres-comp}
     where
     f = λ g → λ= (mult-loop g)
@@ -37,14 +37,13 @@ module EM₁HSpace {i} (G : AbGroup i) where
       ap λ= (λ= (EM₁-elim
         {P = λ x → mult-loop (G.comp g₁ g₂) x
                 == mult-loop g₁ x ∙ mult-loop g₂ x}
-        (λ _ →  =-preserves-level (=-preserves-level EM₁-level))
         (emloop-comp g₁ g₂)
-        (λ _ → prop-has-all-paths-↓ (EM₁-level _ _ _ _))
-        (λ _ _ → set-↓-has-all-paths-↓ (=-preserves-level (EM₁-level _ _)))))
+        (λ _ → prop-has-all-paths-↓)
+        (λ _ _ → set-↓-has-all-paths-↓)))
       ∙ ! (∙-λ= _ _)
 
   mult : EM₁ G.grp → EM₁ G.grp → EM₁ G.grp
-  mult = EM₁-rec {C = EM₁ G.grp → EM₁ G.grp} (Π-level (λ _ → EM₁-level)) (λ x → x) mult-hom
+  mult = EM₁-rec {C = EM₁ G.grp → EM₁ G.grp} (λ x → x) mult-hom
 
   H-⊙EM₁ : HSpaceStructure (⊙EM₁ G.grp)
   H-⊙EM₁ = from-alt-h-space $ record { μ = mult; unit-l = unit-l; unit-r = unit-r; coh = coh }
@@ -52,16 +51,14 @@ module EM₁HSpace {i} (G : AbGroup i) where
     unit-l : (x : EM₁ G.grp) → mult embase x == x
     unit-l = EM₁-elim
       {P = λ x → mult embase x == x}
-      (λ _ → =-preserves-level EM₁-level)
       idp
       (λ g → ↓-app=idf-in $ ∙'-unit-l (emloop g) ∙ (! (ap-idf (emloop g)))
                             ∙ ! (∙-unit-r (ap (mult embase) (emloop g))))
-      (λ _ _ → set-↓-has-all-paths-↓ (EM₁-level _ _))
+      (λ _ _ → set-↓-has-all-paths-↓)
 
     unit-r : (x : EM₁ G.grp) → mult x embase == x
     unit-r = EM₁-elim
       {P = λ x → mult x embase == x}
-      (λ _ → =-preserves-level EM₁-level)
       idp
       (λ g → ↓-app=idf-in $
          idp ∙' emloop g
@@ -70,14 +67,14 @@ module EM₁HSpace {i} (G : AbGroup i) where
            =⟨ ! (app=-β (mult-loop g) embase) ⟩
          app= (λ= (mult-loop g)) embase
            =⟨ ! (EM₁Rec.emloop-β {C = EM₁ G.grp → EM₁ G.grp}
-                   (Π-level (λ _ → EM₁-level)) (λ x → x) mult-hom g)
+                   (λ x → x) mult-hom g)
               |in-ctx (λ w → app= w embase) ⟩
          app= (ap mult (emloop g)) embase
            =⟨ ∘-ap (λ f → f embase) mult (emloop g) ⟩
          ap (λ z → mult z embase) (emloop g)
            =⟨ ! (∙-unit-r (ap (λ z → mult z embase) (emloop g))) ⟩
          ap (λ z → mult z embase) (emloop g) ∙ idp ∎)
-      (λ _ _ → set-↓-has-all-paths-↓ (EM₁-level _ _))
+      (λ _ _ → set-↓-has-all-paths-↓)
 
     coh : unit-l embase == unit-r embase
     coh = idp

--- a/theorems/homotopy/EilenbergMacLane.agda
+++ b/theorems/homotopy/EilenbergMacLane.agda
@@ -11,8 +11,8 @@ open import homotopy.EilenbergMacLane1
 module homotopy.EilenbergMacLane where
 
 -- EM(G,n) when G is π₁(A,a₀)
-module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
-  (gA : has-level 1 (de⊙ X)) (H-X : HSS X) where
+module EMImplicit {i} {X : Ptd i} {{_ : is-connected 0 (de⊙ X)}}
+  {{_ : has-level 1 (de⊙ X)}} (H-X : HSS X) where
 
   private
     A = de⊙ X
@@ -26,13 +26,14 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
     EM = de⊙ (⊙EM n)
 
   EM-level : (n : ℕ) → has-level ⟨ n ⟩ (EM n)
-  EM-level O = gA a₀ a₀
-  EM-level (S n) = Trunc-level
+  EM-level O = ⟨⟩
+  EM-level (S n) = ⟨⟩
 
-  EM-conn : (n : ℕ) → is-connected ⟨ n ⟩ (EM (S n))
-  EM-conn n = Trunc-preserves-conn ⟨ S n ⟩
-                  (transport (λ t → is-connected t (de⊙ (⊙Susp^ n X)))
-                    (+2+0 ⟨ n ⟩₋₂) (⊙Susp^-conn n cA))
+  instance
+    EM-conn : (n : ℕ) → is-connected ⟨ n ⟩ (EM (S n))
+    EM-conn n = Trunc-preserves-conn
+                    (transport (λ t → is-connected t (de⊙ (⊙Susp^ n X)))
+                      (+2+0 ⟨ n ⟩₋₂) (⊙Susp^-conn n))
 
   {-
   π (S k) (EM (S n)) (embase (S n)) == π k (EM n) (embase n)
@@ -55,7 +56,7 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
               lemma (S n') = ≤-trans (≤-ap-S (lemma n')) (inr ltS)
 
     private
-      module SS = Susp^StableSucc X cA k (S n) Skle
+      module SS = Susp^StableSucc X k (S n) Skle
 
     abstract
       stable : πS (S k) (⊙EM (S SSn)) ≃ᴳ πS k (⊙EM SSn)
@@ -75,9 +76,8 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
     π₁ n =
       contr-iso-0ᴳ (πS 0 (⊙EM (S (S n))))
         (connected-at-level-is-contr
-          (raise-level-≤T (≤T-ap-S (≤T-ap-S (-2≤T ⟨ n ⟩₋₂)))
-                          (Trunc-level {n = 0}))
-          (Trunc-preserves-conn 0 (path-conn (EM-conn (S n)))))
+          {{raise-level-≤T (≤T-ap-S (≤T-ap-S (-2≤T ⟨ n ⟩₋₂)))
+                          (Trunc-level {n = 0})}})
 
     -- some clutter here arises from the definition of <;
     -- any simple way to avoid this?
@@ -106,7 +106,7 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
     π₁ = πS-Trunc-fuse-≤-iso 0 1 X ≤T-refl
 
     private
-      module Π₂ = Pi2HSusp gA cA H-X
+      module Π₂ = Pi2HSusp H-X
 
     π₂ : πS 1 (⊙EM 2) ≃ᴳ πS 0 X
     π₂ = Π₂.π₂-Susp
@@ -126,8 +126,8 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
       contr-iso-0ᴳ (πS k (⊙EM n))
         (inhab-prop-is-contr
           [ idp^ (S k) ]
-          (Trunc-preserves-level 0 (Ω^-level -1 (S k) _
-            (raise-level-≤T (lemma lt) (EM-level n)))))
+          {{Trunc-preserves-level 0 (Ω^-level -1 (S k) _
+            (raise-level-≤T (lemma lt) (EM-level n)))}})
       where lemma : {k n : ℕ} → n < k → ⟨ n ⟩ ≤T (⟨ k ⟩₋₂ +2+ -1)
             lemma ltS = inl (! (+2+-comm _ -1))
             lemma (ltSR lt) = ≤T-trans (lemma lt) (inr ltS)
@@ -135,14 +135,14 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
   module Spectrum where
 
     private
-      module Π₂ = Pi2HSusp gA cA H-X
+      module Π₂ = Pi2HSusp H-X
 
     spectrum0 : ⊙Ω (⊙EM 1) ⊙≃ ⊙EM 0
     spectrum0 =
       ⊙Ω (⊙EM 1)
         ⊙≃⟨ ≃-to-⊙≃ (Trunc=-equiv _ _) idp ⟩
       ⊙Trunc 0 (⊙Ω X)
-        ⊙≃⟨ ≃-to-⊙≃ (unTrunc-equiv _ (gA a₀ a₀)) idp ⟩
+        ⊙≃⟨ ≃-to-⊙≃ (unTrunc-equiv _) idp ⟩
       ⊙Ω X ⊙≃∎
 
     spectrum1 : ⊙Ω (⊙EM 2) ⊙≃ ⊙EM 1
@@ -152,13 +152,14 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
       ⊙Trunc 1 (⊙Ω (⊙Susp X))
         ⊙≃⟨ Π₂.⊙main-lemma ⟩
       X
-        ⊙≃⟨ ≃-to-⊙≃ (unTrunc-equiv _ gA) idp ⊙⁻¹ ⟩
+        ⊙≃⟨ ≃-to-⊙≃ (unTrunc-equiv _) idp ⊙⁻¹ ⟩
       ⊙EM 1 ⊙≃∎
 
     private
-      sconn : (n : ℕ) → is-connected ⟨ S n ⟩ (de⊙ (⊙Susp^ (S n) X))
-      sconn n = transport (λ t → is-connected t (de⊙ (⊙Susp^ (S n) X)))
-                          (+2+0 ⟨ n ⟩₋₁) (⊙Susp^-conn (S n) cA)
+      instance
+        sconn : (n : ℕ) → is-connected ⟨ S n ⟩ (de⊙ (⊙Susp^ (S n) X))
+        sconn n = transport (λ t → is-connected t (de⊙ (⊙Susp^ (S n) X)))
+                            (+2+0 ⟨ n ⟩₋₁) (⊙Susp^-conn (S n))
 
       kle : (n : ℕ) → ⟨ S (S n) ⟩ ≤T ⟨ n ⟩ +2+ ⟨ n ⟩
       kle O = inl idp
@@ -168,7 +169,7 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
 
       module FS (n : ℕ) =
         FreudenthalEquiv ⟨ n ⟩₋₁ ⟨ S (S n) ⟩ (kle n)
-          (⊙Susp^ (S n) X) (sconn n)
+          (⊙Susp^ (S n) X)
 
     spectrumSS : (n : ℕ)
       → ⊙Ω (⊙EM (S (S (S n)))) ⊙≃ ⊙EM (S (S n))
@@ -187,7 +188,7 @@ module EMImplicit {i} {X : Ptd i} (cA : is-connected 0 (de⊙ X))
 
 module EMExplicit {i} (G : AbGroup i) where
   module HSpace = EM₁HSpace G
-  open EMImplicit EM₁-conn EM₁-level HSpace.H-⊙EM₁ public
+  open EMImplicit HSpace.H-⊙EM₁ public
 
   open BelowDiagonal public using (πS-below)
 

--- a/theorems/homotopy/EilenbergMacLane1.agda
+++ b/theorems/homotopy/EilenbergMacLane1.agda
@@ -16,17 +16,17 @@ module homotopy.EilenbergMacLane1 {i} (G : Group i) where
     comp-equiv-id : comp-equiv G.ident == ide G.El
     comp-equiv-id =
       pair= (λ= G.unit-r)
-            (prop-has-all-paths-↓ {B = is-equiv} is-equiv-is-prop)
+            (prop-has-all-paths-↓ {B = is-equiv})
 
     comp-equiv-comp : (g₁ g₂ : G.El) → comp-equiv (G.comp g₁ g₂)
                       == (comp-equiv g₂ ∘e comp-equiv g₁)
     comp-equiv-comp g₁ g₂ =
       pair= (λ= (λ x → ! (G.assoc x g₁ g₂)))
-            (prop-has-all-paths-↓ {B = is-equiv} is-equiv-is-prop)
+            (prop-has-all-paths-↓ {B = is-equiv})
 
     Ω-group : Group (lsucc i)
     Ω-group = Ω^S-group 0
-      ⊙[ (0 -Type i) , (G.El , G.El-level) ] (0 -Type-level i)
+      ⊙[ (0 -Type i) , (G.El , G.El-level) ]
 
     Codes-hom : G →ᴳ Ω-group
     Codes-hom = group-hom (nType=-out ∘ ua ∘ comp-equiv) pres-comp where
@@ -48,7 +48,7 @@ module homotopy.EilenbergMacLane1 {i} (G : Group i) where
             =∎
 
     Codes : EM₁ G → 0 -Type i
-    Codes = EM₁-rec {G = G} {C = 0 -Type i} (0 -Type-level i)
+    Codes = EM₁-rec {G = G} {C = 0 -Type i}
                     (G.El , G.El-level)
                     Codes-hom
 
@@ -58,8 +58,7 @@ module homotopy.EilenbergMacLane1 {i} (G : Group i) where
         ↓-ap-out fst Codes (emloop g) $
         ↓-ap-out (idf _) fst (ap Codes (emloop g)) $
         transport (λ w → g' == G.comp g' g [ idf _ ↓ ap fst w ])
-                  (! (EM₁Rec.emloop-β (0 -Type-level i)
-                                     (G.El , G.El-level) Codes-hom g)) $
+                  (! (EM₁Rec.emloop-β (G.El , G.El-level) Codes-hom g)) $
         transport (λ w → g' == G.comp g' g [ idf _ ↓ w ])
                   (! (fst=-β (ua $ comp-equiv g) _)) $
         ↓-idf-ua-in (comp-equiv g) idp
@@ -76,10 +75,9 @@ module homotopy.EilenbergMacLane1 {i} (G : Group i) where
     decode : {x : EM₁ G} → fst (Codes x) → embase == x
     decode {x} =
       EM₁-elim {P = λ x' → fst (Codes x') → embase == x'}
-        (λ _ → Π-level (λ _ → =-preserves-level EM₁-level))
         emloop
         loop'
-        (λ _ _ → prop-has-all-paths-↓ (↓-level (Π-level (λ _ → EM₁-level _ _))))
+        (λ _ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}})
         x
       where
       loop' : (g : G.El)
@@ -99,7 +97,7 @@ module homotopy.EilenbergMacLane1 {i} (G : Group i) where
     emloop-equiv : G.El ≃ (embase' G == embase)
     emloop-equiv = equiv emloop encode decode-encode encode-emloop
 
-  Ω¹-EM₁ : Ω^S-group 0 (⊙EM₁ G) EM₁-level ≃ᴳ G
+  Ω¹-EM₁ : Ω^S-group 0 (⊙EM₁ G) ≃ᴳ G
   Ω¹-EM₁ = ≃-to-≃ᴳ (emloop-equiv ⁻¹)
     (λ l₁ l₂ → <– (ap-equiv emloop-equiv _ _) $
       emloop (encode (l₁ ∙ l₂))
@@ -112,4 +110,4 @@ module homotopy.EilenbergMacLane1 {i} (G : Group i) where
         =∎)
 
   π₁-EM₁ : πS 0 (⊙EM₁ G) ≃ᴳ G
-  π₁-EM₁ = Ω¹-EM₁ ∘eᴳ unTrunc-iso (Ω^S-group-structure 0 (⊙EM₁ G)) (EM₁-level _ _)
+  π₁-EM₁ = Ω¹-EM₁ ∘eᴳ unTrunc-iso (Ω^S-group-structure 0 (⊙EM₁ G))

--- a/theorems/homotopy/Freudenthal.agda
+++ b/theorems/homotopy/Freudenthal.agda
@@ -13,7 +13,7 @@ private
 
 module FreudenthalEquiv
   {i} (n k : ℕ₋₂) (kle : k ≤T S n +2+ S n)
-  (X : Ptd i) (cX : is-connected (S (S n)) (de⊙ X)) where
+  (X : Ptd i) {{cX : is-connected (S (S n)) (de⊙ X)}} where
 
   Q : Susp (de⊙ X) → Type i
   Q x = Trunc k (north == x)
@@ -23,8 +23,6 @@ module FreudenthalEquiv
 
   Codes-mer-args : WedgeExt.args {a₀ = pt X} {b₀ = [_] {n = k} (pt X)}
   Codes-mer-args = record {n = S n; m = S n;
-    cA = cX;
-    cB = Trunc-preserves-conn k cX;
     P = λ _ _ → (Trunc k (de⊙ X) , raise-level-≤T kle Trunc-level);
     f = [_]; g = idf _; p = idp}
 
@@ -49,8 +47,8 @@ module FreudenthalEquiv
 
   Codes-mer-is-equiv : (x : de⊙ X) → is-equiv (Codes-mer x)
   Codes-mer-is-equiv =
-    conn-extend (pointed-conn-out (de⊙ X) (pt X) cX)
-      (λ x' → (is-equiv (Codes-mer x') , prop-has-level-S is-equiv-is-prop))
+    conn-extend (pointed-conn-out {n = S n} (de⊙ X) (pt X))
+      (λ x' → (is-equiv (Codes-mer x') , is-equiv-level))
       (λ tt → transport is-equiv (! (Codes-mer-β-r)) (idf-is-equiv _))
 
   Codes-mer-equiv : (x : de⊙ X) → Trunc k (de⊙ X) ≃ Trunc k (de⊙ X)
@@ -59,8 +57,8 @@ module FreudenthalEquiv
   Codes-mer-inv-x₀ : <– (Codes-mer-equiv (pt X)) == idf _
   Codes-mer-inv-x₀ =
        ap is-equiv.g (conn-extend-β
-          (pointed-conn-out (de⊙ X) (pt X) cX)
-          (λ x' → (is-equiv (Codes-mer x') , prop-has-level-S is-equiv-is-prop))
+          (pointed-conn-out (de⊙ X) (pt X))
+          (λ x' → (is-equiv (Codes-mer x') , is-equiv-level))
           _ unit)
      ∙ lemma (! (Codes-mer-β-r)) (snd $ ide _)
     where lemma : ∀ {i j} {A : Type i} {B : Type j} {f g : A → B}
@@ -73,7 +71,7 @@ module FreudenthalEquiv
 
   Codes-has-level : (x : Susp (de⊙ X)) → has-level k (Codes x)
   Codes-has-level = Susp-elim Trunc-level Trunc-level
-                      (λ _ → prop-has-all-paths-↓ has-level-is-prop)
+                      (λ _ → prop-has-all-paths-↓)
 
   decodeN : Codes north → Trunc k (north' (de⊙ X) == north)
   decodeN = Trunc-fmap up
@@ -88,12 +86,12 @@ module FreudenthalEquiv
   encode₀ α = transport Codes α [ pt X ]
 
   encode : {x : Susp (de⊙ X)} → Trunc k (north == x) → Codes x
-  encode {x} tα = Trunc-rec (Codes-has-level x) encode₀ tα
+  encode {x} tα = Trunc-rec {{Codes-has-level x}} encode₀ tα
 
   abstract
     encode-decodeN : (c : Codes north) → encode (decodeN c) == c
     encode-decodeN = Trunc-elim
-      (λ _ → =-preserves-level Trunc-level)
+      {{λ _ → =-preserves-level Trunc-level}}
       (λ x →
         encode (decodeN [ x ])
           =⟨ idp ⟩
@@ -203,12 +201,12 @@ module FreudenthalEquiv
 
       STS-args : WedgeExt.args {a₀ = pt X} {b₀ = pt X}
       STS-args =
-        record {n = S n; m = S n; cA = cX; cB = cX; P = P; f = f; g = g; p = p}
+        record {n = S n; m = S n; P = P; f = f; g = g; p = p}
 
       STS : (x' : de⊙ X) (c : Codes north) →
         transport Q (merid x') (Trunc-fmap up c)
         == Trunc-fmap (merid) (transport Codes (merid x') c)
-      STS x' = Trunc-elim (λ _ → =-preserves-level Trunc-level)
+      STS x' = Trunc-elim {{λ _ → =-preserves-level Trunc-level}}
                           (WedgeExt.ext STS-args x')
 
   abstract
@@ -216,7 +214,7 @@ module FreudenthalEquiv
       → decode {x} (encode {x} tα) == tα
     decode-encode {x} = Trunc-elim
       {P = λ tα → decode {x} (encode {x} tα) == tα}
-      (λ _ → =-preserves-level Trunc-level)
+      {{λ _ → =-preserves-level Trunc-level}}
       (J (λ y p → decode {y} (encode {y} [ p ]) == [ p ])
          (ap [_] (!-inv-r (merid (pt X)))))
 
@@ -235,14 +233,14 @@ module FreudenthalEquiv
 {- Used to prove stability in iterated suspensions -}
 module FreudenthalIso
   {i} (n : ℕ₋₂) (k : ℕ) (kle : ⟨ S k ⟩ ≤T S (n +2+ S n))
-  (X : Ptd i) (cX : is-connected (S (S n)) (de⊙ X)) where
+  (X : Ptd i) {{_ : is-connected (S (S n)) (de⊙ X)}} where
 
-  open FreudenthalEquiv n ⟨ S k ⟩ kle X cX public
+  open FreudenthalEquiv n ⟨ S k ⟩ kle X public
 
-  hom : Ω^S-group k (⊙Trunc ⟨ S k ⟩ X) Trunc-level
-     →ᴳ Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Ω (⊙Susp X))) Trunc-level
-  hom = Ω^S-group-fmap k Trunc-level Trunc-level (decodeN , decodeN-pt)
+  hom : Ω^S-group k (⊙Trunc ⟨ S k ⟩ X)
+     →ᴳ Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Ω (⊙Susp X)))
+  hom = Ω^S-group-fmap k (decodeN , decodeN-pt)
 
-  iso : Ω^S-group k (⊙Trunc ⟨ S k ⟩ X) Trunc-level
-     ≃ᴳ Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Ω (⊙Susp X))) Trunc-level
-  iso = Ω^S-group-emap k Trunc-level Trunc-level ⊙eq
+  iso : Ω^S-group k (⊙Trunc ⟨ S k ⟩ X)
+     ≃ᴳ Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Ω (⊙Susp X)))
+  iso = Ω^S-group-emap k ⊙eq

--- a/theorems/homotopy/GroupSetsRepresentCovers.agda
+++ b/theorems/homotopy/GroupSetsRepresentCovers.agda
@@ -5,7 +5,7 @@ import homotopy.ConstantToSetExtendsToProp as ConstExt
 open import homotopy.RibbonCover
 
 module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
-  (A-conn : is-connected 0 (de⊙ X)) where
+  {{_ : is-connected 0 (de⊙ X)}} where
 
   open Cover
 
@@ -21,7 +21,7 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
 
   -- Covering spaces to G-sets.
   cover-to-grpset-struct : ∀ {j} (cov : Cover A j)
-    → GroupSetStructure (πS 0 X) (Fiber cov a₁) (Fiber-is-set cov a₁)
+    → GroupSetStructure (πS 0 X) (Fiber cov a₁)
   cover-to-grpset-struct cov = record
     { act = cover-trace cov
     ; unit-r = cover-trace-idp₀ cov
@@ -31,7 +31,6 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
   cover-to-grpset : ∀ {j} → Cover A j → GroupSet (πS 0 X) j
   cover-to-grpset cov = record
     { El = Fiber cov a₁
-    ; El-level = Fiber-level cov a₁
     ; grpset-struct = cover-to-grpset-struct cov
     }
 
@@ -40,7 +39,7 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
     abstract
       [base-path] : ∀ {a₂ : A} → Trunc -1 (a₁ == a₂)
       [base-path] {a₂} =
-        –> (Trunc=-equiv [ a₁ ] [ a₂ ]) (contr-has-all-paths A-conn [ a₁ ] [ a₂ ])
+        –> (Trunc=-equiv [ a₁ ] [ a₂ ]) (contr-has-all-paths [ a₁ ] [ a₂ ])
 
   -- Part 1: Show that the synthesized cover (ribbon) is fiberwisely
   --         equivalent to the original fiber.
@@ -67,7 +66,7 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
             ∎
 
       module FiberAndPathToRibbon {a₂} (a↑ : Fiber cov a₂)
-        = ConstExt Ribbon-is-set
+        = ConstExt
           (fiber+path-to-ribbon a↑)
           (fiber+path-to-ribbon-is-path-irrelevant a↑)
 
@@ -85,7 +84,7 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
   ribbon-to-fiber : ∀ {j} (cov : Cover A j) {a₂}
     → Ribbon X (cover-to-grpset cov) a₂ → Cover.Fiber cov a₂
   ribbon-to-fiber cov {a₂} r =
-    Ribbon-rec (Fiber-is-set cov a₂) (cover-trace cov) (cover-paste cov) r
+    Ribbon-rec (cover-trace cov) (cover-paste cov) r
 
   private
     -- Some routine computations.
@@ -95,15 +94,14 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
         → fiber-to-ribbon cov (ribbon-to-fiber cov r) == r
       ribbon-to-fiber-to-ribbon cov {a₂} = Ribbon-elim
         {P = λ r → fiber-to-ribbon cov (ribbon-to-fiber cov r) == r}
-        (λ _ → =-preserves-set Ribbon-is-set)
         (λ a↑ p → Trunc-elim
           -- All ugly things will go away when bp = proj bp′
-          (λ bp → Ribbon-is-set
+          {{λ bp → has-level-apply Ribbon-is-set
                     (fiber+path₋₁-to-ribbon cov (cover-trace cov a↑ p) bp)
-                    (trace a↑ p))
+                    (trace a↑ p)}}
           (lemma a↑ p)
           [base-path])
-        (λ _ _ _ → prop-has-all-paths-↓ (Ribbon-is-set _ _))
+        (λ _ _ _ → prop-has-all-paths-↓)
         where
           abstract
             lemma : ∀ {a₂} (a↑ : Cover.Fiber cov a₁) (p : a₁ =₀ a₂) (bp : a₁ == a₂)
@@ -123,10 +121,10 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
         → ribbon-to-fiber cov (fiber-to-ribbon cov {a₂} a↑) == a↑
       fiber-to-ribbon-to-fiber cov {a₂} a↑ = Trunc-elim
         -- All ugly things will go away when bp = proj bp′
-        (λ bp → Cover.Fiber-is-set cov a₂
+        {{λ bp → has-level-apply (Cover.Fiber-is-set cov)
                   (ribbon-to-fiber cov
                     (fiber+path₋₁-to-ribbon cov a↑ bp))
-                  a↑)
+                  a↑}}
         (lemma a↑)
         [base-path]
         where
@@ -151,7 +149,7 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
   ribbon-a₁-to-El : ∀ {j} {gs : GroupSet (πS 0 X) j}
     → Ribbon X gs a₁ → GroupSet.El gs
   ribbon-a₁-to-El {j} {gs} = let open GroupSet gs in
-    Ribbon-rec El-level act assoc
+    Ribbon-rec act assoc
 
   ribbon-a₁-to-El-equiv : ∀ {j} {gs : GroupSet (πS 0 X) j}
     → Ribbon X gs a₁ ≃ GroupSet.El gs
@@ -161,7 +159,6 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
       (λ a↑ → unit-r a↑)
       (Ribbon-elim
         {P = λ r → trace (ribbon-a₁-to-El r) idp₀ == r}
-        (λ _ → =-preserves-set Ribbon-is-set)
         (λ y p →
           trace (act y p) idp₀
             =⟨ paste y p idp₀ ⟩
@@ -169,14 +166,14 @@ module homotopy.GroupSetsRepresentCovers {i} (X : Ptd i)
             =⟨ ap (trace y) $ ∙₀-unit-r p ⟩
           trace y p
             ∎)
-        (λ _ _ _ → prop-has-all-paths-↓ (Ribbon-is-set _ _)))
+        (λ _ _ _ → prop-has-all-paths-↓))
 
   grpset-to-cover-to-grpset : ∀ {j} (gs : GroupSet (πS 0 X) (lmax i j))
     → cover-to-grpset (grpset-to-cover gs) == gs
   grpset-to-cover-to-grpset gs =
     groupset=
       ribbon-a₁-to-El-equiv
-      (λ {x₁}{x₂} x= → Trunc-elim (λ _ → =-preserves-set $ GroupSet.El-is-set gs) λ g →
+      (λ {x₁}{x₂} x= → Trunc-elim λ g →
         ribbon-a₁-to-El (transport (Ribbon X gs) g x₁)
           =⟨ ap (λ x → ribbon-a₁-to-El (transport (Ribbon X gs) g x))
                 $ ! $ <–-inv-l ribbon-a₁-to-El-equiv x₁ ⟩

--- a/theorems/homotopy/HSpace.agda
+++ b/theorems/homotopy/HSpace.agda
@@ -51,7 +51,7 @@ from-alt-h-space hss = record {AlternativeHSpaceStructure hss}
 to-alt-h-space : ∀ {i} {X : Ptd i} → HSpaceStructure X → AlternativeHSpaceStructure X
 to-alt-h-space hss = record {HSpaceStructure hss}
 
-module ConnectedHSpace {i} {X : Ptd i} (c : is-connected 0 (de⊙ X))
+module ConnectedHSpace {i} {X : Ptd i} {{_ : is-connected 0 (de⊙ X)}}
   (hX : HSpaceStructure X) where
 
   open HSpaceStructure hX public
@@ -63,12 +63,12 @@ module ConnectedHSpace {i} {X : Ptd i} (c : is-connected 0 (de⊙ X))
   -}
 
   l-is-equiv : ∀ x → is-equiv (λ y → μ y x)
-  l-is-equiv = prop-over-connected {a = pt X} c
+  l-is-equiv = prop-over-connected {a = pt X}
     (λ x → (is-equiv (λ y → μ y x) , is-equiv-is-prop))
     (transport! is-equiv (λ= unit-r) (idf-is-equiv _))
 
   r-is-equiv : ∀ x → is-equiv (λ y → μ x y)
-  r-is-equiv = prop-over-connected {a = pt X} c
+  r-is-equiv = prop-over-connected {a = pt X}
     (λ x → (is-equiv (λ y → μ x y) , is-equiv-is-prop))
     (transport! is-equiv (λ= unit-l) (idf-is-equiv _))
 

--- a/theorems/homotopy/Hopf.agda
+++ b/theorems/homotopy/Hopf.agda
@@ -8,7 +8,7 @@ open import homotopy.JoinSusp
 module homotopy.Hopf where
 
 import homotopy.HopfConstruction
-module Hopf = homotopy.HopfConstruction S¹-conn ⊙S¹-hSpace
+module Hopf = homotopy.HopfConstruction ⊙S¹-hSpace
 
 Hopf : S² → Type₀
 Hopf = Hopf.H.f

--- a/theorems/homotopy/HopfConstruction.agda
+++ b/theorems/homotopy/HopfConstruction.agda
@@ -3,10 +3,10 @@
 open import HoTT
 open import homotopy.HSpace
 
-module homotopy.HopfConstruction {i} {X : Ptd i} (c : is-connected 0 (de⊙ X))
+module homotopy.HopfConstruction {i} {X : Ptd i} {{_ : is-connected 0 (de⊙ X)}}
   (hX : HSpaceStructure X) where
 
-module μ = ConnectedHSpace c hX
+module μ = ConnectedHSpace hX
 μ = μ.μ
 private
   A = de⊙ X

--- a/theorems/homotopy/IterSuspensionStable.agda
+++ b/theorems/homotopy/IterSuspensionStable.agda
@@ -7,7 +7,7 @@ module homotopy.IterSuspensionStable where
 
 {- π (S k) (Ptd-Susp^ (S n) X) == π k (Ptd-Susp^ n X), where k = S k'
    Susp^Stable below assumes k ≠ O instead of taking k' as the argument -}
-module Susp^StableSucc {i} (X : Ptd i) (cX : is-connected 0 (de⊙ X))
+module Susp^StableSucc {i} (X : Ptd i) {{_ : is-connected 0 (de⊙ X)}}
   (k n : ℕ) (Skle : S k ≤ n *2) where
 
   {- some numeric computations -}
@@ -22,8 +22,8 @@ module Susp^StableSucc {i} (X : Ptd i) (cX : is-connected 0 (de⊙ X))
   private
     module F = FreudenthalIso
       ⟨ n ⟩₋₂ k Skle' (⊙Susp^ n X)
-      (transport (λ t → is-connected t (de⊙ (⊙Susp^ n X)))
-                 (+2+0 ⟨ n ⟩₋₂) (⊙Susp^-conn n cX))
+      {{transport (λ t → is-connected t (de⊙ (⊙Susp^ n X)))
+                 (+2+0 ⟨ n ⟩₋₂) (⊙Susp^-conn n)}}
 
   stable : πS (S k) (⊙Susp^ (S n) X) ≃ᴳ πS k (⊙Susp^ n X)
   stable =
@@ -31,8 +31,8 @@ module Susp^StableSucc {i} (X : Ptd i) (cX : is-connected 0 (de⊙ X))
       ≃ᴳ⟨ πS-Ω-split-iso k (⊙Susp^ (S n) X) ⟩
     πS k (⊙Ω (⊙Susp^ (S n) X))
       ≃ᴳ⟨ Ω^S-group-Trunc-fuse-diag-iso k (⊙Ω (⊙Susp^ (S n) X)) ⁻¹ᴳ ⟩
-    Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Ω (⊙Susp^ (S n) X))) Trunc-level
+    Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Ω (⊙Susp^ (S n) X)))
       ≃ᴳ⟨ F.iso ⁻¹ᴳ ⟩
-    Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Susp^ n X)) Trunc-level
+    Ω^S-group k (⊙Trunc ⟨ S k ⟩ (⊙Susp^ n X))
       ≃ᴳ⟨ Ω^S-group-Trunc-fuse-diag-iso k (⊙Susp^ n X) ⟩
     πS k (⊙Susp^ n X) ≃ᴳ∎

--- a/theorems/homotopy/LoopSpaceCircle.agda
+++ b/theorems/homotopy/LoopSpaceCircle.agda
@@ -153,7 +153,7 @@ paths-mike (x , t) = paths-mike-c x t where
                     =⟨ Σ-∙ (↓-loop^ n) q ⟩
           pair= (loop^ n ∙ loop) (↓-loop^ n ∙ᵈ q)
                     =⟨ pair== (! (loop^+ n 1) ∙ ap loop^ (ℤ+-comm n 1 ∙ S¹Cover.↓-loop-out q))
-                              (set-↓-has-all-paths-↓ ℤ-is-set) ⟩
+                              set-↓-has-all-paths-↓ ⟩
           pair= (loop^ n') (↓-loop^ n') ∎))) where
 
       ↓-loop^ : (n : ℤ) → 0 == n [ S¹Cover ↓ loop^ n ]
@@ -161,7 +161,7 @@ paths-mike (x , t) = paths-mike-c x t where
 
 abstract
   contr-mike : is-contr (Σ S¹ S¹Cover)
-  contr-mike = ((base , 0) , paths-mike)
+  contr-mike = has-level-make ((base , 0) , paths-mike)
 
 {- 5. Flattening lemma proof that [Σ S¹ Cover] is contractible -}
 
@@ -172,7 +172,7 @@ open S¹Cover using (module Wt; Wt; cct; ppt; flattening-S¹)
 -- We prove that the flattened HIT corresponding to the universal cover of the
 -- circle (the real line) is contractible
 Wt-is-contr : is-contr Wt
-Wt-is-contr = (cct tt 0 , Wt.elim (base* ∘ snd) (loop* ∘ snd)) where
+Wt-is-contr = has-level-make (cct tt 0 , Wt.elim (base* ∘ snd) (loop* ∘ snd)) where
 
   -- This is basically [loop^] using a different composition order
   base* : (n : ℤ) → cct tt 0 == cct tt n
@@ -238,7 +238,7 @@ abstract
 encode-decode : (x : S¹) (t : S¹Cover x) → encode (decode x t) == t
 encode-decode =
   S¹-elim {P = λ x → (t : S¹Cover x) → encode (decode x t) == t}
-    encode-loop^ (↓-Π-in (λ q → prop-has-all-paths-↓ (ℤ-is-set _ _)))
+    encode-loop^ (↓-Π-in (λ q → prop-has-all-paths-↓))
 
 encode-is-equiv' : (x : S¹) → is-equiv (encode {x})
 encode-is-equiv' x = is-eq encode (decode x) (encode-decode x) (decode-encode x)
@@ -248,19 +248,20 @@ encode-is-equiv' x = is-eq encode (decode x) (encode-decode x) (decode-encode x)
 abstract
   S¹Cover-is-set : {y : S¹} → is-set (S¹Cover y)
   S¹Cover-is-set {y} = S¹-elim {P = λ y → is-set (S¹Cover y)}
-    ℤ-is-set (prop-has-all-paths-↓ is-set-is-prop) y
+    ℤ-is-set prop-has-all-paths-↓ y
 
   ΩS¹-is-set : {y : S¹} → is-set (base == y)
   ΩS¹-is-set {y} = equiv-preserves-level ((encode {y} , encode-is-equiv y) ⁻¹)
-                                         (S¹Cover-is-set {y})
+                                         {{S¹Cover-is-set {y}}}
 
 S¹-level : has-level 1 S¹
-S¹-level =
-  S¹-elim (λ _ → ΩS¹-is-set) (prop-has-all-paths-↓ (Π-level (λ x → is-set-is-prop)))
+S¹-level = has-level-make (S¹-elim ⟨⟩ prop-has-all-paths-↓) where instance _ = ΩS¹-is-set
+
+instance S¹-level-instance = S¹-level
 
 {- 9. More stuff -}
 
-ΩS¹-iso-ℤ : Ω^S-group 0 ⊙S¹ S¹-level ≃ᴳ ℤ-group
+ΩS¹-iso-ℤ : Ω^S-group 0 ⊙S¹ ≃ᴳ ℤ-group
 ΩS¹-iso-ℤ = ≃-to-≃ᴳ ΩS¹≃ℤ encode-pres-∙ where
   abstract
     encode-∙ : ∀ {x₁ x₂} (loop₁ : base == x₁) (loop₂ : x₁ == x₂)
@@ -282,5 +283,5 @@ S¹-level =
           =∎
 
 abstract
-  ΩS¹-is-abelian : is-abelian (Ω^S-group 0 ⊙S¹ S¹-level)
+  ΩS¹-is-abelian : is-abelian (Ω^S-group 0 ⊙S¹)
   ΩS¹-is-abelian = iso-preserves-abelian (ΩS¹-iso-ℤ ⁻¹ᴳ) ℤ-group-is-abelian

--- a/theorems/homotopy/LoopSpaceCircle.agda
+++ b/theorems/homotopy/LoopSpaceCircle.agda
@@ -161,7 +161,7 @@ paths-mike (x , t) = paths-mike-c x t where
 
 abstract
   contr-mike : is-contr (Σ S¹ S¹Cover)
-  contr-mike = has-level-make ((base , 0) , paths-mike)
+  contr-mike = has-level-in ((base , 0) , paths-mike)
 
 {- 5. Flattening lemma proof that [Σ S¹ Cover] is contractible -}
 
@@ -172,7 +172,7 @@ open S¹Cover using (module Wt; Wt; cct; ppt; flattening-S¹)
 -- We prove that the flattened HIT corresponding to the universal cover of the
 -- circle (the real line) is contractible
 Wt-is-contr : is-contr Wt
-Wt-is-contr = has-level-make (cct tt 0 , Wt.elim (base* ∘ snd) (loop* ∘ snd)) where
+Wt-is-contr = has-level-in (cct tt 0 , Wt.elim (base* ∘ snd) (loop* ∘ snd)) where
 
   -- This is basically [loop^] using a different composition order
   base* : (n : ℤ) → cct tt 0 == cct tt n
@@ -255,7 +255,7 @@ abstract
                                          {{S¹Cover-is-set {y}}}
 
 S¹-level : has-level 1 S¹
-S¹-level = has-level-make (S¹-elim ⟨⟩ prop-has-all-paths-↓) where instance _ = ΩS¹-is-set
+S¹-level = has-level-in (S¹-elim ⟨⟩ prop-has-all-paths-↓) where instance _ = ΩS¹-is-set
 
 instance S¹-level-instance = S¹-level
 

--- a/theorems/homotopy/PathSetIsInitalCover.agda
+++ b/theorems/homotopy/PathSetIsInitalCover.agda
@@ -28,7 +28,6 @@ module homotopy.PathSetIsInitalCover {i} (X : Ptd i)
 
       lemma₂ : ∀ a p → cover-hom a p == quotient-cover a p
       lemma₂ a = Trunc-elim
-        (λ p → =-preserves-set (⊙cov.Fiber-level a))
         (lemma₁ a)
 
     theorem : cover-hom == quotient-cover

--- a/theorems/homotopy/Pi2HSusp.agda
+++ b/theorems/homotopy/Pi2HSusp.agda
@@ -6,8 +6,8 @@ import homotopy.WedgeExtension as WedgeExt
 
 module homotopy.Pi2HSusp where
 
-module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
-  (cA : is-connected 0 (de⊙ X)) (H-X : HSS X)
+module Pi2HSusp {i} {X : Ptd i} {{_ : has-level 1 (de⊙ X)}}
+  {{_ : is-connected 0 (de⊙ X)}} (H-X : HSS X)
   where
 
   {- TODO this belongs somewhere else, but where? -}
@@ -19,7 +19,7 @@ module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
       ∙ ap ua (Subtype=-out is-equiv-prop (λ= α))
       ∙ ua-η q
 
-  module μ = ConnectedHSpace cA H-X
+  module μ = ConnectedHSpace H-X
   μ = μ.μ
   private
     A = de⊙ X
@@ -34,14 +34,14 @@ module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
   Codes = Codes.f
 
   Codes-level : (x : Susp A) → has-level 1 (Codes x)
-  Codes-level = Susp-elim gA gA
-    (λ _ → prop-has-all-paths-↓ has-level-is-prop)
+  Codes-level = Susp-elim ⟨⟩ ⟨⟩
+    (λ _ → prop-has-all-paths-↓)
 
   encode₀ : {x : Susp A} → (north == x) → Codes x
   encode₀ α = transport Codes α e
 
   encode : {x : Susp A} → P x → Codes x
-  encode {x} = Trunc-rec (Codes-level x) encode₀
+  encode {x} = Trunc-rec {{Codes-level x}} encode₀
 
   decode' : A → P north
   decode' a = [ (merid a ∙ ! (merid e)) ]
@@ -87,8 +87,8 @@ module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
     homomorphism = WedgeExt.ext args
       where
       args : WedgeExt.args {a₀ = e} {b₀ = e}
-      args = record {m = -1; n = -1; cA = cA; cB = cA;
-        P = λ a a' → (_ , Trunc-level {n = 1} _ _);
+      args = record {m = -1; n = -1;
+        P = λ a a' → (_ , ⟨⟩);
         f = λ a →  ap [_] $
               merid (μ a e)
                 =⟨ ap merid (μ.unit-r a) ⟩
@@ -141,7 +141,8 @@ module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
       → decode {x} (encode {x} tα) == tα
     decode-encode {x} = Trunc-elim
       {P = λ tα → decode {x} (encode {x} tα) == tα}
-      (λ _ → =-preserves-level Trunc-level)
+      -- FIXME: Agda very slow (looping?) when omitting the next line
+      {{λ _ → =-preserves-level Trunc-level}}
       (J (λ y p → decode {y} (encode {y} [ p ]) == [ p ])
          (ap [_] (!-inv-r (merid e))))
 
@@ -152,8 +153,8 @@ module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
   ⊙main-lemma = ≃-to-⊙≃ main-lemma-eq idp
 
   abstract
-    main-lemma-iso : Ω^S-group 0 (⊙Trunc 1 (⊙Ω (⊙Susp X))) Trunc-level
-                  ≃ᴳ Ω^S-group 0 (⊙Trunc 1 X) Trunc-level
+    main-lemma-iso : Ω^S-group 0 (⊙Trunc 1 (⊙Ω (⊙Susp X)))
+                  ≃ᴳ Ω^S-group 0 (⊙Trunc 1 X)
     main-lemma-iso = (record {f = f; pres-comp = pres-comp} , ie)
       where
       h : ⊙Trunc 1 (⊙Ω (⊙Susp X)) ⊙→ ⊙Trunc 1 X
@@ -167,7 +168,7 @@ module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
       pres-comp = Ω^S-fmap-∙ 0 h
 
       ie : is-equiv f
-      ie = Ω^-isemap 1 h (snd $ ((unTrunc-equiv A gA)⁻¹ ∘e main-lemma-eq))
+      ie = Ω^-isemap 1 h (snd $ ((unTrunc-equiv A)⁻¹ ∘e main-lemma-eq))
 
   abstract
     π₂-Susp : πS 1 (⊙Susp X) ≃ᴳ πS 0 X
@@ -176,8 +177,8 @@ module Pi2HSusp {i} {X : Ptd i} (gA : has-level 1 (de⊙ X))
         ≃ᴳ⟨ πS-Ω-split-iso 0 (⊙Susp X) ⟩
       πS 0 (⊙Ω (⊙Susp X))
         ≃ᴳ⟨ Ω^S-group-Trunc-fuse-diag-iso 0 (⊙Ω (⊙Susp X)) ⁻¹ᴳ ⟩
-      Ω^S-group 0 (⊙Trunc 1 (⊙Ω (⊙Susp X))) Trunc-level
+      Ω^S-group 0 (⊙Trunc 1 (⊙Ω (⊙Susp X)))
         ≃ᴳ⟨ main-lemma-iso ⟩
-      Ω^S-group 0 (⊙Trunc 1 X) Trunc-level
+      Ω^S-group 0 (⊙Trunc 1 X)
         ≃ᴳ⟨ Ω^S-group-Trunc-fuse-diag-iso 0 X ⟩
       πS 0 X ≃ᴳ∎

--- a/theorems/homotopy/PinSn.agda
+++ b/theorems/homotopy/PinSn.agda
@@ -11,21 +11,21 @@ module homotopy.PinSn where
 
   private
     π1S¹-iso-ℤ : πS 0 ⊙S¹ ≃ᴳ ℤ-group
-    π1S¹-iso-ℤ = ΩS¹-iso-ℤ ∘eᴳ unTrunc-iso ΩS¹-group-structure ΩS¹-is-set
+    π1S¹-iso-ℤ = ΩS¹-iso-ℤ ∘eᴳ unTrunc-iso ΩS¹-group-structure
 
   private
     πS-SphereS'-iso-ℤ : ∀ n → πS n (⊙Susp^ n ⊙S¹) ≃ᴳ ℤ-group
     πS-SphereS'-iso-ℤ 0 = π1S¹-iso-ℤ
     πS-SphereS'-iso-ℤ 1 =
       πS 1 ⊙S²
-        ≃ᴳ⟨ Pi2HSusp.π₂-Susp S¹-level S¹-conn ⊙S¹-hSpace ⟩
+        ≃ᴳ⟨ Pi2HSusp.π₂-Susp ⊙S¹-hSpace ⟩
       πS 0 ⊙S¹
         ≃ᴳ⟨ πS-SphereS'-iso-ℤ O ⟩
       ℤ-group
         ≃ᴳ∎
     πS-SphereS'-iso-ℤ (S (S n)) =
       πS (S (S n)) (⊙Susp^ (S (S n)) ⊙S¹)
-        ≃ᴳ⟨ Susp^StableSucc.stable ⊙S¹ S¹-conn
+        ≃ᴳ⟨ Susp^StableSucc.stable ⊙S¹
              (S n) (S n) (≤-ap-S $ ≤-ap-S $ *2-increasing n) ⟩
       πS (S n) (⊙Susp^ (S n) ⊙S¹)
         ≃ᴳ⟨ πS-SphereS'-iso-ℤ (S n) ⟩

--- a/theorems/homotopy/PropJoinProp.agda
+++ b/theorems/homotopy/PropJoinProp.agda
@@ -5,31 +5,31 @@ open import HoTT
 {- Proof that if [A] and [B] are two propositions, then so is [A * B]. -}
 
 module homotopy.PropJoinProp
-  {i} {A : Type i} (pA : is-prop A)
-  {j} {B : Type j} (pB : is-prop B) where
+  {i} {A : Type i} {{_ : is-prop A}}
+  {j} {B : Type j} {{_ : is-prop B}} where
 
 contr-left : (a : A) → is-contr (A * B)
-contr-left a = left a , Pushout-elim
-  (λ a' → ap left (prop-has-all-paths pA a a'))
+contr-left a = has-level-make (left a , Pushout-elim
+  (λ a' → ap left (prop-has-all-paths a a'))
   (λ b' → glue (a , b'))
   (λ {(a' , b') → ↓-cst=idf-in' $ ! $
-    ↓-app=cst-out (apd (λ a → glue (a , b')) (prop-has-all-paths pA a a'))})
+    ↓-app=cst-out (apd (λ a → glue (a , b')) (prop-has-all-paths a a'))}))
 
 contr-right : (b : B) → is-contr (A * B)
-contr-right b = right b , Pushout-elim
+contr-right b = has-level-make (right b , Pushout-elim
   (λ a' → ! (glue (a' , b)))
-  (λ b' → ap right (prop-has-all-paths pB b b'))
+  (λ b' → ap right (prop-has-all-paths b b'))
   (λ {(a' , b') → ↓-cst=idf-in' $
     ! (glue (a' , b)) ∙ glue (a' , b')
-      =⟨ ! (↓-cst=app-out' $ apd (λ b → glue (a' , b)) (prop-has-all-paths pB b b'))
+      =⟨ ! (↓-cst=app-out' $ apd (λ b → glue (a' , b)) (prop-has-all-paths b b'))
         |in-ctx ! (glue (a' , b)) ∙_ ⟩
-    ! (glue (a' , b)) ∙ glue (a' , b) ∙ ap right (prop-has-all-paths pB b b')
-      =⟨ ! $ ∙-assoc (! (glue (a' , b))) (glue (a' , b)) (ap right (prop-has-all-paths pB b b')) ⟩
-    (! (glue (a' , b)) ∙ glue (a' , b)) ∙ ap right (prop-has-all-paths pB b b')
-      =⟨ !-inv-l (glue (a' , b)) |in-ctx _∙ ap right (prop-has-all-paths pB b b') ⟩
-    ap right (prop-has-all-paths pB b b')
-      =∎})
+    ! (glue (a' , b)) ∙ glue (a' , b) ∙ ap right (prop-has-all-paths b b')
+      =⟨ ! $ ∙-assoc (! (glue (a' , b))) (glue (a' , b)) (ap right (prop-has-all-paths b b')) ⟩
+    (! (glue (a' , b)) ∙ glue (a' , b)) ∙ ap right (prop-has-all-paths b b')
+      =⟨ !-inv-l (glue (a' , b)) |in-ctx _∙ ap right (prop-has-all-paths b b') ⟩
+    ap right (prop-has-all-paths b b')
+      =∎}))
 
 prop*prop-is-prop : is-prop (A * B)
 prop*prop-is-prop = inhab-to-contr-is-prop $
-  Pushout-rec contr-left contr-right (λ _ → prop-has-all-paths is-contr-is-prop _ _)
+  Pushout-rec contr-left contr-right (λ _ → prop-has-all-paths _ _)

--- a/theorems/homotopy/PropJoinProp.agda
+++ b/theorems/homotopy/PropJoinProp.agda
@@ -9,14 +9,14 @@ module homotopy.PropJoinProp
   {j} {B : Type j} {{_ : is-prop B}} where
 
 contr-left : (a : A) → is-contr (A * B)
-contr-left a = has-level-make (left a , Pushout-elim
+contr-left a = has-level-in (left a , Pushout-elim
   (λ a' → ap left (prop-has-all-paths a a'))
   (λ b' → glue (a , b'))
   (λ {(a' , b') → ↓-cst=idf-in' $ ! $
     ↓-app=cst-out (apd (λ a → glue (a , b')) (prop-has-all-paths a a'))}))
 
 contr-right : (b : B) → is-contr (A * B)
-contr-right b = has-level-make (right b , Pushout-elim
+contr-right b = has-level-in (right b , Pushout-elim
   (λ a' → ! (glue (a' , b)))
   (λ b' → ap right (prop-has-all-paths b b'))
   (λ {(a' , b') → ↓-cst=idf-in' $

--- a/theorems/homotopy/RelativelyConstantToSetExtendsViaSurjection.agda
+++ b/theorems/homotopy/RelativelyConstantToSetExtendsViaSurjection.agda
@@ -5,7 +5,7 @@ import homotopy.ConstantToSetExtendsToProp as ConstExt
 
 module homotopy.RelativelyConstantToSetExtendsViaSurjection
   {i j k} {A : Type i} {B : Type j} {C : B → Type k}
-  (C-is-set : ∀ b → is-set (C b))
+  {{_ : ∀ {b} → is-set (C b)}}
   (f : A → B) (f-is-surj : is-surj f)
   (g : (a : A) → C (f a))
   (g-is-const : ∀ a₁ a₂ → (p : f a₁ == f a₂) → g a₁ == g a₂ [ C ↓ p ])
@@ -28,11 +28,11 @@ module homotopy.RelativelyConstantToSetExtendsViaSurjection
 
     module CE (b : B) =
       ConstExt {A = hfiber f b} {B = C b}
-        (C-is-set b) (lemma b) (lemma-const b)
+        (lemma b) (lemma-const b)
 
   ext : Π B C
   ext b = CE.ext b (f-is-surj b)
 
   β : (a : A) → ext (f a) == g a
   β a = ap (CE.ext (f a))
-    (prop-has-all-paths Trunc-level (f-is-surj (f a)) [ a , idp ])
+    (prop-has-all-paths (f-is-surj (f a)) [ a , idp ])

--- a/theorems/homotopy/RibbonCover.agda
+++ b/theorems/homotopy/RibbonCover.agda
@@ -20,7 +20,6 @@ module homotopy.RibbonCover {i : ULevel} where
       A = de⊙ X
       a₁ = pt X
       El = GroupSet.El gs
-      El-level = GroupSet.El-level gs
       infix 80 _⊙_
       _⊙_ = GroupSet.act gs
 
@@ -39,7 +38,6 @@ module homotopy.RibbonCover {i : ULevel} where
       A = de⊙ X
       a = pt X
       El = GroupSet.El gs
-      El-level = GroupSet.El-level gs
       infix 80 _⊙_
       _⊙_ = GroupSet.act gs
 
@@ -62,14 +60,12 @@ module homotopy.RibbonCover {i : ULevel} where
       Make each fiber a set and cancel all higher structures
       due to [paste].
     -}
-    Ribbon-level : is-set (Ribbon X gs a₂)
-    Ribbon-level = SetQuot-level
-
-    Ribbon-is-set = Ribbon-level
+    Ribbon-is-set : is-set (Ribbon X gs a₂)
+    Ribbon-is-set = SetQuot-is-set
 
     -- Elimination rules.
     module RibbonElim {j} {P : Ribbon X gs a₂ → Type j}
-      (P-level : ∀ r → is-set (P r))
+      {{P-level : ∀ {r} → is-set (P r)}}
       (trace* : ∀ el p → P (trace el p))
       (paste* : ∀ el loop p
                 → trace* (el ⊙ loop) p == trace* el (loop ∙₀ p)
@@ -82,7 +78,7 @@ module homotopy.RibbonCover {i : ULevel} where
         rel* : ∀ {α₁ α₂} (r : RibbonRel X gs a₂ α₁ α₂) → q[ α₁ ]* == q[ α₂ ]* [ P ↓ quot-rel r ]
         rel* (ribbon-rel el loop p) = paste* el loop p
 
-        module M = SetQuotElim P-level q[_]* rel*
+        module M = SetQuotElim q[_]* rel*
 
       f : Π (Ribbon X gs a₂) P
       f = M.f
@@ -90,13 +86,13 @@ module homotopy.RibbonCover {i : ULevel} where
     open RibbonElim public using () renaming (f to Ribbon-elim)
 
     module RibbonRec {j} {P : Type j}
-      (P-level : is-set P)
+      {{P-level : is-set P}}
       (trace* : ∀ el p → P)
       (paste* : ∀ el loop p
                 → trace* (el ⊙ loop) p == trace* el (loop ∙₀ p)) where
 
       private
-        module M = RibbonElim (λ _ → P-level) trace*
+        module M = RibbonElim trace*
           (λ el loop p → ↓-cst-in (paste* el loop p))
 
       f : Ribbon X gs a₂ → P
@@ -108,9 +104,7 @@ module homotopy.RibbonCover {i : ULevel} where
   Ribbon-cover : ∀ (X : Ptd i) {j} (gs : GroupSet (πS 0 X) j)
     → Cover (de⊙ X) (lmax i j)
   Ribbon-cover X gs = record
-    { Fiber = Ribbon X gs
-    ; Fiber-level = λ a → Ribbon-level
-    }
+    { Fiber = Ribbon X gs }
 
   transp-trace : ∀ {A : Type i} {a₁} {j}
     {gs : GroupSet (πS 0 ⊙[ A , a₁ ]) j}

--- a/theorems/homotopy/SpaceFromGroups.agda
+++ b/theorems/homotopy/SpaceFromGroups.agda
@@ -13,8 +13,8 @@ module homotopy.SpaceFromGroups where
 {- From a sequence of spaces (Fₙ) such that Fₙ is n-connected and
  - n+1-truncated, construct a space X such that πₙ₊₁(X) == πₙ₊₁(Fₙ) -}
 module SpaceFromEMs {i} (F : ℕ → Ptd i)
-  (pF : (n : ℕ) → has-level ⟨ S n ⟩ (de⊙ (F n)))
-  (cF : (n : ℕ) → is-connected ⟨ n ⟩ (de⊙ (F n))) where
+  {{pF : {n : ℕ} → has-level ⟨ S n ⟩ (de⊙ (F n))}}
+  {{cF : (n : ℕ) → is-connected ⟨ n ⟩ (de⊙ (F n))}} where
 
   X : Ptd i
   X = ⊙FinTuples F
@@ -22,7 +22,7 @@ module SpaceFromEMs {i} (F : ℕ → Ptd i)
   πS-X : (n : ℕ) → πS n X ≃ᴳ πS n (F n)
   πS-X n =
     πS n (⊙FinTuples F)
-      ≃ᴳ⟨ prefix-lemma n O F pF ⟩
+      ≃ᴳ⟨ prefix-lemma n O F ⟩
     πS n (⊙FinTuples (λ k → F (n + k)))
       ≃ᴳ⟨ πS-emap n (⊙fin-tuples-cons (λ k → F (n + k))) ⁻¹ᴳ ⟩
     πS n (F (n + O) ⊙× ⊙FinTuples (λ k → F (n + S k)))
@@ -30,16 +30,16 @@ module SpaceFromEMs {i} (F : ℕ → Ptd i)
     πS n (F (n + O)) ×ᴳ πS n (⊙FinTuples (λ k → F (n + S k)))
       ≃ᴳ⟨ ×ᴳ-emap (idiso (πS n (F (n + O))) )
          (contr-iso-0ᴳ _ $
-           connected-at-level-is-contr (Trunc-level {n = 0}) $
-             Trunc-preserves-conn 0 $ Ω^-conn _ (S n) _ $
+           connected-at-level-is-contr {{⟨⟩}}
+             {{Trunc-preserves-conn {n = 0} $ Ω^-conn _ (S n) _ $
                transport
                  (λ k → is-connected k
                           (FinTuples (λ k → F (n + S k))))
                  (+2+-comm 0 ⟨ n ⟩₋₁)
-                 (ncolim-conn _ _ $ connected-lemma _ _ $ λ k →
+                 (ncolim-conn _ _ {{connected-lemma _ _ (λ k →
                    transport (λ s → is-connected ⟨ s ⟩ (de⊙ (F (n + S k))))
                      (+-βr n k ∙ +-comm (S n) k)
-                     (cF (n + S k)))) ⟩
+                     (cF (n + S k)))}})}}) ⟩
     πS n (F (n + O)) ×ᴳ 0ᴳ
       ≃ᴳ⟨ ×ᴳ-unit-r _ ⟩
     πS n (F (n + O))
@@ -50,11 +50,11 @@ module SpaceFromEMs {i} (F : ℕ → Ptd i)
     {- In computing πₙ₊₁, spaces before Fₙ are ignored because of their
      - truncation level -}
     prefix-lemma : (n : ℕ) (m : ℕ) (F : ℕ → Ptd i)
-      (pF : (k : ℕ) → has-level ⟨ S m + k ⟩ (de⊙ (F k)))
+      {{_ : {k : ℕ} → has-level ⟨ S m + k ⟩ (de⊙ (F k))}}
       → πS (m + n) (⊙FinTuples F)
         ≃ᴳ πS (m + n) (⊙FinTuples (λ k → F (n + k)))
-    prefix-lemma O m F pF = idiso _
-    prefix-lemma (S n) m F pF =
+    prefix-lemma O m F = idiso _
+    prefix-lemma (S n) m F =
       πS (m + S n) (⊙FinTuples F)
         ≃ᴳ⟨ πS-emap (m + S n) (⊙fin-tuples-cons F) ⁻¹ᴳ ⟩
       πS (m + S n) (F O ⊙× ⊙FinTuples (F ∘ S))
@@ -70,7 +70,7 @@ module SpaceFromEMs {i} (F : ℕ → Ptd i)
       lemma₁ : πS (m + S n) (F O) ≃ᴳ 0ᴳ
       lemma₁ =
         πS->level-econv (m + S n) _ (F O)
-          (⟨⟩-monotone-< (<-ap-S (<-+-l m (O<S n)))) (pF O)
+          (⟨⟩-monotone-< (<-ap-S (<-+-l m (O<S n))))
 
       {- ignore the rest by recursive call -}
       lemma₂ : πS (m + S n) (⊙FinTuples (F ∘ S))
@@ -80,9 +80,8 @@ module SpaceFromEMs {i} (F : ℕ → Ptd i)
           ≃ᴳ⟨ transportᴳ-iso (λ s → πS s (⊙FinTuples (F ∘ S))) (+-βr m n) ⟩
         πS (S m + n) (⊙FinTuples (F ∘ S))
           ≃ᴳ⟨ prefix-lemma n (S m) (F ∘ S)
-                (λ k → transport (λ s → has-level ⟨ s ⟩ (de⊙ (F (S k))))
-                     (+-βr (S m) k)
-                     (pF (S k))) ⟩
+                {{λ {k} → transport (λ s → has-level ⟨ s ⟩ (de⊙ (F (S k))))
+                     (+-βr (S m) k) ⟨⟩}} ⟩
         πS (S m + n) (⊙FinTuples (λ k → F (S (n + k))))
           ≃ᴳ⟨ transportᴳ-iso (λ s → πS s (⊙FinTuples (λ k → F (S (n + k))))) (+-βr m n) ⁻¹ᴳ ⟩
         πS (m + S n) (⊙FinTuples (λ k → F (S (n + k))))
@@ -92,11 +91,11 @@ module SpaceFromEMs {i} (F : ℕ → Ptd i)
       (cA' : (n : ℕ) → is-connected ⟨ n + m ⟩ (de⊙ (F n)))
       (n : ℕ) → is-connected ⟨ m ⟩ (FinTuplesType F n)
     connected-lemma m F cA' O =
-      Trunc-preserves-level ⟨ m ⟩ (Lift-level Unit-is-contr)
+      Trunc-preserves-level ⟨ m ⟩ ⟨⟩
     connected-lemma m F cA' (S n) = ×-conn
       (cA' O)
       (connected-lemma m (F ∘ S)
-        (λ n → connected-≤T (⟨⟩-monotone-≤ (inr ltS)) (cA' (S n))) n)
+        (λ n → connected-≤T (⟨⟩-monotone-≤ (inr ltS)) {{cA' (S n)}}) n)
 
 {- Given sequence of groups (Gₙ : n ≥ 1) such that Gₙ is abelian for n > 1,
  - construct a space X such that πₙ(X) == Gₙ. -}
@@ -108,15 +107,16 @@ module SpaceFromGroups {i} (G : ℕ → Group i)
     F O = ⊙EM₁ (G O)
     F (S n) = EMExplicit.⊙EM (G (S n) , abG-S n) (S (S n))
 
-    pF : (n : ℕ) → has-level ⟨ S n ⟩ (de⊙ (F n))
-    pF O = EM₁-level {G = G O}
-    pF (S n) = EMExplicit.EM-level (G (S n) , abG-S n) (S (S n))
+    instance
+      pF : (n : ℕ) → has-level ⟨ S n ⟩ (de⊙ (F n))
+      pF O = EM₁-level {G = G O}
+      pF (S n) = EMExplicit.EM-level (G (S n) , abG-S n) (S (S n))
 
-    cF : (n : ℕ) → is-connected ⟨ n ⟩ (de⊙ (F n))
-    cF O = EM₁-conn {G = G O}
-    cF (S n) = EMExplicit.EM-conn (G (S n) , abG-S n) (S n)
+      cF : (n : ℕ) → is-connected ⟨ n ⟩ (de⊙ (F n))
+      cF O = EM₁-conn {G = G O}
+      cF (S n) = EMExplicit.EM-conn (G (S n) , abG-S n) (S n)
 
-    module M = SpaceFromEMs F pF cF
+    module M = SpaceFromEMs F
 
   X = M.X
 

--- a/theorems/homotopy/SphereEndomorphism.agda
+++ b/theorems/homotopy/SphereEndomorphism.agda
@@ -11,7 +11,7 @@ module homotopy.SphereEndomorphism where
   ⊙SphereS-endo-out : ∀ n
     → Trunc 0 (⊙Sphere (S n) ⊙→ ⊙Sphere (S n))
     → Trunc 0 ( Sphere (S n)  →  Sphere (S n))
-  ⊙SphereS-endo-out n = Trunc-rec Trunc-level ([_] ∘ fst)
+  ⊙SphereS-endo-out n = Trunc-rec ([_] ∘ fst)
 
   -- For [S¹], the pointedness is free because of the commutativity of its loop space.
 
@@ -45,7 +45,7 @@ module homotopy.SphereEndomorphism where
 
   abstract
     ⊙S¹-endo-in-η : ∀ f → ⊙S¹-endo-in (⊙SphereS-endo-out 0 f) == f
-    ⊙S¹-endo-in-η = Trunc-elim (λ _ → =-preserves-set Trunc-level)
+    ⊙S¹-endo-in-η = Trunc-elim
       λ{(f , pt) → ap [_] $
         ⊙S¹-endo-in''-shifted pt (ap f loop) ∙ ⊙λ= (S¹-rec-η f , idp)}
       where
@@ -56,7 +56,7 @@ module homotopy.SphereEndomorphism where
       ⊙S¹-endo-in''-shifted idp _ = idp
 
     ⊙S¹-endo-out-β : ∀ f → ⊙SphereS-endo-out 0 (⊙S¹-endo-in f) == f
-    ⊙S¹-endo-out-β = Trunc-elim (λ _ → =-preserves-level Trunc-level)
+    ⊙S¹-endo-out-β = Trunc-elim
       λ f → ! (ap (λ f → [ fst (⊙S¹-endo-in' f) ]) (λ= $ S¹-rec-η f))
           ∙ ⊙S¹-endo-out'-β (f base) (ap f loop)
           ∙ ap [_] (λ= $ S¹-rec-η f)
@@ -67,7 +67,7 @@ module homotopy.SphereEndomorphism where
           == [ S¹-rec base* loop* ] :> Trunc 0 (S¹ → S¹)
         ⊙S¹-endo-out'-β = S¹-elim
           (λ loop* → ap (λ loop* → [ S¹-rec base loop* ]) (S¹Rec.loop-β base loop*))
-          (prop-has-all-paths-↓ $ Π-is-prop λ loop* → Trunc-level {n = 0} _ _)
+          prop-has-all-paths-↓
 
   ⊙S¹-endo-out-is-equiv : is-equiv (⊙SphereS-endo-out 0)
   ⊙S¹-endo-out-is-equiv = is-eq _ ⊙S¹-endo-in ⊙S¹-endo-out-β ⊙S¹-endo-in-η
@@ -76,34 +76,33 @@ module homotopy.SphereEndomorphism where
 
   private
     SphereSS-conn : ∀ n → is-connected 1 (Sphere (S (S n)))
-    SphereSS-conn n = connected-≤T (≤T-+2+-l 1 (-2≤T ⟨ n ⟩₋₂)) (Sphere-conn (S (S n)))
+    SphereSS-conn n = connected-≤T (≤T-+2+-l 1 (-2≤T ⟨ n ⟩₋₂))
 
     SphereSS-conn-path : ∀ n (x y : Sphere (S (S n))) → is-connected 0 (x == y)
     SphereSS-conn-path n x y = path-conn (SphereSS-conn n)
 
     SphereSS-has-all-trunc-paths : ∀ n (x y : Sphere (S (S n))) → Trunc 0 (x == y)
     SphereSS-has-all-trunc-paths n x y = –> (Trunc=-equiv [ x ] [ y ])
-      (contr-has-all-paths (SphereSS-conn n) [ x ] [ y ])
+      (contr-has-all-paths {{SphereSS-conn n}} [ x ] [ y ])
 
   ⊙SphereSS-endo-in : ∀ n
     → Trunc 0 ( Sphere (S (S n))  →  Sphere (S (S n)))
     → Trunc 0 (⊙Sphere (S (S n)) ⊙→ ⊙Sphere (S (S n)))
-  ⊙SphereSS-endo-in n = Trunc-rec Trunc-level λ f →
-    Trunc-rec Trunc-level (λ pt → [ f , pt ])
+  ⊙SphereSS-endo-in n = Trunc-rec λ f →
+    Trunc-rec (λ pt → [ f , pt ])
       (SphereSS-has-all-trunc-paths n (f north) north)
 
   abstract
     ⊙SphereSS-endo-in-η : ∀ n f → ⊙SphereSS-endo-in n (⊙SphereS-endo-out (S n) f) == f
-    ⊙SphereSS-endo-in-η n = Trunc-elim (λ _ → =-preserves-set Trunc-level)
-      λ{(f , pt) → ap (Trunc-rec Trunc-level (λ pt → [ f , pt ]))
-        (contr-has-all-paths (SphereSS-conn-path n (f north) north)
+    ⊙SphereSS-endo-in-η n = Trunc-elim
+      λ{(f , pt) → ap (Trunc-rec (λ pt → [ f , pt ]))
+        (contr-has-all-paths {{SphereSS-conn-path n (f north) north}}
           (SphereSS-has-all-trunc-paths n (f north) north) [ pt ])}
 
     ⊙SphereSS-endo-out-β : ∀ n f → ⊙SphereS-endo-out (S n) (⊙SphereSS-endo-in n f) == f
-    ⊙SphereSS-endo-out-β n = Trunc-elim (λ _ → =-preserves-set Trunc-level)
+    ⊙SphereSS-endo-out-β n = Trunc-elim
       λ f → Trunc-elim
-        {P = λ pt → ⊙SphereS-endo-out (S n) (Trunc-rec Trunc-level (λ pt → [ f , pt ]) pt) == [ f ]}
-        (λ _ → =-preserves-set Trunc-level)
+        {P = λ pt → ⊙SphereS-endo-out (S n) (Trunc-rec (λ pt → [ f , pt ]) pt) == [ f ]}
         (λ pt → idp) (SphereSS-has-all-trunc-paths n (f north) north)
 
   ⊙SphereSS-endo-out-is-equiv : ∀ n → is-equiv (⊙SphereS-endo-out (S n))

--- a/theorems/homotopy/VanKampen.agda
+++ b/theorems/homotopy/VanKampen.agda
@@ -19,7 +19,7 @@ module homotopy.VanKampen {i j k l}
     abstract
       lemma : ∀ c → q[ ⟧a idp₀ ] == q[ ⟧b idp₀ ] [ (λ p → code p p) ↓ glue c ]
       lemma = SurjExt.ext
-        (λ c → ↓-preserves-set SetQuot-is-set)
+        {{↓-preserves-level ⟨⟩}}
         h h-is-surj
         (λ d → from-transp (λ p → code p p) (glue (h d)) $
           transport (λ p → code p p) (glue (h d)) q[ ⟧a idp₀ ]
@@ -34,23 +34,23 @@ module homotopy.VanKampen {i j k l}
             =⟨ quot-rel (pcBBr-idp₀-idp₀ (pc-b idp₀)) ⟩
           q[ ⟧b idp₀ ]
             =∎)
-        (λ _ _ _ → prop-has-all-paths-↓ $ ↓-level SetQuot-is-set)
+        (λ _ _ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}})
 
   encode : ∀ {p₀ p₁} → p₀ =₀ p₁ → code p₀ p₁
-  encode {p₀} {p₁} pPP = transport₀ (code p₀) (code-is-set {p₀} {p₁}) pPP (encode-idp p₀)
+  encode {p₀} {p₁} pPP = transport₀ (code p₀) {{code-is-set {p₀} {p₁}}} pPP (encode-idp p₀)
 
   abstract
     decode-encode-idp : ∀ p → decode {p} {p} (encode-idp p) == idp₀
     decode-encode-idp = Pushout-elim
       {P = λ p → decode {p} {p} (encode-idp p) == idp₀}
       (λ _ → idp) (λ _ → idp)
-      (λ c → prop-has-all-paths-↓ (Trunc-level {n = 0} idp₀ (idp₀ :> Trunc 0 (right (g c) == _))))
+      (λ c → prop-has-all-paths-↓)
 
     decode-encode' : ∀ {p₀ p₁} (pPP : p₀ == p₁) → decode {p₀} {p₁} (encode [ pPP ]) == [ pPP ]
     decode-encode' idp = decode-encode-idp _
 
     decode-encode : ∀ {p₀ p₁} (pPP : p₀ =₀ p₁) → decode {p₀} {p₁} (encode pPP) == pPP
-    decode-encode = Trunc-elim (λ _ → =-preserves-set Trunc-level) decode-encode'
+    decode-encode = Trunc-elim decode-encode'
 
   abstract
     transp-idcAA-r : ∀ {a₀ a₁} (p : a₀ == a₁) -- [idc] = identity code
@@ -63,7 +63,6 @@ module homotopy.VanKampen {i j k l}
       → encode (decodeAB q[ c ]) == q[ c ]
     encode-decodeAA {a₀} (pc-a pA) = Trunc-elim
       {P = λ pA → encode (decodeAA q[ ⟧a pA ]) == q[ ⟧a pA ]}
-      (λ _ → =-preserves-set SetQuot-is-set)
       (λ pA →
         transport (codeAP a₀) (ap left pA) q[ ⟧a idp₀ ]
           =⟨ ap (λ e → coe e q[ ⟧a idp₀ ]) (∘-ap (codeAP a₀) left pA) ⟩
@@ -74,10 +73,9 @@ module homotopy.VanKampen {i j k l}
       pA
     encode-decodeAA {a₀} (pc-aba d pc pA) = Trunc-elim
       {P = λ pA → encode (decodeAA q[ pc ab⟦ d ⟧a pA ]) == q[ pc ab⟦ d ⟧a pA ]}
-      (λ _ → =-preserves-set SetQuot-is-set)
       (λ pA →
         encode (decodeAB q[ pc ] ∙₀' [ ! (glue (h d)) ∙' ap left pA ])
-          =⟨ transp₀-∙₀' (λ p₁ → code-is-set {left a₀} {p₁}) (decodeAB q[ pc ]) [ ! (glue (h d)) ∙' ap left pA ] (encode-idp (left a₀)) ⟩
+          =⟨ transp₀-∙₀' {{λ {p₁} → code-is-set {left a₀} {p₁}}} (decodeAB q[ pc ]) [ ! (glue (h d)) ∙' ap left pA ] (encode-idp (left a₀)) ⟩
         transport (codeAP a₀) (! (glue (h d)) ∙' ap left pA) (encode (decodeAB q[ pc ]))
           =⟨ ap (transport (codeAP a₀) (! (glue (h d)) ∙' ap left pA)) (encode-decodeAB pc) ⟩
         transport (codeAP a₀) (! (glue (h d)) ∙' ap left pA) q[ pc ]
@@ -95,10 +93,9 @@ module homotopy.VanKampen {i j k l}
       pA
     encode-decodeAB {a₀} (pc-aab d pc pB) = Trunc-elim
       {P = λ pB → encode (decodeAB q[ pc aa⟦ d ⟧b pB ]) == q[ pc aa⟦ d ⟧b pB ]}
-      (λ _ → =-preserves-set SetQuot-is-set)
       (λ pB →
         encode (decodeAA q[ pc ] ∙₀' [ glue (h d) ∙' ap right pB ])
-          =⟨ transp₀-∙₀' (λ p₁ → code-is-set {left a₀} {p₁}) (decodeAA q[ pc ]) [ glue (h d) ∙' ap right pB ] (encode-idp (left a₀)) ⟩
+          =⟨ transp₀-∙₀' {{λ {p₁} → code-is-set {left a₀} {p₁}}} (decodeAA q[ pc ]) [ glue (h d) ∙' ap right pB ] (encode-idp (left a₀)) ⟩
         transport (codeAP a₀) (glue (h d) ∙' ap right pB) (encode (decodeAA q[ pc ]))
           =⟨ ap (transport (codeAP a₀) (glue (h d) ∙' ap right pB)) (encode-decodeAA pc) ⟩
         transport (codeAP a₀) (glue (h d) ∙' ap right pB) q[ pc ]
@@ -127,10 +124,9 @@ module homotopy.VanKampen {i j k l}
       → encode (decodeBB q[ c ]) == q[ c ]
     encode-decodeBA {b₀} (pc-bba d pc pA) = Trunc-elim
       {P = λ pA → encode (decodeBA q[ pc bb⟦ d ⟧a pA ]) == q[ pc bb⟦ d ⟧a pA ]}
-      (λ _ → =-preserves-set SetQuot-is-set)
       (λ pA →
         encode (decodeBB q[ pc ] ∙₀' [ ! (glue (h d)) ∙' ap left pA ])
-          =⟨ transp₀-∙₀' (λ p₁ → code-is-set {right b₀} {p₁}) (decodeBB q[ pc ]) [ ! (glue (h d)) ∙' ap left pA ] (encode-idp (right b₀)) ⟩
+          =⟨ transp₀-∙₀' {{λ {p₁} → code-is-set {right b₀} {p₁}}} (decodeBB q[ pc ]) [ ! (glue (h d)) ∙' ap left pA ] (encode-idp (right b₀)) ⟩
         transport (codeBP b₀) (! (glue (h d)) ∙' ap left pA) (encode (decodeBB q[ pc ]))
           =⟨ ap (transport (codeBP b₀) (! (glue (h d)) ∙' ap left pA)) (encode-decodeBB pc) ⟩
         transport (codeBP b₀) (! (glue (h d)) ∙' ap left pA) q[ pc ]
@@ -148,7 +144,6 @@ module homotopy.VanKampen {i j k l}
       pA
     encode-decodeBB {b₀} (pc-b pB) = Trunc-elim
       {P = λ pB → encode (decodeBB q[ ⟧b pB ]) == q[ ⟧b pB ]}
-      (λ _ → =-preserves-set SetQuot-is-set)
       (λ pB →
         transport (codeBP b₀) (ap right pB) q[ ⟧b idp₀ ]
           =⟨ ap (λ e → coe e q[ ⟧b idp₀ ]) (∘-ap (codeBP b₀) right pB) ⟩
@@ -159,10 +154,9 @@ module homotopy.VanKampen {i j k l}
       pB
     encode-decodeBB {b₀} (pc-bab d pc pB) = Trunc-elim
       {P = λ pB → encode (decodeBB q[ pc ba⟦ d ⟧b pB ]) == q[ pc ba⟦ d ⟧b pB ]}
-      (λ _ → =-preserves-set SetQuot-is-set)
       (λ pB →
         encode (decodeBA q[ pc ] ∙₀' [ glue (h d) ∙' ap right pB ])
-          =⟨ transp₀-∙₀' (λ p₁ → code-is-set {right b₀} {p₁}) (decodeBA q[ pc ]) [ glue (h d) ∙' ap right pB ] (encode-idp (right b₀)) ⟩
+          =⟨ transp₀-∙₀' {{λ {p₁} → code-is-set {right b₀} {p₁}}} (decodeBA q[ pc ]) [ glue (h d) ∙' ap right pB ] (encode-idp (right b₀)) ⟩
         transport (codeBP b₀) (glue (h d) ∙' ap right pB) (encode (decodeBA q[ pc ]))
           =⟨ ap (transport (codeBP b₀) (glue (h d) ∙' ap right pB)) (encode-decodeBA pc) ⟩
         transport (codeBP b₀) (glue (h d) ∙' ap right pB) q[ pc ]
@@ -187,28 +181,24 @@ module homotopy.VanKampen {i j k l}
       (λ a₀ → Pushout-elim
         (λ a₁ → SetQuot-elim
           {P = λ cPP → encode (decodeAA cPP) == cPP}
-          (λ _ → =-preserves-set SetQuot-is-set)
           (encode-decodeAA {a₀} {a₁})
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _)))
+          (λ _ → prop-has-all-paths-↓))
         (λ b₁ → SetQuot-elim
           {P = λ cPP → encode (decodeAB cPP) == cPP}
-          (λ _ → =-preserves-set SetQuot-is-set)
           (encode-decodeAB {a₀} {b₁})
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _)))
-        (λ _ → prop-has-all-paths-↓ $ Π-is-prop λ cPP → SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓))
       (λ b₀ → Pushout-elim
         (λ a₁ → SetQuot-elim
           {P = λ cPP → encode (decodeBA cPP) == cPP}
-          (λ _ → =-preserves-set SetQuot-is-set)
           (encode-decodeBA {b₀} {a₁})
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _)))
+          (λ _ → prop-has-all-paths-↓))
         (λ b₁ → SetQuot-elim
           {P = λ cPP → encode (decodeBB cPP) == cPP}
-          (λ _ → =-preserves-set SetQuot-is-set)
           (encode-decodeBB {b₀} {b₁})
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _)))
-        (λ _ → prop-has-all-paths-↓ $ Π-is-prop λ cPP → SetQuot-is-set _ _))
-      (λ _ → prop-has-all-paths-↓ $ Π-is-prop λ p₁ → Π-is-prop λ cPP → codeBP-is-set {p₁ = p₁} _ _)
+          (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓))
+      (λ _ → prop-has-all-paths-↓ {{Π-level (λ p₁ → Π-level (λ cPP → has-level-apply (codeBP-is-set {p₁ = p₁}) _ _))}})
       p₀ p₁
 
   vankampen : ∀ p₀ p₁ → (p₀ =₀ p₁) ≃ code p₀ p₁

--- a/theorems/homotopy/WedgeExtension.agda
+++ b/theorems/homotopy/WedgeExtension.agda
@@ -9,8 +9,8 @@ module homotopy.WedgeExtension
   record args : Type (lmax (lsucc i) (lsucc j)) where
     field
       n m : ℕ₋₂
-      cA : is-connected (S n) A
-      cB : is-connected (S m) B
+      {{cA}} : is-connected (S n) A
+      {{cB}} : is-connected (S m) B
       P : A → B → (n +2+ m) -Type (lmax i j)
       f : (a : A) → fst (P a b₀)
       g : (b : B) → fst (P a₀ b)
@@ -22,11 +22,11 @@ module homotopy.WedgeExtension
 
       Q : A → n -Type (lmax i j)
       Q a = ((Σ (∀ b → fst (P a b)) (λ k → (k ∘ cst b₀) == cst (f a)) ,
-                conn-extend-general (pointed-conn-out B b₀ cB)
+                conn-extend-general (pointed-conn-out B b₀)
                                     (P a) (cst (f a))))
 
       l : Π A (fst ∘ Q)
-      l = conn-extend (pointed-conn-out A a₀ cA)
+      l = conn-extend (pointed-conn-out A a₀)
                       Q (λ (_ : Unit) → (g , ap cst (! p)))
 
 
@@ -47,7 +47,7 @@ module homotopy.WedgeExtension
       abstract
         β-r-aux : fst (l r a₀) == g
         β-r-aux = fst= (conn-extend-β
-          (pointed-conn-out A a₀ cA)
+          (pointed-conn-out A a₀)
           (Q r) (λ (_ : Unit) → (g , ap cst (! p))) unit)
 
     abstract
@@ -72,7 +72,7 @@ module homotopy.WedgeExtension
         lemma₁ : β-l a₀ == ap (λ s → s unit) (ap cst (! p))
                  [ (λ k → k b₀ == f a₀) ↓ β-r-aux ]
         lemma₁ = ap↓ (ap (λ s → s unit)) $
-                      snd= (conn-extend-β (pointed-conn-out A a₀ cA)
+                      snd= (conn-extend-β (pointed-conn-out A a₀)
                            (Q r) (λ (_ : Unit) → (g , ap cst (! p))) unit)
 
         lemma₂ : β-r b₀ ∙ ! p == β-l a₀

--- a/theorems/homotopy/blakersmassey/CoherenceData.agda
+++ b/theorems/homotopy/blakersmassey/CoherenceData.agda
@@ -123,7 +123,7 @@ to : ∀ {a₀ a₁ b₀ b₁} (q₀₀ : Q a₀ b₀) (q₁₁ : Q a₁ b₁)
   → (r : bmleft a₀ == bmright b₁)
   → Trunc (m +2+ n) (hfiber (λ q₁₀ → bmglue q₀₀ ∙' ! (bmglue q₁₀) ∙' bmglue q₁₁) r)
   → Trunc (m +2+ n) (hfiber bmglue r)
-to q₀₀ q₁₁ r = Trunc-rec Trunc-level (to' q₀₀ q₁₁ r)
+to q₀₀ q₁₁ r = Trunc-rec (to' q₀₀ q₁₁ r)
 
 module From {a₀ b₁} (q₀₁ : Q a₀ b₁) where
   U = Σ A λ a → Q a b₁
@@ -197,7 +197,7 @@ from : ∀ {a₀ a₁ b₀ b₁} (q₀₀ : Q a₀ b₀) (q₁₁ : Q a₁ b₁)
   → (r : bmleft a₀ == bmright b₁)
   → Trunc (m +2+ n) (hfiber bmglue r)
   → Trunc (m +2+ n) (hfiber (λ q₁₀ → bmglue q₀₀ ∙' ! (bmglue q₁₀) ∙' bmglue q₁₁) r)
-from q₀₀ q₁₁ r = Trunc-rec Trunc-level (from' q₀₀ q₁₁ r)
+from q₀₀ q₁₁ r = Trunc-rec (from' q₀₀ q₁₁ r)
 
 -- Equivalence
 
@@ -346,7 +346,7 @@ abstract
 
   from-to : ∀ {a₀ a₁ b₀ b₁} (q₀₀ : Q a₀ b₀) (q₁₁ : Q a₁ b₁) r fiber
     → from q₀₀ q₁₁ r (to q₀₀ q₁₁ r fiber) == fiber
-  from-to q₀₀ q₁₁ r = Trunc-elim (λ _ → =-preserves-level Trunc-level) (from-to' q₀₀ q₁₁ r)
+  from-to q₀₀ q₁₁ r = Trunc-elim (from-to' q₀₀ q₁₁ r)
 
 module ToFrom {a₀ b₁} (q₀₁ : Q a₀ b₁) where
   -- upper
@@ -402,7 +402,7 @@ abstract
 
   to-from : ∀ {a₀ a₁ b₀ b₁} (q₀₀ : Q a₀ b₀) (q₁₁ : Q a₁ b₁) r fiber
     → to q₀₀ q₁₁ r (from q₀₀ q₁₁ r fiber) == fiber
-  to-from q₀₀ q₁₁ r = Trunc-elim (λ _ → =-preserves-level Trunc-level) (to-from' q₀₀ q₁₁ r)
+  to-from q₀₀ q₁₁ r = Trunc-elim (to-from' q₀₀ q₁₁ r)
 
 eqv : ∀ {a₀ a₁ b₀ b₁} (q₀₀ : Q a₀ b₀) (q₁₁ : Q a₁ b₁) r
   → Trunc (m +2+ n) (hfiber (λ q₁₀ → bmglue q₀₀ ∙' ! (bmglue q₁₀) ∙' bmglue q₁₁) r)

--- a/theorems/homotopy/elims/SuspSmash.agda
+++ b/theorems/homotopy/elims/SuspSmash.agda
@@ -56,7 +56,7 @@ private
       ∙ ap (λ sp → fst (fill-template (snd sp)
                                       (fst fill-base ◃ smin* (pt X) (pt Y))
                                       (smbase*-template (snd sp))))
-           (contr-has-all-paths (pathfrom-is-contr (smin (pt X) (pt Y)))
+           (contr-has-all-paths {{pathfrom-is-contr (smin (pt X) (pt Y))}}
                                 (smbasel , smgluel (pt X))
                                 (smbaser , smgluer (pt Y)))
 

--- a/theorems/homotopy/vankampen/Code.agda
+++ b/theorems/homotopy/vankampen/Code.agda
@@ -31,9 +31,9 @@ module homotopy.vankampen.Code {i j k l}
     pcAB-to-pcBB-rel d₀ (pcABr-cong r pB) = pcBBr-cong (pcAA-to-pcBA-rel d₀ r) pB
 
   cAA-to-cBA : ∀ d₀ {a} → codeAA (f (h d₀)) a → codeBA (g (h d₀)) a
-  cAA-to-cBA d₀ = SetQuot-rec SetQuot-level (q[_] ∘ pcAA-to-pcBA d₀) (quot-rel ∘ pcAA-to-pcBA-rel d₀)
+  cAA-to-cBA d₀ = SetQuot-rec (q[_] ∘ pcAA-to-pcBA d₀) (quot-rel ∘ pcAA-to-pcBA-rel d₀)
   cAB-to-cBB : ∀ d₀ {b} → codeAB (f (h d₀)) b → codeBB (g (h d₀)) b
-  cAB-to-cBB d₀ = SetQuot-rec SetQuot-level (q[_] ∘ pcAB-to-pcBB d₀) (quot-rel ∘ pcAB-to-pcBB-rel d₀)
+  cAB-to-cBB d₀ = SetQuot-rec (q[_] ∘ pcAB-to-pcBB d₀) (quot-rel ∘ pcAB-to-pcBB-rel d₀)
 
   -- BX to AX
   pcBA-to-pcAA : ∀ d₀ {a} → precodeBA (g (h d₀)) a → precodeAA (f (h d₀)) a
@@ -56,9 +56,9 @@ module homotopy.vankampen.Code {i j k l}
     pcBB-to-pcAB-rel d₀ (pcBBr-cong r pB) = pcABr-cong (pcBA-to-pcAA-rel d₀ r) pB
 
   cBA-to-cAA : ∀ d₀ {a} → codeBA (g (h d₀)) a → codeAA (f (h d₀)) a
-  cBA-to-cAA d₀ = SetQuot-rec SetQuot-level (q[_] ∘ pcBA-to-pcAA d₀) (quot-rel ∘ pcBA-to-pcAA-rel d₀)
+  cBA-to-cAA d₀ = SetQuot-rec (q[_] ∘ pcBA-to-pcAA d₀) (quot-rel ∘ pcBA-to-pcAA-rel d₀)
   cBB-to-cAB : ∀ d₀ {b} → codeBB (g (h d₀)) b → codeAB (f (h d₀)) b
-  cBB-to-cAB d₀ = SetQuot-rec SetQuot-level (q[_] ∘ pcBB-to-pcAB d₀) (quot-rel ∘ pcBB-to-pcAB-rel d₀)
+  cBB-to-cAB d₀ = SetQuot-rec (q[_] ∘ pcBB-to-pcAB d₀) (quot-rel ∘ pcBB-to-pcAB-rel d₀)
 
   -- roundtrips
   abstract
@@ -110,15 +110,13 @@ module homotopy.vankampen.Code {i j k l}
       abstract
         to-from : ∀ cBA → to (from cBA) == cBA
         to-from = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (pcBA-to-pcAA-to-pcBA d₀)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
         from-to : ∀ cAA → from (to cAA) == cAA
         from-to = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (pcAA-to-pcBA-to-pcAA d₀)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
     abstract
       eqv-is-const : ∀ d₁ d₂ (p : h d₁ == h d₂)
@@ -126,7 +124,7 @@ module homotopy.vankampen.Code {i j k l}
         [ (λ c → codeAA (f c) a₁ ≃ codeBA (g c) a₁) ↓ p ]
       eqv-is-const d₁ d₂ p = ↓-Subtype-in (λ d → is-equiv-prop) $
         ↓-→-from-transp $ λ= $
-          SetQuot-elim (λ _ → =-preserves-set SetQuot-is-set)
+          SetQuot-elim
             (λ pcAA →
               transport (λ c → codeBA (g c) a₁) p q[ pcAA-to-pcBA d₁ pcAA ]
                 =⟨ ap-∘ (λ b → codeBA b a₁) g p |in-ctx (λ p → coe p q[ pcAA-to-pcBA d₁ pcAA ]) ⟩
@@ -144,10 +142,9 @@ module homotopy.vankampen.Code {i j k l}
                 =⟨ ∘-ap (λ c → codeAA c a₁) f p |in-ctx (λ p → coe p q[ pcAA ]) |in-ctx cAA-to-cBA d₂ ⟩
               cAA-to-cBA d₂ (transport (λ c → codeAA (f c) a₁) p q[ pcAA ])
                 =∎)
-            (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+            (λ _ → prop-has-all-paths-↓)
 
     module SE = SurjExt
-      (λ c → ≃-is-set SetQuot-is-set SetQuot-is-set)
       h h-is-surj
       eqv-on-image
       eqv-is-const
@@ -172,15 +169,13 @@ module homotopy.vankampen.Code {i j k l}
       abstract
         to-from : ∀ cBB → to (from cBB) == cBB
         to-from = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (pcBB-to-pcAB-to-pcBB d₀)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
         from-to : ∀ cAB → from (to cAB) == cAB
         from-to = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (pcAB-to-pcBB-to-pcAB d₀)
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
     abstract
       eqv-is-const : ∀ d₁ d₂ (p : h d₁ == h d₂)
@@ -188,7 +183,7 @@ module homotopy.vankampen.Code {i j k l}
         [ (λ c → codeAB (f c) b₁ ≃ codeBB (g c) b₁) ↓ p ]
       eqv-is-const d₁ d₂ p = ↓-Subtype-in (λ d → is-equiv-prop) $
         ↓-→-from-transp $ λ= $
-          SetQuot-elim (λ _ → =-preserves-set SetQuot-is-set)
+          SetQuot-elim
             (λ pcAB →
               transport (λ c → codeBB (g c) b₁) p q[ pcAB-to-pcBB d₁ pcAB ]
                 =⟨ ap-∘ (λ b → codeBB b b₁) g p |in-ctx (λ p → coe p q[ pcAB-to-pcBB d₁ pcAB ]) ⟩
@@ -206,10 +201,9 @@ module homotopy.vankampen.Code {i j k l}
                 =⟨ ∘-ap (λ c → codeAB c b₁) f p |in-ctx (λ p → coe p q[ pcAB ]) |in-ctx cAB-to-cBB d₂ ⟩
               cAB-to-cBB d₂ (transport (λ c → codeAB (f c) b₁) p q[ pcAB ])
                 =∎)
-            (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+            (λ _ → prop-has-all-paths-↓)
 
     module SE = SurjExt
-      (λ c → ≃-is-set SetQuot-is-set SetQuot-is-set)
       h h-is-surj
       eqv-on-image
       eqv-is-const
@@ -236,7 +230,6 @@ module homotopy.vankampen.Code {i j k l}
              [ (λ p → codeAP (f (h d₀)) p ≃ codeBP (g (h d₀)) p) ↓ glue (h d₁) ]
         lemma = ↓-Subtype-in (λ d → is-equiv-prop) $
           ↓-→-from-transp $ λ= $ SetQuot-elim
-            (λ _ → =-preserves-set SetQuot-is-set)
             (λ pcAA →
               transport (λ p → codeBP (g (h d₀)) p) (glue (h d₁)) q[ pcAA-to-pcBA d₀ pcAA ]
                 =⟨ transp-cBP-glue d₁ (pcAA-to-pcBA d₀ pcAA) ⟩
@@ -244,7 +237,7 @@ module homotopy.vankampen.Code {i j k l}
                 =⟨ ! $ transp-cAP-glue d₁ pcAA |in-ctx cAB-to-cBB d₀ ⟩
               cAB-to-cBB d₀ (transport (λ p → codeAP (f (h d₀)) p) (glue (h d₁)) q[ pcAA ])
                 =∎)
-            (λ _ → prop-has-all-paths-↓ $ SetQuot-is-set _ _)
+            (λ _ → prop-has-all-paths-↓)
 
     abstract
       path : ∀ c₀ c₁
@@ -252,14 +245,14 @@ module homotopy.vankampen.Code {i j k l}
         == CodeABEquivCodeBB.eqv (g c₁) c₀
         [ (λ p → codeAP (f c₀) p ≃ codeBP (g c₀) p) ↓ glue c₁ ]
       path = SurjExt.ext
-        (λ c₀ → Π-is-set λ c₁ → ↓-preserves-level $ ≃-is-set SetQuot-is-set SetQuot-is-set)
+        {{Π-level (λ _ → ↓-preserves-level ⟨⟩)}}
         h h-is-surj
         (λ d₀ → SurjExt.ext
-          (λ c₁ → ↓-preserves-level $ ≃-is-set SetQuot-is-set SetQuot-is-set)
+          {{↓-preserves-level ⟨⟩}}
           h h-is-surj
           (λ d₁ → path-on-image d₀ d₁)
-          (λ _ _ _ → prop-has-all-paths-↓ $ ↓-level $ ≃-is-set SetQuot-is-set SetQuot-is-set))
-        (λ _ _ _ → prop-has-all-paths-↓ $ Π-is-prop λ _ → ↓-level $ ≃-is-set SetQuot-is-set SetQuot-is-set)
+          (λ _ _ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}}))
+        (λ _ _ _ → prop-has-all-paths-↓ {{Π-level (λ _ → ↓-level ⟨⟩)}})
 
 
   cAP-equiv-cBP : ∀ c₀ p₁ → codeAP (f c₀) p₁ ≃ codeBP (g c₀) p₁
@@ -282,8 +275,9 @@ module homotopy.vankampen.Code {i j k l}
       {P = λ p₀ → ∀ p₁ → is-set (code p₀ p₁)}
       (λ a₀ p₁ → codeAP-level {a₀} {p₁})
       (λ b₀ p₁ → codeBP-level {b₀} {p₁})
-      (λ c₀ → prop-has-all-paths-↓ $ Π-is-prop λ p₁ → is-set-is-prop)
+      (λ c₀ → prop-has-all-paths-↓)
       p₀ p₁
+
   code-is-set = code-level
 
   abstract
@@ -336,11 +330,10 @@ module homotopy.vankampen.Code {i j k l}
       decodeAA {f c₀} {a₁} == decodeBA {g c₀} {a₁}
       [ (λ p₀ → code p₀ (left a₁) → p₀ =₀ left a₁) ↓ glue c₀ ]
     decodeAA-is-decodeBA {a₁ = a₁} = SurjExt.ext
-      (λ _ → ↓-preserves-level $ Π-is-set λ _ → Trunc-level) h h-is-surj
+      {{↓-preserves-level ⟨⟩}} h h-is-surj
       (λ d₀ → ↓-→-from-transp $ λ= $ SetQuot-elim
         {P = λ cAA → transport (_=₀ left a₁) (glue (h d₀)) (decodeAA cAA)
                   == decodeBA (transport (λ p₀ → code p₀ (left a₁)) (glue (h d₀)) cAA)}
-        (λ _ → =-preserves-set Trunc-level)
         (λ pcAA →
           transport (_=₀ left a₁) (glue (h d₀)) (pcAA-to-path pcAA)
             =⟨ transp₀-idf=₀cst [ glue (h d₀) ] (pcAA-to-path pcAA) ⟩
@@ -360,19 +353,18 @@ module homotopy.vankampen.Code {i j k l}
             =⟨ ap (λ p → decodeBA (coe p q[ pcAA ])) (∘-ap (λ f₁ → f₁ (left a₁)) code (glue (h d₀))) ⟩
           decodeBA (transport (λ p₀ → code p₀ (left a₁)) (glue (h d₀)) q[ pcAA ])
             =∎)
-        (λ _ → prop-has-all-paths-↓ $ Trunc-level {n = 0} _ _))
-      (λ _ _ _ → prop-has-all-paths-↓ $ ↓-level $ Π-is-set λ _ → Trunc-level)
+        (λ _ → prop-has-all-paths-↓))
+      (λ _ _ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}})
 
   abstract
     decodeAB-is-decodeBB : ∀ {b₁} c₀ →
       decodeAB {f c₀} {b₁} == decodeBB {g c₀} {b₁}
       [ (λ p₀ → code p₀ (right b₁) → p₀ =₀ right b₁) ↓ glue c₀ ]
     decodeAB-is-decodeBB {b₁ = b₁} = SurjExt.ext
-      (λ _ → ↓-preserves-level $ Π-is-set λ _ → Trunc-level) h h-is-surj
+      {{↓-preserves-level ⟨⟩}} h h-is-surj
       (λ d₀ → ↓-→-from-transp $ λ= $ SetQuot-elim
         {P = λ cAB → transport (_=₀ right b₁) (glue (h d₀)) (decodeAB cAB)
                   == decodeBB (transport (λ p₀ → code p₀ (right b₁)) (glue (h d₀)) cAB)}
-        (λ _ → =-preserves-set Trunc-level)
         (λ pcAB →
           transport (_=₀ right b₁) (glue (h d₀)) (pcAB-to-path pcAB)
             =⟨ transp₀-idf=₀cst [ glue (h d₀) ] (pcAB-to-path pcAB) ⟩
@@ -392,8 +384,8 @@ module homotopy.vankampen.Code {i j k l}
             =⟨ ap (λ p → decodeBB (coe p q[ pcAB ])) (∘-ap (λ f₁ → f₁ (right b₁)) code (glue (h d₀))) ⟩
           decodeBB (transport (λ p₀ → code p₀ (right b₁)) (glue (h d₀)) q[ pcAB ])
             =∎)
-        (λ _ → prop-has-all-paths-↓ $ Trunc-level {n = 0} _ _))
-      (λ _ _ _ → prop-has-all-paths-↓ $ ↓-level $ Π-is-set λ _ → Trunc-level)
+        (λ _ → prop-has-all-paths-↓))
+      (λ _ _ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}})
 
   abstract
     decodeAP-is-decodeBP : ∀ c₀ p₁
@@ -404,7 +396,7 @@ module homotopy.vankampen.Code {i j k l}
         [ (λ p₀ → code p₀ p₁ → p₀ =₀ p₁) ↓ glue c₀ ]}
       (λ a₁ → decodeAA-is-decodeBA {a₁ = a₁} c₀)
       (λ b₁ → decodeAB-is-decodeBB {b₁ = b₁} c₀)
-      (λ _ → prop-has-all-paths-↓ $ ↓-level $ Π-is-set λ _ → Trunc-level)
+      (λ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}})
 
   decode : ∀ {p₀ p₁} → code p₀ p₁ → p₀ =₀ p₁
   decode {p₀} {p₁} = Pushout-elim

--- a/theorems/homotopy/vankampen/CodeAP.agda
+++ b/theorems/homotopy/vankampen/CodeAP.agda
@@ -51,12 +51,12 @@ module homotopy.vankampen.CodeAP {i j k l}
   codeAB a₀ b₁ = SetQuot (precodeAB-rel {a₀} {b₁})
 
   c-aba : ∀ {a₀} d {a₁} (pc : codeAB a₀ (g (h d))) (pA : f (h d) =₀ a₁) → codeAA a₀ a₁
-  c-aba d {a₁} c pA = SetQuot-rec SetQuot-is-set
+  c-aba d {a₁} c pA = SetQuot-rec
     (λ pc → q[ pc-aba d pc pA ])
     (λ r → quot-rel $ pcAAr-cong r pA) c
 
   c-aab : ∀ {a₀} d {b₁} (pc : codeAA a₀ (f (h d))) (pB : g (h d) =₀ b₁) → codeAB a₀ b₁
-  c-aab d {a₁} c pB = SetQuot-rec SetQuot-is-set
+  c-aab d {a₁} c pB = SetQuot-rec
     (λ pc → q[ pc-aab d pc pB ])
     (λ r → quot-rel $ pcABr-cong r pB) c
 
@@ -65,7 +65,7 @@ module homotopy.vankampen.CodeAP {i j k l}
   abstract
     pcAA-idp₀-idp₀-head : ∀ {d₀ a} (pA : f (h d₀) =₀ a)
       → q[ ⟧a idp₀ aa⟦ d₀ ⟧b idp₀ ab⟦ d₀ ⟧a pA ] == q[ ⟧a pA ] :> codeAA _ a
-    pcAA-idp₀-idp₀-head {d₀} = Trunc-elim (λ _ → =-preserves-set SetQuot-is-set) lemma where
+    pcAA-idp₀-idp₀-head {d₀} = Trunc-elim lemma where
       lemma : ∀ {a} (pA : f (h d₀) == a)
         → q[ ⟧a idp₀ aa⟦ d₀ ⟧b idp₀ ab⟦ d₀ ⟧a [ pA ] ] == q[ ⟧a [ pA ] ] :> codeAA _ a
       lemma idp = quot-rel $ pcAAr-idp₀-idp₀ (⟧a idp₀)
@@ -111,15 +111,13 @@ module homotopy.vankampen.CodeAP {i j k l}
       abstract
         from-to : ∀ cAA → from (to cAA) == cAA
         from-to = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (λ pcAA → quot-rel (pcAAr-idp₀-idp₀ pcAA))
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
         to-from : ∀ cAB → to (from cAB) == cAB
         to-from = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (λ pcAB → quot-rel (pcABr-idp₀-idp₀ pcAB))
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
     abstract
       eqv-is-const : ∀ d₁ d₂ (p : h d₁ == h d₂)
@@ -127,7 +125,7 @@ module homotopy.vankampen.CodeAP {i j k l}
         [ (λ c → codeAA a₀ (f c) ≃ codeAB a₀ (g c)) ↓ p ]
       eqv-is-const d₁ d₂ p = ↓-Subtype-in (λ d → is-equiv-prop) $
         ↓-→-from-transp $ λ= $
-          SetQuot-elim (λ _ → =-preserves-set SetQuot-is-set)
+          SetQuot-elim
             (λ pcAA →
               transport (λ c → codeAB a₀ (g c)) p q[ pcAA aa⟦ d₁ ⟧b idp₀ ]
                 =⟨ ap-∘ (codeAB a₀) g p |in-ctx (λ p → coe p q[ pcAA aa⟦ d₁ ⟧b idp₀ ]) ⟩
@@ -141,10 +139,9 @@ module homotopy.vankampen.CodeAP {i j k l}
                 =⟨ ∘-ap (codeAA a₀) f p |in-ctx (λ p → coe p q[ pcAA ]) |in-ctx (λ c → c-aab d₂ c idp₀) ⟩
               c-aab d₂ (transport (λ c → codeAA a₀ (f c)) p q[ pcAA ]) idp₀
                 =∎)
-            (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+            (λ _ → prop-has-all-paths-↓)
 
     module SE = SurjExt
-      (λ c → ≃-is-set SetQuot-is-set SetQuot-is-set)
       h h-is-surj
       eqv-on-image
       eqv-is-const
@@ -168,7 +165,7 @@ module homotopy.vankampen.CodeAP {i j k l}
       {P = λ p₁ → is-set (codeAP a₀ p₁)}
       (λ a₁ → SetQuot-is-set)
       (λ b₁ → SetQuot-is-set)
-      (λ c₁ → prop-has-all-paths-↓ is-set-is-prop)
+      (λ c₁ → prop-has-all-paths-↓)
       p₁
   codeAP-is-set = codeAP-level
 
@@ -230,24 +227,23 @@ module homotopy.vankampen.CodeAP {i j k l}
         natural₀ : ∀ {c₀ c₁} (p : c₀ =₀ c₁)
           → (ap₀ left (ap₀ f p) ∙₀' [ glue c₁ ]) == ([ glue c₀ ] ∙₀' ap₀ right (ap₀ g p))
           :> (left (f c₀) =₀ right (g c₁) :> Pushout span)
-        natural₀ = Trunc-elim (λ _ → =-preserves-set Trunc-level) (ap [_] ∘ natural)
+        natural₀ = Trunc-elim (ap [_] ∘ natural)
     pcAB-to-path-rel (pcABr-cong pcAA pB) = pcAA-to-path-rel pcAA |in-ctx _∙₀' [ glue (h _) ] ∙₀' ap₀ right pB
 
   decodeAA : ∀ {a₀ a₁} → codeAA a₀ a₁ → left a₀ =₀ left a₁ :> Pushout span
   decodeAB : ∀ {a₀ b₁} → codeAB a₀ b₁ → left a₀ =₀ right b₁ :> Pushout span
-  decodeAA = SetQuot-rec Trunc-level pcAA-to-path pcAA-to-path-rel
-  decodeAB = SetQuot-rec Trunc-level pcAB-to-path pcAB-to-path-rel
+  decodeAA = SetQuot-rec pcAA-to-path pcAA-to-path-rel
+  decodeAB = SetQuot-rec pcAB-to-path pcAB-to-path-rel
 
   abstract
     decodeAA-is-decodeAB : ∀ {a₀} c₁ →
       decodeAA {a₀} {f c₁} == decodeAB {a₀} {g c₁}
       [ (λ p₁ → codeAP a₀ p₁ → left a₀ =₀ p₁) ↓ glue c₁ ]
     decodeAA-is-decodeAB {a₀ = a₀} = SurjExt.ext
-      (λ _ → ↓-preserves-level $ Π-is-set λ _ → Trunc-level) h h-is-surj
+      {{↓-preserves-level ⟨⟩}} h h-is-surj
       (λ d₁ → ↓-→-from-transp $ λ= $ SetQuot-elim
         {P = λ cAA → transport (left a₀ =₀_) (glue (h d₁)) (decodeAA cAA)
                   == decodeAB (transport (codeAP a₀) (glue (h d₁)) cAA)}
-        (λ _ → =-preserves-set Trunc-level)
         (λ pcAA →
           transport (left a₀ =₀_) (glue (h d₁)) (pcAA-to-path pcAA)
             =⟨ transp₀-cst=₀idf [ glue (h d₁) ] (pcAA-to-path pcAA) ⟩
@@ -259,8 +255,8 @@ module homotopy.vankampen.CodeAP {i j k l}
             =⟨ ! $ ap (λ p → decodeAB (coe p q[ pcAA ])) (CodeAP.glue-β a₀ (h d₁)) ⟩
           decodeAB (transport (codeAP a₀) (glue (h d₁)) q[ pcAA ])
             =∎)
-        (λ _ → prop-has-all-paths-↓ $ Trunc-level {n = 0} _ _))
-      (λ _ _ _ → prop-has-all-paths-↓ $ ↓-level $ Π-is-set λ _ → Trunc-level)
+        (λ _ → prop-has-all-paths-↓))
+      (λ _ _ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}})
 
   decodeAP : ∀ {a₀ p₁} → codeAP a₀ p₁ → left a₀ =₀ p₁
   decodeAP {p₁ = p₁} = Pushout-elim

--- a/theorems/homotopy/vankampen/CodeBP.agda
+++ b/theorems/homotopy/vankampen/CodeBP.agda
@@ -51,12 +51,12 @@ module homotopy.vankampen.CodeBP {i j k l}
   codeBA b₀ a₁ = SetQuot (precodeBA-rel {b₀} {a₁})
 
   c-bba : ∀ {a₀} d {a₁} (pc : codeBB a₀ (g (h d))) (pA : f (h d) =₀ a₁) → codeBA a₀ a₁
-  c-bba d {a₁} c pA = SetQuot-rec SetQuot-is-set
+  c-bba d {a₁} c pA = SetQuot-rec
     (λ pc → q[ pc-bba d pc pA ])
     (λ r → quot-rel $ pcBAr-cong r pA) c
 
   c-bab : ∀ {a₀} d {b₁} (pc : codeBA a₀ (f (h d))) (pB : g (h d) =₀ b₁) → codeBB a₀ b₁
-  c-bab d {a₁} c pB = SetQuot-rec SetQuot-is-set
+  c-bab d {a₁} c pB = SetQuot-rec
     (λ pc → q[ pc-bab d pc pB ])
     (λ r → quot-rel $ pcBBr-cong r pB) c
 
@@ -65,7 +65,7 @@ module homotopy.vankampen.CodeBP {i j k l}
   abstract
     pcBB-idp₀-idp₀-head : ∀ {d₀ b} (pB : g (h d₀) =₀ b)
       → q[ ⟧b idp₀ bb⟦ d₀ ⟧a idp₀ ba⟦ d₀ ⟧b pB ] == q[ ⟧b pB ] :> codeBB _ b
-    pcBB-idp₀-idp₀-head {d₀} = Trunc-elim (λ _ → =-preserves-set SetQuot-is-set) lemma where
+    pcBB-idp₀-idp₀-head {d₀} = Trunc-elim lemma where
       lemma : ∀ {b} (pB : g (h d₀) == b)
         → q[ ⟧b idp₀ bb⟦ d₀ ⟧a idp₀ ba⟦ d₀ ⟧b [ pB ] ] == q[ ⟧b [ pB ] ] :> codeBB _ b
       lemma idp = quot-rel $ pcBBr-idp₀-idp₀ (⟧b idp₀)
@@ -111,15 +111,13 @@ module homotopy.vankampen.CodeBP {i j k l}
       abstract
         from-to : ∀ cBA → from (to cBA) == cBA
         from-to = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (λ pcBA → quot-rel (pcBAr-idp₀-idp₀ pcBA))
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
         to-from : ∀ cBB → to (from cBB) == cBB
         to-from = SetQuot-elim
-          (λ _ → =-preserves-set SetQuot-is-set)
           (λ pcBB → quot-rel (pcBBr-idp₀-idp₀ pcBB))
-          (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+          (λ _ → prop-has-all-paths-↓)
 
     abstract
       eqv-is-const : ∀ d₁ d₂ (p : h d₁ == h d₂)
@@ -127,7 +125,7 @@ module homotopy.vankampen.CodeBP {i j k l}
         [ (λ c → codeBA b₀ (f c) ≃ codeBB b₀ (g c)) ↓ p ]
       eqv-is-const d₁ d₂ p = ↓-Subtype-in (λ d → is-equiv-prop) $
         ↓-→-from-transp $ λ= $
-          SetQuot-elim (λ _ → =-preserves-set SetQuot-is-set)
+          SetQuot-elim
             (λ pcBA →
               transport (λ c → codeBB b₀ (g c)) p q[ pcBA ba⟦ d₁ ⟧b idp₀ ]
                 =⟨ ap-∘ (codeBB b₀) g p |in-ctx (λ p → coe p q[ pcBA ba⟦ d₁ ⟧b idp₀ ]) ⟩
@@ -141,10 +139,9 @@ module homotopy.vankampen.CodeBP {i j k l}
                 =⟨ ∘-ap (codeBA b₀) f p |in-ctx (λ p → coe p q[ pcBA ]) |in-ctx (λ c → c-bab d₂ c idp₀) ⟩
               c-bab d₂ (transport (λ c → codeBA b₀ (f c)) p q[ pcBA ]) idp₀
                 =∎)
-            (λ _ → prop-has-all-paths-↓ (SetQuot-is-set _ _))
+            (λ _ → prop-has-all-paths-↓)
 
     module SE = SurjExt
-      (λ c → ≃-is-set SetQuot-is-set SetQuot-is-set)
       h h-is-surj
       eqv-on-image
       eqv-is-const
@@ -168,7 +165,7 @@ module homotopy.vankampen.CodeBP {i j k l}
       {P = λ p₁ → is-set (codeBP a₀ p₁)}
       (λ a₁ → SetQuot-is-set)
       (λ b₁ → SetQuot-is-set)
-      (λ c₁ → prop-has-all-paths-↓ is-set-is-prop)
+      (λ c₁ → prop-has-all-paths-↓)
       p₁
   codeBP-is-set = codeBP-level
 
@@ -230,24 +227,23 @@ module homotopy.vankampen.CodeBP {i j k l}
         natural₀ : ∀ {c₀ c₁} (p : c₀ =₀ c₁)
           → (ap₀ left (ap₀ f p) ∙₀' [ glue c₁ ]) == ([ glue c₀ ] ∙₀' ap₀ right (ap₀ g p))
           :> (left (f c₀) =₀ right (g c₁) :> Pushout span)
-        natural₀ = Trunc-elim (λ _ → =-preserves-set Trunc-level) (ap [_] ∘ natural)
+        natural₀ = Trunc-elim (ap [_] ∘ natural)
     pcBB-to-path-rel (pcBBr-cong pcBA pB) = pcBA-to-path-rel pcBA |in-ctx _∙₀' [ glue (h _) ] ∙₀' ap₀ right pB
 
   decodeBA : ∀ {b₀ a₁} → codeBA b₀ a₁ → right b₀ =₀ left a₁ :> Pushout span
   decodeBB : ∀ {b₀ b₁} → codeBB b₀ b₁ → right b₀ =₀ right b₁ :> Pushout span
-  decodeBA = SetQuot-rec Trunc-level pcBA-to-path pcBA-to-path-rel
-  decodeBB = SetQuot-rec Trunc-level pcBB-to-path pcBB-to-path-rel
+  decodeBA = SetQuot-rec pcBA-to-path pcBA-to-path-rel
+  decodeBB = SetQuot-rec pcBB-to-path pcBB-to-path-rel
 
   abstract
     decodeBA-is-decodeBB : ∀ {b₀} c₁ →
       decodeBA {b₀} {f c₁} == decodeBB {b₀} {g c₁}
       [ (λ p₁ → codeBP b₀ p₁ → right b₀ =₀ p₁) ↓ glue c₁ ]
     decodeBA-is-decodeBB {b₀ = b₀} = SurjExt.ext
-      (λ _ → ↓-preserves-level $ Π-is-set λ _ → Trunc-level) h h-is-surj
+      {{↓-preserves-level ⟨⟩}} h h-is-surj
       (λ d₁ → ↓-→-from-transp $ λ= $ SetQuot-elim
         {P = λ cBA → transport (right b₀ =₀_) (glue (h d₁)) (decodeBA cBA)
                   == decodeBB (transport (codeBP b₀) (glue (h d₁)) cBA)}
-        (λ _ → =-preserves-set Trunc-level)
         (λ pcBA →
           transport (right b₀ =₀_) (glue (h d₁)) (pcBA-to-path pcBA)
             =⟨ transp₀-cst=₀idf [ glue (h d₁) ] (pcBA-to-path pcBA) ⟩
@@ -259,8 +255,8 @@ module homotopy.vankampen.CodeBP {i j k l}
             =⟨ ! $ ap (λ p → decodeBB (coe p q[ pcBA ])) (CodeBP.glue-β b₀ (h d₁)) ⟩
           decodeBB (transport (codeBP b₀) (glue (h d₁)) q[ pcBA ])
             =∎)
-        (λ _ → prop-has-all-paths-↓ $ Trunc-level {n = 0} _ _))
-      (λ _ _ _ → prop-has-all-paths-↓ $ ↓-level $ Π-is-set λ _ → Trunc-level)
+        (λ _ → prop-has-all-paths-↓))
+      (λ _ _ _ → prop-has-all-paths-↓ {{↓-level ⟨⟩}})
 
   decodeBP : ∀ {b₀ p₁} → codeBP b₀ p₁ → right b₀ =₀ p₁
   decodeBP {p₁ = p₁} = Pushout-elim


### PR DESCRIPTION
This pull request changes the library in order to use instance arguments to make Agda automatically deduce arguments of type `has-level n A`.

In particular, when using a function like `Trunc-elim`, `SetQuot-elim`, `prop-has-all-paths`, and so on, you don’t need to give the proof that the thing is of the appropriate truncation level, Agda will figure it out automatically most of the time. If Agda doesn’t figure it out, you can always give it explicitely using instance arguments syntax `{{ arg }}`.
Note in particular that Agda probably won’t figure it out if it uses `raise-level` or `Trunc-preserves-level` or a few others, but most of the time it does work.

Another notable change (needed for instance arguments to work) is that I changed the definition of `has-level n A` (see `core/lib/NType.agda`) and it now does not reduce anymore. In practice that means that:

- Given `p : is-contr A`, use `contr-center p` and `contr-path p` instead of `fst p` and `snd p`
- Given `p : has-level (S n) A` and `a b : A`, use `has-level-apply p a b` instead of `p a b` to get an element of type `has-level n (a == b)`
- Given `q : Σ A (λ x → ((y : A) → x == y))`, use `has-level-make q` in order to get an element of type `is-contr A`
- Given `f : (a b : A) → has-level n (a == b)`, use `has-level-make f` in order to get an element of type `has-level (S n) A`