### PR TITLE
Generalize cup product maps using tensor product

### DIFF
--- a/core/lib/Relation.agda
+++ b/core/lib/Relation.agda
@@ -7,6 +7,9 @@ module lib.Relation {i} where
 Rel : ∀ (A : Type i) j → Type (lmax i (lsucc j))
 Rel A j = A → A → Type j
 
+empty-rel : ∀ {A : Type i} → Rel A lzero
+empty-rel _ _ = Empty
+
 module _ {A : Type i} {j} (rel : Rel A j) where
 
   Decidable : Type (lmax i j)

--- a/core/lib/groups/FreeAbelianGroup.agda
+++ b/core/lib/groups/FreeAbelianGroup.agda
@@ -2,259 +2,66 @@
 
 open import lib.Basics
 open import lib.NType2
-open import lib.types.Empty
 open import lib.types.Group
-open import lib.types.Int
-open import lib.types.List
-open import lib.types.Nat
-open import lib.types.Pi
-open import lib.types.SetQuotient
-open import lib.types.Sigma
 open import lib.types.Word
+open import lib.groups.GeneratedAbelianGroup
+open import lib.groups.GeneratedGroup
 open import lib.groups.GroupProduct
 open import lib.groups.Homomorphism
 open import lib.groups.Isomorphism
 
 module lib.groups.FreeAbelianGroup {i} where
 
--- the relation for making the quotient.
+module FreeAbelianGroup (A : Type i) where
 
--- [fsr-sym] is not needed, but it seems more principled to
--- make [FormalSumRel] an equivalence relation.
-data FormalSumRel {A : Type i} : Word A → Word A → Type i where
-  fsr-refl : ∀ {l₁ l₂} → l₁ == l₂ → FormalSumRel l₁ l₂
-  fsr-trans : ∀ {l₁ l₂ l₃} → FormalSumRel l₁ l₂ → FormalSumRel l₂ l₃ → FormalSumRel l₁ l₃
-  fsr-sym : ∀ {l₁ l₂} → FormalSumRel l₁ l₂ → FormalSumRel l₂ l₁
-  fsr-cons : ∀ x {l₁ l₂} → FormalSumRel l₁ l₂ → FormalSumRel (x :: l₁) (x :: l₂)
-  fsr-swap : ∀ x₁ x₂ l → FormalSumRel (x₁ :: x₂ :: l) (x₂ :: x₁ :: l)
-  fsr-flip : ∀ x₁ l → FormalSumRel (x₁ :: flip x₁ :: l) l
-
--- The quotient
-FormalSum : Type i → Type i
-FormalSum A = SetQuot (FormalSumRel {A})
-
-module _ {A : Type i} where
-
-  fs[_] : Word A → FormalSum A
-  fs[_] = q[_]
-
-  module FormalSumElim {k} {P : FormalSum A → Type k}
-    {{p : {x : FormalSum A} → is-set (P x)}} (incl* : (a : Word A) → P fs[ a ])
-    (rel* : ∀ {a₁ a₂} (r : FormalSumRel a₁ a₂) → incl* a₁ == incl* a₂ [ P ↓ quot-rel r ])
-    = SetQuotElim incl* rel*
-  open FormalSumElim public using () renaming (f to FormalSum-elim)
-
-  module FormalSumRec {k} {B : Type k} {{p : is-set B}} (incl* : Word A → B)
-    (rel* : ∀ {a₁ a₂} (r : FormalSumRel a₁ a₂) → incl* a₁ == incl* a₂)
-    = SetQuotRec incl* rel*
-  open FormalSumRec public using () renaming (f to FormalSum-rec)
-
-module _ {A : Type i} where
-  -- useful properties that remain public
-  abstract
-    FormalSumRel-cong-++-l :
-      ∀ {l₁ l₁'} → FormalSumRel {A} l₁ l₁'
-      → (l₂ : Word A)
-      → FormalSumRel (l₁ ++ l₂) (l₁' ++ l₂)
-    FormalSumRel-cong-++-l (fsr-refl idp) l₂ = fsr-refl idp
-    FormalSumRel-cong-++-l (fsr-trans fsr₁ fsr₂) l₂ = fsr-trans (FormalSumRel-cong-++-l fsr₁ l₂) (FormalSumRel-cong-++-l fsr₂ l₂)
-    FormalSumRel-cong-++-l (fsr-sym fsr) l₂ = fsr-sym (FormalSumRel-cong-++-l fsr l₂)
-    FormalSumRel-cong-++-l (fsr-cons x fsr₁) l₂ = fsr-cons x (FormalSumRel-cong-++-l fsr₁ l₂)
-    FormalSumRel-cong-++-l (fsr-swap x₁ x₂ l₁) l₂ = fsr-swap x₁ x₂ (l₁ ++ l₂)
-    FormalSumRel-cong-++-l (fsr-flip x₁ l₁) l₂ = fsr-flip x₁ (l₁ ++ l₂)
-
-    FormalSumRel-cong-++-r :
-      ∀ (l₁ : Word A)
-      → ∀ {l₂ l₂'} → FormalSumRel l₂ l₂'
-      → FormalSumRel (l₁ ++ l₂) (l₁ ++ l₂')
-    FormalSumRel-cong-++-r nil fsr₂ = fsr₂
-    FormalSumRel-cong-++-r (x :: l₁) fsr₂ = fsr-cons x (FormalSumRel-cong-++-r l₁ fsr₂)
-
-    FormalSumRel-swap1 : ∀ x l₁ l₂ → FormalSumRel {A} (l₁ ++ (x :: l₂)) (x :: l₁ ++ l₂)
-    FormalSumRel-swap1 x nil l₂ = fsr-refl idp
-    FormalSumRel-swap1 x (x₁ :: l₁) l₂ = fsr-trans (fsr-cons x₁ (FormalSumRel-swap1 x l₁ l₂)) (fsr-swap x₁ x (l₁ ++ l₂))
-
-module _ (A : Type i) where
   private
-    infixl 80 _⊞_
-    _⊞_ : FormalSum A → FormalSum A → FormalSum A
-    _⊞_ = FormalSum-rec
-      (λ l₁ → FormalSum-rec (λ l₂ → fs[ l₁ ++ l₂ ])
-        (λ r → quot-rel $ FormalSumRel-cong-++-r l₁ r))
-      (λ {l₁} {l₁'} r → λ= $ FormalSum-elim
-        (λ l₂ → quot-rel $ FormalSumRel-cong-++-l r l₂)
-        (λ _ → prop-has-all-paths-↓))
+    module Gen = GeneratedAbelianGroup A empty-rel
+  open Gen hiding (GenAbGroup; module HomomorphismEquiv) public
 
-    abstract
-      FormalSumRel-cong-flip : ∀ {l₁ l₂}
-        → FormalSumRel {A} l₁ l₂ → FormalSumRel (Word-flip l₁) (Word-flip l₂)
-      FormalSumRel-cong-flip (fsr-refl idp) = fsr-refl idp
-      FormalSumRel-cong-flip (fsr-trans fsr₁ fsr₂) = fsr-trans (FormalSumRel-cong-flip fsr₁) (FormalSumRel-cong-flip fsr₂)
-      FormalSumRel-cong-flip (fsr-sym fsr) = fsr-sym (FormalSumRel-cong-flip fsr)
-      FormalSumRel-cong-flip (fsr-cons x fsr₁) = fsr-cons (flip x) (FormalSumRel-cong-flip fsr₁)
-      FormalSumRel-cong-flip (fsr-swap x₁ x₂ l) = fsr-swap (flip x₁) (flip x₂) (Word-flip l)
-      FormalSumRel-cong-flip (fsr-flip (inl x) l) = fsr-flip (inr x) (Word-flip l)
-      FormalSumRel-cong-flip (fsr-flip (inr x) l) = fsr-flip (inl x) (Word-flip l)
+  CommutativityRel : Rel (Word A) i
+  CommutativityRel = AbGroupRel
 
-    ⊟ : FormalSum A → FormalSum A
-    ⊟ = FormalSum-rec (fs[_] ∘ Word-flip)
-      (λ r → quot-rel $ FormalSumRel-cong-flip r)
+  FormalSumRel : Rel (Word A) i
+  FormalSumRel = QuotWordRel
 
-    ⊞-unit : FormalSum A
-    ⊞-unit = fs[ nil ]
+  FormalSum : Type i
+  FormalSum = QuotWord
 
-    abstract
-      ⊞-unit-l : ∀ g → ⊞-unit ⊞ g == g
-      ⊞-unit-l = FormalSum-elim
-        (λ _ → idp)
-        (λ _ → prop-has-all-paths-↓)
-
-      ⊞-assoc : ∀ g₁ g₂ g₃ → (g₁ ⊞ g₂) ⊞ g₃ == g₁ ⊞ (g₂ ⊞ g₃)
-      ⊞-assoc = FormalSum-elim
-        (λ l₁ → FormalSum-elim
-          (λ l₂ → FormalSum-elim
-            (λ l₃ → ap fs[_] $ ++-assoc l₁ l₂ l₃)
-            (λ _ → prop-has-all-paths-↓))
-          (λ _ → prop-has-all-paths-↓))
-        (λ _ → prop-has-all-paths-↓)
-
-      Word-inv-l : ∀ l → FormalSumRel {A} (Word-flip l ++ l) nil
-      Word-inv-l nil = fsr-refl idp
-      Word-inv-l (x :: l) =
-        fsr-trans (FormalSumRel-swap1 x (flip x :: Word-flip l) l) $
-        fsr-trans (fsr-flip x (Word-flip l ++ l)) (Word-inv-l l)
-
-      ⊟-inv-l : ∀ g → (⊟ g) ⊞ g == ⊞-unit
-      ⊟-inv-l = FormalSum-elim
-        (λ l → quot-rel (Word-inv-l l))
-        (λ _ → prop-has-all-paths-↓)
-
-      FormalSumRel-swap : ∀ l₁ l₂ → FormalSumRel {A} (l₁ ++ l₂) (l₂ ++ l₁)
-      FormalSumRel-swap l₁ nil = fsr-refl (++-unit-r l₁)
-      FormalSumRel-swap l₁ (x :: l₂) = fsr-trans (FormalSumRel-swap1 x l₁ l₂) (fsr-cons x (FormalSumRel-swap l₁ l₂))
-
-      ⊞-comm : ∀ g₁ g₂ → g₁ ⊞ g₂ == g₂ ⊞ g₁
-      ⊞-comm = FormalSum-elim
-        (λ l₁ → FormalSum-elim
-          (λ l₂ → quot-rel $ FormalSumRel-swap l₁ l₂)
-          (λ _ → prop-has-all-paths-↓))
-        (λ _ → prop-has-all-paths-↓)
-
-  FormalSum-group-structure : GroupStructure (FormalSum A)
-  FormalSum-group-structure = record
-    { ident = ⊞-unit
-    ; inv = ⊟
-    ; comp = _⊞_
-    ; unit-l = ⊞-unit-l
-    ; assoc = ⊞-assoc
-    ; inv-l = ⊟-inv-l
-    }
+  FreeGroup : Group i
+  FreeGroup = Gen.GenGroup
 
   FreeAbGroup : AbGroup i
-  FreeAbGroup = group _ FormalSum-group-structure , ⊞-comm
+  FreeAbGroup = Gen.GenAbGroup
 
   module FreeAbGroup = AbGroup FreeAbGroup
 
-{- Freeness (universal properties) -}
+  {- Universal Property -}
+  module Freeness {j} (G : AbGroup j) where
 
-module _ {A : Type i} {j} (G : AbGroup j) where
+    private
+      module G = AbGroup G
 
-  private
-    module G = AbGroup G
+    extend-equiv : (A → G.El) ≃ (FreeAbGroup.grp →ᴳ G.grp)
+    extend-equiv =
+      Gen.HomomorphismEquiv.extend-equiv G ∘e every-function-respects-empty-rel-equiv A G.grp
 
-    abstract
-      Word-extendᴳ-emap : ∀ f {l₁ l₂}
-        → FormalSumRel {A} l₁ l₂
-        → Word-extendᴳ G.grp f l₁ == Word-extendᴳ G.grp f l₂
-      Word-extendᴳ-emap f (fsr-refl idp) = idp
-      Word-extendᴳ-emap f (fsr-trans fsr fsr₁) = (Word-extendᴳ-emap f fsr) ∙ (Word-extendᴳ-emap f fsr₁)
-      Word-extendᴳ-emap f (fsr-sym fsr) = ! (Word-extendᴳ-emap f fsr)
-      Word-extendᴳ-emap f (fsr-cons x fsr) = ap (G.comp (PlusMinus-extendᴳ G.grp f x)) (Word-extendᴳ-emap f fsr)
-      Word-extendᴳ-emap f (fsr-swap x₁ x₂ l) =
-          ! (G.assoc (PlusMinus-extendᴳ G.grp f x₁) (PlusMinus-extendᴳ G.grp f x₂) (Word-extendᴳ G.grp f l))
-        ∙ ap (λ g → G.comp g (Word-extendᴳ G.grp f l)) (G.comm (PlusMinus-extendᴳ G.grp f x₁) (PlusMinus-extendᴳ G.grp f x₂))
-        ∙ G.assoc (PlusMinus-extendᴳ G.grp f x₂) (PlusMinus-extendᴳ G.grp f x₁) (Word-extendᴳ G.grp f l)
-      Word-extendᴳ-emap f (fsr-flip (inl x) l) =
-          ! (G.assoc (f x) (G.inv (f x)) (Word-extendᴳ G.grp f l))
-        ∙ ap (λ g → G.comp g (Word-extendᴳ G.grp f l)) (G.inv-r (f x)) ∙ G.unit-l _
-      Word-extendᴳ-emap f (fsr-flip (inr x) l) =
-          ! (G.assoc (G.inv (f x)) (f x) (Word-extendᴳ G.grp f l))
-        ∙ ap (λ g → G.comp g (Word-extendᴳ G.grp f l)) (G.inv-l (f x)) ∙ G.unit-l _
+    extend : (A → G.El) → (FreeAbGroup.grp →ᴳ G.grp)
+    extend = –> extend-equiv
 
-  FormalSum-extend : (A → G.El) → FormalSum A → G.El
-  FormalSum-extend f = FormalSum-rec (Word-extendᴳ G.grp f)
-    (λ r → Word-extendᴳ-emap f r)
+    extend-is-equiv : is-equiv extend
+    extend-is-equiv = snd extend-equiv
 
-  FreeAbGroup-extend : (A → G.El) → (FreeAbGroup.grp A →ᴳ G.grp)
-  FreeAbGroup-extend f' = record {M} where
-    module M where
-      f : FreeAbGroup.El A → G.El
-      f = FormalSum-extend f'
-      abstract
-        pres-comp : preserves-comp (FreeAbGroup.comp A) G.comp f
-        pres-comp =
-          FormalSum-elim
-            (λ l₁ → FormalSum-elim
-              (λ l₂ → Word-extendᴳ-++ G.grp f' l₁ l₂)
-              (λ _ → prop-has-all-paths-↓))
-            (λ _ → prop-has-all-paths-↓)
+    extend-hom : Πᴳ A (λ _ → G.grp) →ᴳ hom-group FreeAbGroup.grp G
+    extend-hom = record {M} where
+      module M where
+        f : (A → G.El) → (FreeAbGroup.grp →ᴳ G.grp)
+        f = extend
+        abstract
+          pres-comp : preserves-comp (Group.comp (Πᴳ A (λ _ → G.grp))) (Group.comp (hom-group FreeAbGroup.grp G)) f
+          pres-comp = λ f₁ f₂ → group-hom= $ λ= $
+            QuotWord-elim
+              (Word-extendᴳ-comp G f₁ f₂)
+              (λ _ → prop-has-all-paths-↓)
 
-  private
-    module Lemma (hom : FreeAbGroup.grp A →ᴳ G.grp) where
-      open GroupHom hom
-      f* : A → G.El
-      f* a = f fs[ inl a :: nil ]
-
-      abstract
-        PlusMinus-extend-hom : ∀ x → PlusMinus-extendᴳ G.grp f* x == f fs[ x :: nil ]
-        PlusMinus-extend-hom (inl x) = idp
-        PlusMinus-extend-hom (inr x) = ! $ pres-inv fs[ inl x :: nil ]
-
-        Word-extend-hom : ∀ l → Word-extendᴳ G.grp f* l == f fs[ l ]
-        Word-extend-hom nil = ! pres-ident
-        Word-extend-hom (x :: l) = ap2 G.comp (PlusMinus-extend-hom x) (Word-extend-hom l) ∙ ! (pres-comp _ _)
-    open Lemma
-
-  FreeAbGroup-extend-is-equiv : is-equiv FreeAbGroup-extend
-  FreeAbGroup-extend-is-equiv = is-eq _ from to-from from-to where
-    to = FreeAbGroup-extend
-    from = f*
-
-    abstract
-      to-from : ∀ h → to (from h) == h
-      to-from h = group-hom= $ λ= $ FormalSum-elim
-        (λ l → Word-extend-hom h l)
-        (λ _ → prop-has-all-paths-↓)
-
-      from-to : ∀ f → from (to f) == f
-      from-to f = λ= λ a → G.unit-r (f a)
-
-  FreeAbGroup-extend-hom : Πᴳ A (λ _ → G.grp) →ᴳ hom-group (FreeAbGroup.grp A) G
-  FreeAbGroup-extend-hom = record {M} where
-    module M where
-      f : (A → G.El) → (FreeAbGroup.grp A →ᴳ G.grp)
-      f = FreeAbGroup-extend
-      abstract
-        pres-comp : preserves-comp (Group.comp (Πᴳ A (λ _ → G.grp))) (Group.comp (hom-group (FreeAbGroup.grp A) G)) f
-        pres-comp = λ f₁ f₂ → group-hom= $ λ= $
-          FormalSum-elim
-            (Word-extendᴳ-comp G f₁ f₂)
-            (λ _ → prop-has-all-paths-↓)
-
-  FreeAbGroup-extend-iso : Πᴳ A (λ _ → G.grp) ≃ᴳ hom-group (FreeAbGroup.grp A) G
-  FreeAbGroup-extend-iso = FreeAbGroup-extend-hom , FreeAbGroup-extend-is-equiv
-
-{- relation with [Word-exp] -}
-
-module _ {A : Type i} where
-
-  abstract
-    FormalSumRel-pres-exp : ∀ (a : A) z →
-      fs[ Word-exp a z ] == GroupStructure.exp (FormalSum-group-structure A) fs[ inl a :: nil ] z
-    FormalSumRel-pres-exp a (pos O) = idp
-    FormalSumRel-pres-exp a (pos (S O)) = idp
-    FormalSumRel-pres-exp a (pos (S (S n))) =
-      ap (Group.comp (FreeAbGroup.grp A) fs[ inl a :: nil ]) (FormalSumRel-pres-exp a (pos (S n)))
-    FormalSumRel-pres-exp a (negsucc O) = idp
-    FormalSumRel-pres-exp a (negsucc (S n)) =
-      ap (Group.comp (FreeAbGroup.grp A) fs[ inr a :: nil ]) (FormalSumRel-pres-exp a (negsucc n))
+    extend-iso : Πᴳ A (λ _ → G.grp) ≃ᴳ hom-group FreeAbGroup.grp G
+    extend-iso = extend-hom , snd extend-equiv

--- a/core/lib/groups/FreeGroup.agda
+++ b/core/lib/groups/FreeGroup.agda
@@ -1,16 +1,9 @@
 {-# OPTIONS --without-K --rewriting #-}
 
 open import lib.Basics
-open import lib.NType2
-open import lib.Relation
 open import lib.types.Empty
-open import lib.types.Sigma
-open import lib.types.Pi
 open import lib.types.Group
-open import lib.types.Nat
-open import lib.types.List
 open import lib.types.Word
-open import lib.types.SetQuotient
 open import lib.groups.GeneratedGroup
 open import lib.groups.Homomorphism
 

--- a/core/lib/groups/FreeGroup.agda
+++ b/core/lib/groups/FreeGroup.agda
@@ -7,43 +7,29 @@ open import lib.types.Word
 open import lib.groups.GeneratedGroup
 open import lib.groups.Homomorphism
 
-module lib.groups.FreeGroup {i} (A : Type i) where
+module lib.groups.FreeGroup where
 
-EmptyRel : Word A → Word A → Type lzero
-EmptyRel _ _ = Empty
-
--- open module FreeGroupM = lib.groups.GeneratedGroup A EmptyRel
-
-FreeQuotWordRel : Rel (Word A) i
-FreeQuotWordRel = QuotWordRel {A = A} {R = EmptyRel}
-
-FreeGroup : Group i
-FreeGroup = GeneratedGroup A EmptyRel
-
-FreeQuotWord : Type i
-FreeQuotWord = QuotWord A EmptyRel
-
--- freeness
-
-module _ {j} (G : Group j) where
+module FreeGroup {i} (A : Type i) where
 
   private
-    module G = Group G
+    module Gen = GeneratedGroup A empty-rel
+  open Gen hiding (GenGroup) public
 
-  every-function-is-legal : ∀ (f : A → G.El) → LegalFunction {A = A} {R = EmptyRel} G
-  every-function-is-legal f =
-    record { f = f; legality = λ {_} {_} () }
+  FreeGroup : Group i
+  FreeGroup = Gen.GenGroup
 
-  every-function-is-legal-equiv : (A → G.El) ≃ LegalFunction {A = A} {R = EmptyRel} G
-  every-function-is-legal-equiv =
-    equiv every-function-is-legal
-          LegalFunction.f
-          (λ lf → LegalFunction= G idp)
-          (λ f → idp)
+  module Freeness {j} (G : Group j) where
 
-  FreeGroup-extend-equiv : (A → G.El) ≃ (FreeGroup →ᴳ G)
-  FreeGroup-extend-equiv =
-    GeneratedGroup-extend-equiv G ∘e every-function-is-legal-equiv
+    private
+      module G = Group G
+      module HE = HomomorphismEquiv G
 
-  FreeGroup-extend : (A → G.El) → (FreeGroup →ᴳ G)
-  FreeGroup-extend = –> FreeGroup-extend-equiv
+    extend-equiv : (A → G.El) ≃ (FreeGroup →ᴳ G)
+    extend-equiv =
+      HE.extend-equiv ∘e every-function-respects-empty-rel-equiv A G
+
+    extend : (A → G.El) → (FreeGroup →ᴳ G)
+    extend = –> extend-equiv
+
+    extend-is-equiv : is-equiv extend
+    extend-is-equiv = snd extend-equiv

--- a/core/lib/groups/FreeGroup.agda
+++ b/core/lib/groups/FreeGroup.agda
@@ -2,6 +2,7 @@
 
 open import lib.Basics
 open import lib.NType2
+open import lib.Relation
 open import lib.types.Empty
 open import lib.types.Sigma
 open import lib.types.Pi
@@ -10,208 +11,46 @@ open import lib.types.Nat
 open import lib.types.List
 open import lib.types.Word
 open import lib.types.SetQuotient
+open import lib.groups.GeneratedGroup
 open import lib.groups.Homomorphism
 
-module lib.groups.FreeGroup {i} where
+module lib.groups.FreeGroup {i} (A : Type i) where
 
--- [qwr-sym] is not needed, but it seems more principled to
--- make [QuotWordRel] an equivalence relation.
-data QuotWordRel {A : Type i} : Word A → Word A → Type i where
-  qwr-refl : ∀ {l₁ l₂} → l₁ == l₂ → QuotWordRel l₁ l₂
-  qwr-trans : ∀ {l₁ l₂ l₃} → QuotWordRel l₁ l₂ → QuotWordRel l₂ l₃ → QuotWordRel l₁ l₃
-  qwr-sym : ∀ {l₁ l₂} → QuotWordRel l₁ l₂ → QuotWordRel l₂ l₁
-  qwr-cons : ∀ x {l₁ l₂} → QuotWordRel l₁ l₂ → QuotWordRel (x :: l₁) (x :: l₂)
-  qwr-flip : ∀ x₁ l → QuotWordRel (x₁ :: flip x₁ :: l) l
+EmptyRel : Word A → Word A → Type lzero
+EmptyRel _ _ = Empty
 
--- The quotient
-QuotWord : Type i → Type i
-QuotWord A = SetQuot (QuotWordRel {A})
+-- open module FreeGroupM = lib.groups.GeneratedGroup A EmptyRel
 
-module _ {A : Type i} where
+FreeQuotWordRel : Rel (Word A) i
+FreeQuotWordRel = QuotWordRel {A = A} {R = EmptyRel}
 
-  qw[_] : Word A → QuotWord A
-  qw[_] = q[_]
+FreeGroup : Group i
+FreeGroup = GeneratedGroup A EmptyRel
 
-  module QuotWordElim {k} {P : QuotWord A → Type k}
-    {{_ : {x : QuotWord A} → is-set (P x)}} (incl* : (a : Word A) → P qw[ a ])
-    (rel* : ∀ {a₁ a₂} (r : QuotWordRel a₁ a₂) → incl* a₁ == incl* a₂ [ P ↓ quot-rel r ])
-    = SetQuotElim incl* rel*
-  open QuotWordElim public renaming (f to QuotWord-elim) hiding (quot-rel-β)
-
-  module QuotWordRec {k} {B : Type k} {{_ : is-set B}} (incl* : Word A → B)
-    (rel* : ∀ {a₁ a₂} (r : QuotWordRel a₁ a₂) → incl* a₁ == incl* a₂)
-    = SetQuotRec incl* rel*
-  open QuotWordRec public renaming (f to QuotWord-rec)
-
-module _ (A : Type i) where
-  private
-    abstract
-      QuotWordRel-cong-++-l :
-        ∀ {l₁ l₁'} → QuotWordRel {A} l₁ l₁'
-        → (l₂ : Word A)
-        → QuotWordRel (l₁ ++ l₂) (l₁' ++ l₂)
-      QuotWordRel-cong-++-l (qwr-refl idp) l₂ = qwr-refl idp
-      QuotWordRel-cong-++-l (qwr-trans qwr₁ qwr₂) l₂ = qwr-trans (QuotWordRel-cong-++-l qwr₁ l₂) (QuotWordRel-cong-++-l qwr₂ l₂)
-      QuotWordRel-cong-++-l (qwr-sym qwr) l₂ = qwr-sym (QuotWordRel-cong-++-l qwr l₂)
-      QuotWordRel-cong-++-l (qwr-cons x qwr₁) l₂ = qwr-cons x (QuotWordRel-cong-++-l qwr₁ l₂)
-      QuotWordRel-cong-++-l (qwr-flip x₁ l₁) l₂ = qwr-flip x₁ (l₁ ++ l₂)
-
-      QuotWordRel-cong-++-r :
-        ∀ (l₁ : Word A)
-        → ∀ {l₂ l₂'} → QuotWordRel l₂ l₂'
-        → QuotWordRel (l₁ ++ l₂) (l₁ ++ l₂')
-      QuotWordRel-cong-++-r nil qwr₂ = qwr₂
-      QuotWordRel-cong-++-r (x :: l₁) qwr₂ = qwr-cons x (QuotWordRel-cong-++-r l₁ qwr₂)
-
-    infixl 80 _⊞_
-    _⊞_ : QuotWord A → QuotWord A → QuotWord A
-    _⊞_ = QuotWord-rec
-      (λ l₁ → QuotWord-rec (λ l₂ → qw[ l₁ ++ l₂ ])
-        (λ r → quot-rel $ QuotWordRel-cong-++-r l₁ r))
-      (λ {l₁} {l₁'} r → λ= $ QuotWord-elim
-        (λ l₂ → quot-rel $ QuotWordRel-cong-++-l r l₂)
-        (λ _ → prop-has-all-paths-↓))
-
-    abstract
-      QuotWordRel-cong-flip : ∀ {l₁ l₂}
-        → QuotWordRel {A} l₁ l₂ → QuotWordRel (Word-flip l₁) (Word-flip l₂)
-      QuotWordRel-cong-flip (qwr-refl idp) = qwr-refl idp
-      QuotWordRel-cong-flip (qwr-trans qwr₁ qwr₂) = qwr-trans (QuotWordRel-cong-flip qwr₁) (QuotWordRel-cong-flip qwr₂)
-      QuotWordRel-cong-flip (qwr-sym qwr) = qwr-sym (QuotWordRel-cong-flip qwr)
-      QuotWordRel-cong-flip (qwr-cons x qwr₁) = qwr-cons (flip x) (QuotWordRel-cong-flip qwr₁)
-      QuotWordRel-cong-flip (qwr-flip (inl x) l) = qwr-flip (inr x) (Word-flip l)
-      QuotWordRel-cong-flip (qwr-flip (inr x) l) = qwr-flip (inl x) (Word-flip l)
-
-      QuotWordRel-cong-reverse : ∀ {l₁ l₂}
-        → QuotWordRel {A} l₁ l₂ → QuotWordRel (reverse l₁) (reverse l₂)
-      QuotWordRel-cong-reverse (qwr-refl x) = qwr-refl (ap reverse x)
-      QuotWordRel-cong-reverse (qwr-trans qwr qwr₁) = qwr-trans (QuotWordRel-cong-reverse qwr) (QuotWordRel-cong-reverse qwr₁)
-      QuotWordRel-cong-reverse (qwr-sym qwr) = qwr-sym (QuotWordRel-cong-reverse qwr)
-      QuotWordRel-cong-reverse (qwr-cons x qwr) = QuotWordRel-cong-++-l (QuotWordRel-cong-reverse qwr) (x :: nil)
-      QuotWordRel-cong-reverse (qwr-flip (inl x) l) =
-        qwr-trans (qwr-refl (++-assoc (reverse l) (inr x :: nil) (inl x :: nil))) $
-        qwr-trans (QuotWordRel-cong-++-r (reverse l) (qwr-flip (inr x) nil)) $
-        qwr-refl (++-unit-r (reverse l))
-      QuotWordRel-cong-reverse (qwr-flip (inr x) l) =
-        qwr-trans (qwr-refl (++-assoc (reverse l) (inl x :: nil) (inr x :: nil))) $
-        qwr-trans (QuotWordRel-cong-++-r (reverse l) (qwr-flip (inl x) nil)) $
-        qwr-refl (++-unit-r (reverse l))
-
-    ⊟ : QuotWord A → QuotWord A
-    ⊟ = QuotWord-rec (qw[_] ∘ reverse ∘ Word-flip)
-      (λ r → quot-rel $ QuotWordRel-cong-reverse $ QuotWordRel-cong-flip r)
-
-    ⊞-unit : QuotWord A
-    ⊞-unit = qw[ nil ]
-
-    abstract
-      ⊞-unit-l : ∀ g → ⊞-unit ⊞ g == g
-      ⊞-unit-l = QuotWord-elim
-        (λ _ → idp)
-        (λ _ → prop-has-all-paths-↓)
-
-      ⊞-assoc : ∀ g₁ g₂ g₃ → (g₁ ⊞ g₂) ⊞ g₃ == g₁ ⊞ (g₂ ⊞ g₃)
-      ⊞-assoc = QuotWord-elim
-        (λ l₁ → QuotWord-elim
-          (λ l₂ → QuotWord-elim
-            (λ l₃ → ap qw[_] $ ++-assoc l₁ l₂ l₃)
-            (λ _ → prop-has-all-paths-↓))
-          (λ _ → prop-has-all-paths-↓))
-        (λ _ → prop-has-all-paths-↓)
-
-      Word-inv-l : ∀ l → QuotWordRel {A} (reverse (Word-flip l) ++ l) nil
-      Word-inv-l nil = qwr-refl idp
-      Word-inv-l (inl x :: l) =
-        qwr-trans (qwr-refl (++-assoc (reverse (Word-flip l)) (inr x :: nil) (inl x :: l))) $
-        qwr-trans (QuotWordRel-cong-++-r (reverse (Word-flip l)) (qwr-flip (inr x) l)) $
-        Word-inv-l l
-      Word-inv-l (inr x :: l) =
-        qwr-trans (qwr-refl (++-assoc (reverse (Word-flip l)) (inl x :: nil) (inr x :: l))) $
-        qwr-trans (QuotWordRel-cong-++-r (reverse (Word-flip l)) (qwr-flip (inl x) l)) $
-        Word-inv-l l
-
-      ⊟-inv-l : ∀ g → (⊟ g) ⊞ g == ⊞-unit
-      ⊟-inv-l = QuotWord-elim
-        (λ l → quot-rel (Word-inv-l l))
-        (λ _ → prop-has-all-paths-↓)
-
-  QuotWord-group-structure : GroupStructure (QuotWord A)
-  QuotWord-group-structure = record
-    { ident = ⊞-unit
-    ; inv = ⊟
-    ; comp = _⊞_
-    ; unit-l = ⊞-unit-l
-    ; assoc = ⊞-assoc
-    ; inv-l = ⊟-inv-l
-    }
-
-  FreeGroup : Group i
-  FreeGroup = group _ QuotWord-group-structure
-
-  module FreeGroup = Group FreeGroup
+FreeQuotWord : Type i
+FreeQuotWord = QuotWord A EmptyRel
 
 -- freeness
-module _ {A : Type i} {j} (G : Group j) where
+
+module _ {j} (G : Group j) where
 
   private
     module G = Group G
 
-    abstract
-      Word-extendᴳ-emap : ∀ f {l₁ l₂}
-        → QuotWordRel {A} l₁ l₂
-        → Word-extendᴳ G f l₁ == Word-extendᴳ G f l₂
-      Word-extendᴳ-emap f (qwr-refl idp) = idp
-      Word-extendᴳ-emap f (qwr-trans qwr qwr₁) = (Word-extendᴳ-emap f qwr) ∙ (Word-extendᴳ-emap f qwr₁)
-      Word-extendᴳ-emap f (qwr-sym qwr) = ! (Word-extendᴳ-emap f qwr)
-      Word-extendᴳ-emap f (qwr-cons x qwr) = ap (G.comp (PlusMinus-extendᴳ G f x)) (Word-extendᴳ-emap f qwr)
-      Word-extendᴳ-emap f (qwr-flip (inl x) l) =
-          ! (G.assoc (f x) (G.inv (f x)) (Word-extendᴳ G f l))
-        ∙ ap (λ g → G.comp g (Word-extendᴳ G f l)) (G.inv-r (f x)) ∙ G.unit-l _
-      Word-extendᴳ-emap f (qwr-flip (inr x) l) =
-          ! (G.assoc (G.inv (f x)) (f x) (Word-extendᴳ G f l))
-        ∙ ap (λ g → G.comp g (Word-extendᴳ G f l)) (G.inv-l (f x)) ∙ G.unit-l _
+  every-function-is-legal : ∀ (f : A → G.El) → LegalFunction {A = A} {R = EmptyRel} G
+  every-function-is-legal f =
+    record { f = f; legality = λ {_} {_} () }
 
-  FreeGroup-extend : (A → G.El) → (FreeGroup A →ᴳ G)
-  FreeGroup-extend f' = record {M} where
-    module M where
-      f : QuotWord A → G.El
-      f = QuotWord-rec (Word-extendᴳ G f')
-          (λ r → Word-extendᴳ-emap f' r)
-      abstract
-        pres-comp : preserves-comp (FreeGroup.comp A) G.comp f
-        pres-comp =
-          QuotWord-elim
-            (λ l₁ → QuotWord-elim
-              (λ l₂ → Word-extendᴳ-++ G f' l₁ l₂)
-              (λ _ → prop-has-all-paths-↓))
-            (λ _ → prop-has-all-paths-↓)
+  every-function-is-legal-equiv : (A → G.El) ≃ LegalFunction {A = A} {R = EmptyRel} G
+  every-function-is-legal-equiv =
+    equiv every-function-is-legal
+          LegalFunction.f
+          (λ lf → LegalFunction= G idp)
+          (λ f → idp)
 
-  private
-    module Lemma (hom : FreeGroup A →ᴳ G) where
-      open GroupHom hom
-      f* : A → G.El
-      f* a = f qw[ inl a :: nil ]
+  FreeGroup-extend-equiv : (A → G.El) ≃ (FreeGroup →ᴳ G)
+  FreeGroup-extend-equiv =
+    GeneratedGroup-extend-equiv G ∘e every-function-is-legal-equiv
 
-      abstract
-        PlusMinus-extendᴳ-hom : ∀ x → PlusMinus-extendᴳ G f* x == f qw[ x :: nil ]
-        PlusMinus-extendᴳ-hom (inl x) = idp
-        PlusMinus-extendᴳ-hom (inr x) = ! $ pres-inv qw[ inl x :: nil ]
-
-        Word-extendᴳ-hom : ∀ l → Word-extendᴳ G f* l == f qw[ l ]
-        Word-extendᴳ-hom nil = ! pres-ident
-        Word-extendᴳ-hom (x :: l) = ap2 G.comp (PlusMinus-extendᴳ-hom x) (Word-extendᴳ-hom l) ∙ ! (pres-comp _ _)
-    open Lemma
-
-  FreeGroup-extend-is-equiv : is-equiv FreeGroup-extend
-  FreeGroup-extend-is-equiv = is-eq _ from to-from from-to where
-    to = FreeGroup-extend
-    from = f*
-
-    abstract
-      to-from : ∀ h → to (from h) == h
-      to-from h = group-hom= $ λ= $ QuotWord-elim
-        (λ l → Word-extendᴳ-hom h l)
-        (λ _ → prop-has-all-paths-↓)
-
-      from-to : ∀ f → from (to f) == f
-      from-to f = λ= λ a → G.unit-r (f a)
+  FreeGroup-extend : (A → G.El) → (FreeGroup →ᴳ G)
+  FreeGroup-extend = –> FreeGroup-extend-equiv

--- a/core/lib/groups/GeneratedAbelianGroup.agda
+++ b/core/lib/groups/GeneratedAbelianGroup.agda
@@ -20,7 +20,7 @@ module GeneratedAbelianGroup (A : Type i) (R : Rel (Word A) m) where
 
   private
     module Gen = GeneratedGroup A AbGroupRel
-  open Gen hiding (module HomomorphismEquiv) public
+  open Gen hiding (module HomomorphismEquiv; rel-holds) public
 
   agr-reverse : (w : Word A) → QuotWordRel (reverse w) w
   agr-reverse nil = qwr-refl idp
@@ -45,6 +45,9 @@ module GeneratedAbelianGroup (A : Type i) (R : Rel (Word A) m) where
             (λ lb → quot-rel (qwr-rel (agr-commutes la lb)))
             (λ _ → prop-has-all-paths-↓))
         (λ _ → prop-has-all-paths-↓ {{Π-level ⟨⟩}})
+
+  rel-holds : ∀ {w₁} {w₂} (r : R w₁ w₂) → qw[ w₁ ] == qw[ w₂ ]
+  rel-holds r = Gen.rel-holds (agr-rel r)
 
   module GenAbGroup = AbGroup GenAbGroup
 

--- a/core/lib/groups/GeneratedAbelianGroup.agda
+++ b/core/lib/groups/GeneratedAbelianGroup.agda
@@ -10,70 +10,76 @@ open import lib.types.Word
 open import lib.groups.GeneratedGroup
 open import lib.groups.Homomorphism
 
-module lib.groups.GeneratedAbelianGroup {i m} (A : Type i) {R : Rel (Word A) m} where
+module lib.groups.GeneratedAbelianGroup {i} {m} where
 
-data AbGroupRel : Word A → Word A → Type (lmax i m) where
-  agr-commutes : ∀ l₁ l₂ → AbGroupRel (l₁ ++ l₂) (l₂ ++ l₁)
-  agr-rel : ∀ {l₁ l₂} → R l₁ l₂ → AbGroupRel l₁ l₂
+module _ {A : Type i} {R : Rel (Word A) m} where
 
-GeneratedAbGroup : AbGroup (lmax i m)
-GeneratedAbGroup = grp , grp-is-abelian
-  where
-  grp : Group (lmax i m)
-  grp = GeneratedGroup A AbGroupRel
-  module grp = Group grp
-  grp-is-abelian : is-abelian grp
-  grp-is-abelian =
-    QuotWord-elim {P = λ a → ∀ b → grp.comp a b == grp.comp b a}
-      (λ la →
-        QuotWord-elim {P = λ b → grp.comp qw[ la ] b == grp.comp b qw[ la ]}
-          (λ lb → quot-rel (qwr-rel (agr-commutes la lb)))
-          (λ _ → prop-has-all-paths-↓))
-      (λ _ → prop-has-all-paths-↓ {{Π-level ⟨⟩}})
+  data AbGroupRel : Word A → Word A → Type (lmax i m) where
+    agr-commutes : ∀ l₁ l₂ → AbGroupRel (l₁ ++ l₂) (l₂ ++ l₁)
+    agr-rel : ∀ {l₁ l₂} → R l₁ l₂ → AbGroupRel l₁ l₂
 
-module GeneratedAbGroup = AbGroup GeneratedAbGroup
+module _ (A : Type i) (R : Rel (Word A) m) where
 
-{- Freeness (universal properties) -}
-
-module _ {j} (G : AbGroup j) where
-
-  private
-    module G = AbGroup G
-
-  R-legal-to-AbGroupRel-legal : LegalFunction {A = A} {R} G.grp → LegalFunction {A = A} {AbGroupRel} G.grp
-  R-legal-to-AbGroupRel-legal lf =
-    record { f = lf.f; legality = legality }
+  GeneratedAbGroup : AbGroup (lmax i m)
+  GeneratedAbGroup = grp , grp-is-abelian
     where
-    module lf = LegalFunction lf
-    legality : is-legal {A = A} {AbGroupRel} G.grp lf.f
-    legality (agr-commutes l₁ l₂) =
-      Word-extendᴳ G.grp lf.f (l₁ ++ l₂)
-        =⟨ Word-extendᴳ-++ G.grp lf.f l₁ l₂ ⟩
-      G.comp (Word-extendᴳ G.grp lf.f l₁) (Word-extendᴳ G.grp lf.f l₂)
-        =⟨ G.comm (Word-extendᴳ G.grp lf.f l₁) (Word-extendᴳ G.grp lf.f l₂) ⟩
-      G.comp (Word-extendᴳ G.grp lf.f l₂) (Word-extendᴳ G.grp lf.f l₁)
-        =⟨ ! (Word-extendᴳ-++ G.grp lf.f l₂ l₁) ⟩
-      Word-extendᴳ G.grp lf.f (l₂ ++ l₁) =∎
-    legality (agr-rel r) = lf.legality r
+    grp : Group (lmax i m)
+    grp = GeneratedGroup A (AbGroupRel {A} {R})
+    module grp = Group grp
+    grp-is-abelian : is-abelian grp
+    grp-is-abelian =
+      QuotWord-elim {P = λ a → ∀ b → grp.comp a b == grp.comp b a}
+        (λ la →
+          QuotWord-elim {P = λ b → grp.comp qw[ la ] b == grp.comp b qw[ la ]}
+            (λ lb → quot-rel (qwr-rel (agr-commutes la lb)))
+            (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓ {{Π-level ⟨⟩}})
 
-  AbGroupRel-legal-to-R-legal : LegalFunction {A = A} {AbGroupRel} G.grp → LegalFunction {A = A} {R} G.grp
-  AbGroupRel-legal-to-R-legal lf =
-    record { f = lf.f; legality = legality }
-    where
-    module lf = LegalFunction lf
-    legality : is-legal {A = A} {R} G.grp lf.f
-    legality r = lf.legality (agr-rel r)
+  module GeneratedAbGroup = AbGroup GeneratedAbGroup
 
-  legal-functions-equiv : LegalFunction {A = A} {R} G.grp ≃ LegalFunction {A = A} {AbGroupRel} G.grp
-  legal-functions-equiv =
-    equiv R-legal-to-AbGroupRel-legal
-          AbGroupRel-legal-to-R-legal
-          (λ lf → LegalFunction= _ idp)
-          (λ lf → LegalFunction= _ idp)
+  {- Freeness (universal properties) -}
 
-  GeneratedAbGroup-extend-equiv : LegalFunction {A = A} {R} G.grp ≃ (GeneratedAbGroup.grp →ᴳ G.grp)
-  GeneratedAbGroup-extend-equiv =
-    GeneratedGroup-extend-equiv G.grp ∘e legal-functions-equiv
+  module _ {j} (G : AbGroup j) where
 
-  GeneratedAbGroup-extend : LegalFunction {A = A} {R} G.grp → (GeneratedAbGroup.grp →ᴳ G.grp)
-  GeneratedAbGroup-extend = –> GeneratedAbGroup-extend-equiv
+    private
+      module G = AbGroup G
+
+    R-legal-to-AbGroupRel-legal : LegalFunction {A = A} {R} G.grp
+                                → LegalFunction {A = A} {AbGroupRel {A} {R}} G.grp
+    R-legal-to-AbGroupRel-legal lf =
+      record { f = lf.f; legality = legality }
+      where
+      module lf = LegalFunction {A = A} {R} lf
+      legality : is-legal {A = A} {AbGroupRel} G.grp lf.f
+      legality (agr-commutes l₁ l₂) =
+        Word-extendᴳ G.grp lf.f (l₁ ++ l₂)
+          =⟨ Word-extendᴳ-++ G.grp lf.f l₁ l₂ ⟩
+        G.comp (Word-extendᴳ G.grp lf.f l₁) (Word-extendᴳ G.grp lf.f l₂)
+          =⟨ G.comm (Word-extendᴳ G.grp lf.f l₁) (Word-extendᴳ G.grp lf.f l₂) ⟩
+        G.comp (Word-extendᴳ G.grp lf.f l₂) (Word-extendᴳ G.grp lf.f l₁)
+          =⟨ ! (Word-extendᴳ-++ G.grp lf.f l₂ l₁) ⟩
+        Word-extendᴳ G.grp lf.f (l₂ ++ l₁) =∎
+      legality (agr-rel r) = lf.legality r
+
+    AbGroupRel-legal-to-R-legal : LegalFunction {A = A} {AbGroupRel {A} {R}} G.grp
+                                → LegalFunction {A = A} {R} G.grp
+    AbGroupRel-legal-to-R-legal lf =
+      record { f = lf.f; legality = legality }
+      where
+      module lf = LegalFunction lf
+      legality : is-legal {A = A} {R} G.grp lf.f
+      legality r = lf.legality (agr-rel r)
+
+    legal-functions-equiv : LegalFunction {A = A} {R} G.grp ≃ LegalFunction {A = A} {AbGroupRel} G.grp
+    legal-functions-equiv =
+      equiv R-legal-to-AbGroupRel-legal
+            AbGroupRel-legal-to-R-legal
+            (λ lf → LegalFunction= _ idp)
+            (λ lf → LegalFunction= _ idp)
+
+    GeneratedAbGroup-extend-equiv : LegalFunction {A = A} {R} G.grp ≃ (GeneratedAbGroup.grp →ᴳ G.grp)
+    GeneratedAbGroup-extend-equiv =
+      GeneratedGroup-extend-equiv G.grp ∘e legal-functions-equiv
+
+    GeneratedAbGroup-extend : LegalFunction {A = A} {R} G.grp → (GeneratedAbGroup.grp →ᴳ G.grp)
+    GeneratedAbGroup-extend = –> GeneratedAbGroup-extend-equiv

--- a/core/lib/groups/GeneratedAbelianGroup.agda
+++ b/core/lib/groups/GeneratedAbelianGroup.agda
@@ -1,0 +1,79 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+open import lib.Basics
+open import lib.NType2
+open import lib.types.Group
+open import lib.types.List
+open import lib.types.Pi
+open import lib.types.SetQuotient
+open import lib.types.Word
+open import lib.groups.GeneratedGroup
+open import lib.groups.Homomorphism
+
+module lib.groups.GeneratedAbelianGroup {i m} (A : Type i) {R : Rel (Word A) m} where
+
+data AbGroupRel : Word A → Word A → Type (lmax i m) where
+  agr-commutes : ∀ l₁ l₂ → AbGroupRel (l₁ ++ l₂) (l₂ ++ l₁)
+  agr-rel : ∀ {l₁ l₂} → R l₁ l₂ → AbGroupRel l₁ l₂
+
+GeneratedAbGroup : AbGroup (lmax i m)
+GeneratedAbGroup = grp , grp-is-abelian
+  where
+  grp : Group (lmax i m)
+  grp = GeneratedGroup A AbGroupRel
+  module grp = Group grp
+  grp-is-abelian : is-abelian grp
+  grp-is-abelian =
+    QuotWord-elim {P = λ a → ∀ b → grp.comp a b == grp.comp b a}
+      (λ la →
+        QuotWord-elim {P = λ b → grp.comp qw[ la ] b == grp.comp b qw[ la ]}
+          (λ lb → quot-rel (qwr-rel (agr-commutes la lb)))
+          (λ _ → prop-has-all-paths-↓))
+      (λ _ → prop-has-all-paths-↓ {{Π-level ⟨⟩}})
+
+module GeneratedAbGroup = AbGroup GeneratedAbGroup
+
+{- Freeness (universal properties) -}
+
+module _ {j} (G : AbGroup j) where
+
+  private
+    module G = AbGroup G
+
+  R-legal-to-AbGroupRel-legal : LegalFunction {A = A} {R} G.grp → LegalFunction {A = A} {AbGroupRel} G.grp
+  R-legal-to-AbGroupRel-legal lf =
+    record { f = lf.f; legality = legality }
+    where
+    module lf = LegalFunction lf
+    legality : is-legal {A = A} {AbGroupRel} G.grp lf.f
+    legality (agr-commutes l₁ l₂) =
+      Word-extendᴳ G.grp lf.f (l₁ ++ l₂)
+        =⟨ Word-extendᴳ-++ G.grp lf.f l₁ l₂ ⟩
+      G.comp (Word-extendᴳ G.grp lf.f l₁) (Word-extendᴳ G.grp lf.f l₂)
+        =⟨ G.comm (Word-extendᴳ G.grp lf.f l₁) (Word-extendᴳ G.grp lf.f l₂) ⟩
+      G.comp (Word-extendᴳ G.grp lf.f l₂) (Word-extendᴳ G.grp lf.f l₁)
+        =⟨ ! (Word-extendᴳ-++ G.grp lf.f l₂ l₁) ⟩
+      Word-extendᴳ G.grp lf.f (l₂ ++ l₁) =∎
+    legality (agr-rel r) = lf.legality r
+
+  AbGroupRel-legal-to-R-legal : LegalFunction {A = A} {AbGroupRel} G.grp → LegalFunction {A = A} {R} G.grp
+  AbGroupRel-legal-to-R-legal lf =
+    record { f = lf.f; legality = legality }
+    where
+    module lf = LegalFunction lf
+    legality : is-legal {A = A} {R} G.grp lf.f
+    legality r = lf.legality (agr-rel r)
+
+  legal-functions-equiv : LegalFunction {A = A} {R} G.grp ≃ LegalFunction {A = A} {AbGroupRel} G.grp
+  legal-functions-equiv =
+    equiv R-legal-to-AbGroupRel-legal
+          AbGroupRel-legal-to-R-legal
+          (λ lf → LegalFunction= _ idp)
+          (λ lf → LegalFunction= _ idp)
+
+  GeneratedAbGroup-extend-equiv : LegalFunction {A = A} {R} G.grp ≃ (GeneratedAbGroup.grp →ᴳ G.grp)
+  GeneratedAbGroup-extend-equiv =
+    GeneratedGroup-extend-equiv G.grp ∘e legal-functions-equiv
+
+  GeneratedAbGroup-extend : LegalFunction {A = A} {R} G.grp → (GeneratedAbGroup.grp →ᴳ G.grp)
+  GeneratedAbGroup-extend = –> GeneratedAbGroup-extend-equiv

--- a/core/lib/groups/GeneratedGroup.agda
+++ b/core/lib/groups/GeneratedGroup.agda
@@ -1,0 +1,300 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+open import lib.Basics
+open import lib.NType2
+open import lib.types.Pi
+open import lib.types.Group
+open import lib.types.List
+open import lib.types.Word
+open import lib.types.SetQuotient
+open import lib.groups.Homomorphism
+
+module lib.groups.GeneratedGroup {i m} where
+
+module _ {A : Type i} {R : Rel (Word A) m} where
+
+  -- [qwr-sym] is not needed, but it seems more principled to
+  -- make [QuotWordRel] an equivalence relation.
+  data QuotWordRel : Word A → Word A → Type (lmax i m) where
+    qwr-refl : ∀ {l₁ l₂} → l₁ == l₂ → QuotWordRel l₁ l₂
+    qwr-trans : ∀ {l₁ l₂ l₃} → QuotWordRel l₁ l₂ → QuotWordRel l₂ l₃ → QuotWordRel l₁ l₃
+    qwr-sym : ∀ {l₁ l₂} → QuotWordRel l₁ l₂ → QuotWordRel l₂ l₁
+    qwr-cong : ∀ {l₁ l₂ l₃ l₄} → QuotWordRel l₁ l₂ → QuotWordRel l₃ l₄ → QuotWordRel (l₁ ++ l₃) (l₂ ++ l₄)
+    qwr-flip-r : ∀ x₁ → QuotWordRel (x₁ :: flip x₁ :: nil) nil
+    qwr-rel : ∀ {l₁ l₂} → R l₁ l₂ → QuotWordRel l₁ l₂
+
+  qwr-cong-l : ∀ {l₁ l₂} → QuotWordRel l₁ l₂ → ∀ l₃ → QuotWordRel (l₁ ++ l₃) (l₂ ++ l₃)
+  qwr-cong-l qwr l₃ = qwr-cong qwr (qwr-refl idp)
+
+  qwr-cong-r : ∀ l₁ {l₂ l₃} → QuotWordRel l₂ l₃ → QuotWordRel (l₁ ++ l₂) (l₁ ++ l₃)
+  qwr-cong-r l₁ qwr = qwr-cong (qwr-refl (idp {a = l₁})) qwr
+
+  abstract
+    infixr 10 _qwr⟨_⟩_
+    infixr 10 _qwr⟨id⟩_
+    infix  15 _qwr∎
+
+    _qwr⟨_⟩_ : ∀  l₁ {l₂ l₃} → QuotWordRel l₁ l₂ → QuotWordRel l₂ l₃ → QuotWordRel l₁ l₃
+    _ qwr⟨ p ⟩ q = qwr-trans p q
+
+    _qwr⟨id⟩_ : ∀  l₁ {l₂} → QuotWordRel l₁ l₂ → QuotWordRel l₁ l₂
+    _ qwr⟨id⟩ q = q
+
+    _qwr∎ : ∀ l → QuotWordRel l l
+    _ qwr∎ = qwr-refl idp
+
+  qwr-flip-l : ∀ x₁ → QuotWordRel (flip x₁ :: x₁ :: nil) nil
+  qwr-flip-l x₁ =
+    flip x₁ :: x₁ :: nil
+      qwr⟨ qwr-refl (ap (λ s → flip x₁ :: s :: nil) (! (flip-flip x₁))) ⟩
+    flip x₁ :: flip (flip x₁) :: nil
+      qwr⟨ qwr-flip-r (flip x₁) ⟩
+    nil qwr∎
+
+module _ (A : Type i) (R : Rel (Word A) m) where
+  -- The quotient
+  QuotWord : Type (lmax i m)
+  QuotWord = SetQuot (QuotWordRel {A} {R})
+
+module _ {A : Type i} {R : Rel (Word A) m} where
+
+  qw[_] : Word A → QuotWord A R
+  qw[_] = q[_]
+
+  module QuotWordElim {k} {P : QuotWord A R → Type k}
+    {{_ : {x : QuotWord A R} → is-set (P x)}} (incl* : (a : Word A) → P qw[ a ])
+    (rel* : ∀ {a₁ a₂} (r : QuotWordRel a₁ a₂) → incl* a₁ == incl* a₂ [ P ↓ quot-rel r ])
+    = SetQuotElim incl* rel*
+  open QuotWordElim public renaming (f to QuotWord-elim) hiding (quot-rel-β)
+
+  module QuotWordRec {k} {B : Type k} {{_ : is-set B}} (incl* : Word A → B)
+    (rel* : ∀ {a₁ a₂} (r : QuotWordRel {A} {R} a₁ a₂) → incl* a₁ == incl* a₂)
+    = SetQuotRec incl* rel*
+  open QuotWordRec public renaming (f to QuotWord-rec)
+
+module _ (A : Type i) (R : Rel (Word A) m) where
+  private
+    infixl 80 _⊞_
+    _⊞_ : QuotWord A R → QuotWord A R → QuotWord A R
+    _⊞_ = QuotWord-rec
+      (λ l₁ → QuotWord-rec (λ l₂ → qw[ l₁ ++ l₂ ])
+        (λ r → quot-rel $ qwr-cong-r l₁ r))
+      (λ {l₁} {l₁'} r → λ= $ QuotWord-elim
+        (λ l₂ → quot-rel $ qwr-cong-l r l₂)
+        (λ _ → prop-has-all-paths-↓))
+
+    abstract
+      qwr-cancel-l : ∀ l
+        → QuotWordRel {A} {R} (Word-inverse l ++ l) nil
+      qwr-cancel-l nil = qwr-refl idp
+      qwr-cancel-l (x :: l) =
+        Word-inverse (x :: l) ++ (x :: l)
+          qwr⟨id⟩
+        (Word-inverse l ++ (flip x :: nil)) ++ (x :: l)
+          qwr⟨ qwr-refl (++-assoc (reverse (Word-flip l)) (flip x :: nil) (x :: l)) ⟩
+        Word-inverse l ++ ((flip x :: nil) ++ (x :: l))
+          qwr⟨id⟩
+        Word-inverse l ++ (flip x :: x :: l)
+          qwr⟨ qwr-cong-r (reverse (Word-flip l)) (qwr-cong-l (qwr-flip-l x) l) ⟩
+        Word-inverse l ++ l
+          qwr⟨ qwr-cancel-l l ⟩
+        nil qwr∎
+
+      qwr-cancel-r : ∀ l
+        → QuotWordRel (l ++ Word-inverse l) nil
+      qwr-cancel-r l =
+        l ++ Word-inverse l
+          qwr⟨ qwr-refl (ap (_++ Word-inverse l) (! (Word-inverse-inverse l))) ⟩
+        Word-inverse (Word-inverse l) ++ Word-inverse l
+          qwr⟨ qwr-cancel-l (Word-inverse l) ⟩
+        nil qwr∎
+
+      qwr-cong-inverse : ∀ {l₁ l₂}
+        → QuotWordRel l₁ l₂ → QuotWordRel (Word-inverse l₁) (Word-inverse l₂)
+      qwr-cong-inverse {l₁} {l₂} r =
+        Word-inverse l₁
+          qwr⟨ qwr-refl (! (++-unit-r (Word-inverse l₁))) ⟩
+        Word-inverse l₁ ++ nil
+          qwr⟨ qwr-cong-r (Word-inverse l₁) (qwr-sym (qwr-cancel-r l₂)) ⟩
+        Word-inverse l₁ ++ (l₂ ++ Word-inverse l₂)
+          qwr⟨ qwr-cong-r (Word-inverse l₁) (qwr-cong-l (qwr-sym r) (Word-inverse l₂)) ⟩
+        reverse (Word-flip l₁) ++ (l₁ ++ Word-inverse l₂)
+          qwr⟨ qwr-refl (! (++-assoc (Word-inverse l₁) l₁ (Word-inverse l₂))) ⟩
+        (Word-inverse l₁ ++ l₁) ++ Word-inverse l₂
+          qwr⟨ qwr-cong-l (qwr-cancel-l l₁) (Word-inverse l₂) ⟩
+        Word-inverse l₂ qwr∎
+
+    ⊟ : QuotWord A R → QuotWord A R
+    ⊟ = QuotWord-rec (qw[_] ∘ Word-inverse)
+      (λ r → quot-rel $ qwr-cong-inverse r)
+
+    ⊞-unit : QuotWord A R
+    ⊞-unit = qw[ nil ]
+
+    abstract
+      ⊞-unit-l : ∀ g → ⊞-unit ⊞ g == g
+      ⊞-unit-l = QuotWord-elim
+        (λ _ → idp)
+        (λ _ → prop-has-all-paths-↓)
+
+      ⊞-assoc : ∀ g₁ g₂ g₃ → (g₁ ⊞ g₂) ⊞ g₃ == g₁ ⊞ (g₂ ⊞ g₃)
+      ⊞-assoc = QuotWord-elim
+        (λ l₁ → QuotWord-elim
+          (λ l₂ → QuotWord-elim
+            (λ l₃ → ap qw[_] $ ++-assoc l₁ l₂ l₃)
+            (λ _ → prop-has-all-paths-↓))
+          (λ _ → prop-has-all-paths-↓))
+        (λ _ → prop-has-all-paths-↓)
+
+      ⊟-inv-l : ∀ g → (⊟ g) ⊞ g == ⊞-unit
+      ⊟-inv-l = QuotWord-elim
+        (λ l → quot-rel (qwr-cancel-l l))
+        (λ _ → prop-has-all-paths-↓)
+
+  QuotWord-group-structure : GroupStructure (QuotWord A R)
+  QuotWord-group-structure = record
+    { ident = ⊞-unit
+    ; inv = ⊟
+    ; comp = _⊞_
+    ; unit-l = ⊞-unit-l
+    ; assoc = ⊞-assoc
+    ; inv-l = ⊟-inv-l
+    }
+
+  GeneratedGroup : Group (lmax i m)
+  GeneratedGroup = group _ QuotWord-group-structure
+
+  module GeneratedGroup = Group GeneratedGroup
+
+-- freeness
+module _ {A : Type i} {R : Rel (Word A) m} {j} (G : Group j) where
+
+  private
+    module G = Group G
+
+  is-legal : (A → G.El) → Type (lmax (lmax i j) m)
+  is-legal f = ∀ {l₁ l₂} → R l₁ l₂ → Word-extendᴳ G f l₁ == Word-extendᴳ G f l₂
+
+  abstract
+    is-legal-is-prop : ∀ f → is-prop (is-legal f)
+    is-legal-is-prop f =
+      Πi-level $ λ l₁ →
+      Πi-level $ λ l₂ →
+      Π-level  $ λ r →
+      has-level-apply G.El-level _ _
+
+  record LegalFunction : Type (lmax (lmax i j) m) where
+    field
+      f : A → G.El
+      legality : is-legal f
+
+  LegalFunction= : {lf lg : LegalFunction}
+    → LegalFunction.f lf == LegalFunction.f lg
+    → lf == lg
+  LegalFunction= {lf} {lg} idp =
+    ap mk-legal-function $
+    prop-path (is-legal-is-prop lf.f) lf.legality lg.legality
+    where
+      module lf = LegalFunction lf
+      module lg = LegalFunction lg
+      mk-legal-function : is-legal lf.f → LegalFunction
+      mk-legal-function l = record { f = lf.f; legality = l }
+
+  module _ (fun : LegalFunction) where
+
+    private
+      module fun = LegalFunction fun
+      f* = fun.f
+
+      abstract
+        Word-extendᴳ-emap : ∀ {l₁ l₂}
+          → QuotWordRel {A} {R} l₁ l₂
+          → Word-extendᴳ G f* l₁ == Word-extendᴳ G f* l₂
+        Word-extendᴳ-emap (qwr-refl idp) = idp
+        Word-extendᴳ-emap (qwr-trans qwr qwr₁) = (Word-extendᴳ-emap qwr) ∙ (Word-extendᴳ-emap qwr₁)
+        Word-extendᴳ-emap (qwr-sym qwr) = ! (Word-extendᴳ-emap qwr)
+        Word-extendᴳ-emap (qwr-flip-r x) =
+          G.comp (PlusMinus-extendᴳ G f* x) (G.comp (PlusMinus-extendᴳ G f* (flip x)) G.ident)
+            =⟨ ap (G.comp (PlusMinus-extendᴳ G f* x)) (G.unit-r (PlusMinus-extendᴳ G f* (flip x))) ⟩
+          G.comp (PlusMinus-extendᴳ G f* x) (PlusMinus-extendᴳ G f* (flip x))
+            =⟨ ap (G.comp (PlusMinus-extendᴳ G f* x)) (PlusMinus-extendᴳ-flip G f* x) ⟩
+          G.comp (PlusMinus-extendᴳ G f* x) (G.inv (PlusMinus-extendᴳ G f* x))
+            =⟨ G.inv-r (PlusMinus-extendᴳ G f* x) ⟩
+          G.ident =∎
+        Word-extendᴳ-emap (qwr-cong {l₁} {l₂} {l₃} {l₄} qwr qwr') =
+          Word-extendᴳ G f* (l₁ ++ l₃)
+            =⟨ Word-extendᴳ-++ G f* l₁ l₃ ⟩
+          G.comp (Word-extendᴳ G f* l₁) (Word-extendᴳ G f* l₃)
+            =⟨ ap2 G.comp (Word-extendᴳ-emap qwr) (Word-extendᴳ-emap qwr') ⟩
+          G.comp (Word-extendᴳ G f* l₂) (Word-extendᴳ G f* l₄)
+            =⟨ ! (Word-extendᴳ-++ G f* l₂ l₄) ⟩
+          Word-extendᴳ G f* (l₂ ++ l₄) =∎
+        Word-extendᴳ-emap (qwr-rel r) = fun.legality r
+
+    GeneratedGroup-extend : (GeneratedGroup A R →ᴳ G)
+    GeneratedGroup-extend = record {M} where
+      module M where
+        f : QuotWord A R → G.El
+        f = QuotWord-rec {A} {R} (Word-extendᴳ G f*)
+            (λ r → Word-extendᴳ-emap r)
+        abstract
+          pres-comp : preserves-comp (GeneratedGroup.comp A R) G.comp f
+          pres-comp =
+            QuotWord-elim
+              (λ l₁ → QuotWord-elim
+                (λ l₂ → Word-extendᴳ-++ G f* l₁ l₂)
+                (λ _ → prop-has-all-paths-↓))
+              (λ _ → prop-has-all-paths-↓)
+
+  private
+    module Lemma (hom : GeneratedGroup A R →ᴳ G) where
+      private
+        open GroupHom hom
+        f* : A → G.El
+        f* a = f qw[ inl a :: nil ]
+
+      abstract
+        PlusMinus-extendᴳ-hom : ∀ x → PlusMinus-extendᴳ G f* x == f qw[ x :: nil ]
+        PlusMinus-extendᴳ-hom (inl x) = idp
+        PlusMinus-extendᴳ-hom (inr x) = ! $ pres-inv qw[ inl x :: nil ]
+
+        Word-extendᴳ-hom : ∀ l → Word-extendᴳ G f* l == f qw[ l ]
+        Word-extendᴳ-hom nil = ! pres-ident
+        Word-extendᴳ-hom (x :: l) =
+          G.comp (PlusMinus-extendᴳ G f* x) (Word-extendᴳ G f* l)
+            =⟨ ap2 G.comp (PlusMinus-extendᴳ-hom x) (Word-extendᴳ-hom l) ⟩
+          G.comp (f qw[ x :: nil ]) (f qw[ l ])
+            =⟨ ! (pres-comp _ _) ⟩
+          f qw[ x :: l ] =∎
+
+        f*-legal : ∀ {l₁ l₂} → R l₁ l₂ → Word-extendᴳ G f* l₁ == Word-extendᴳ G f* l₂
+        f*-legal {l₁} {l₂} r =
+          Word-extendᴳ G f* l₁
+            =⟨ Word-extendᴳ-hom l₁ ⟩
+          f qw[ l₁ ]
+            =⟨ ap f (quot-rel (qwr-rel r)) ⟩
+          f qw[ l₂ ]
+            =⟨ ! (Word-extendᴳ-hom l₂) ⟩
+          Word-extendᴳ G f* l₂ =∎
+
+      legal-function : LegalFunction
+      legal-function = record { f = f*; legality = f*-legal }
+
+    open Lemma
+
+  GeneratedGroup-extend-is-equiv : is-equiv GeneratedGroup-extend
+  GeneratedGroup-extend-is-equiv = is-eq _ from to-from from-to where
+    to = GeneratedGroup-extend
+    from = legal-function
+
+    abstract
+      to-from : ∀ h → to (from h) == h
+      to-from h = group-hom= $ λ= $ QuotWord-elim
+        (λ l → Word-extendᴳ-hom h l)
+        (λ _ → prop-has-all-paths-↓)
+
+      from-to : ∀ fun → from (to fun) == fun
+      from-to fun = LegalFunction= (λ= λ a → G.unit-r (LegalFunction.f fun a))
+
+  GeneratedGroup-extend-equiv : LegalFunction ≃ (GeneratedGroup A R →ᴳ G)
+  GeneratedGroup-extend-equiv = GeneratedGroup-extend , GeneratedGroup-extend-is-equiv

--- a/core/lib/groups/GeneratedGroup.agda
+++ b/core/lib/groups/GeneratedGroup.agda
@@ -183,6 +183,9 @@ module GeneratedGroup (A : Type i) (R : Rel (Word A) m) where
     pres-exp a (negsucc (S n)) =
       ap (GenGroup.comp qw[ inr a :: nil ]) (pres-exp a (negsucc n))
 
+    rel-holds : ∀ {w₁} {w₂} (r : R w₁ w₂) → qw[ w₁ ] == qw[ w₂ ]
+    rel-holds r = quot-rel (qwr-rel r)
+
   -- freeness
   module HomomorphismEquiv {j} (G : Group j) where
 

--- a/core/lib/groups/Groups.agda
+++ b/core/lib/groups/Groups.agda
@@ -6,6 +6,7 @@ module lib.groups.Groups where
 open import lib.groups.CommutingSquare public
 open import lib.groups.FreeAbelianGroup public
 open import lib.groups.FreeGroup public
+open import lib.groups.GeneratedAbelianGroup public
 open import lib.groups.GeneratedGroup public
 open import lib.groups.GroupProduct public
 open import lib.groups.Homomorphism public

--- a/core/lib/groups/Groups.agda
+++ b/core/lib/groups/Groups.agda
@@ -6,6 +6,7 @@ module lib.groups.Groups where
 open import lib.groups.CommutingSquare public
 open import lib.groups.FreeAbelianGroup public
 open import lib.groups.FreeGroup public
+open import lib.groups.GeneratedGroup public
 open import lib.groups.GroupProduct public
 open import lib.groups.Homomorphism public
 open import lib.groups.HomotopyGroup public

--- a/core/lib/groups/Groups.agda
+++ b/core/lib/groups/Groups.agda
@@ -19,5 +19,6 @@ open import lib.groups.QuotientGroup public
 open import lib.groups.PullbackGroup public
 open import lib.groups.Subgroup public
 open import lib.groups.SubgroupProp public
+open import lib.groups.TensorProduct public
 open import lib.groups.TruncationGroup public
 open import lib.groups.Unit public

--- a/core/lib/groups/Int.agda
+++ b/core/lib/groups/Int.agda
@@ -9,6 +9,7 @@ open import lib.types.Word
 open import lib.groups.Homomorphism
 open import lib.groups.Isomorphism
 open import lib.groups.FreeAbelianGroup
+open import lib.groups.GeneratedGroup
 open import lib.types.SetQuotient
 
 module lib.groups.Int where
@@ -32,36 +33,51 @@ module lib.groups.Int where
 ℤ-abgroup : AbGroup₀
 ℤ-abgroup = ℤ-group , ℤ-group-is-abelian
 
-ℤ-iso-FreeAbGroup-Unit : ℤ-group ≃ᴳ FreeAbGroup.grp Unit
-ℤ-iso-FreeAbGroup-Unit = ≃-to-≃ᴳ (equiv to from to-from from-to) to-pres-comp where
-  to = FreeAbGroup.exp Unit fs[ inl unit :: nil ]
-  from = FormalSum-extend ℤ-abgroup (λ _ → 1)
-  abstract
-    to-pres-comp = FreeAbGroup.exp-+ Unit fs[ inl unit :: nil ]
+private
+  module OneGeneratorFreeAbGroup = FreeAbelianGroup Unit
 
-    to-from' : ∀ l → to (Word-extendᴳ ℤ-group (λ _ → 1) l) == fs[ l ]
+OneGenFreeAbGroup : AbGroup lzero
+OneGenFreeAbGroup = OneGeneratorFreeAbGroup.FreeAbGroup
+
+private
+  module OneGenFreeAbGroup = AbGroup OneGenFreeAbGroup
+
+ℤ-iso-FreeAbGroup-Unit : ℤ-group ≃ᴳ OneGenFreeAbGroup.grp
+ℤ-iso-FreeAbGroup-Unit = ≃-to-≃ᴳ (equiv to from to-from from-to) to-pres-comp where
+  open OneGeneratorFreeAbGroup
+  module F = Freeness ℤ-abgroup
+  to : Group.El ℤ-group → OneGenFreeAbGroup.El
+  to = OneGenFreeAbGroup.exp qw[ inl unit :: nil ]
+  from : OneGenFreeAbGroup.El → Group.El ℤ-group
+  from = GroupHom.f (F.extend (λ _ → 1))
+  abstract
+    to-pres-comp = OneGenFreeAbGroup.exp-+ qw[ inl unit :: nil ]
+
+    to-from' : ∀ l → to (Word-extendᴳ ℤ-group (λ _ → 1) l) == qw[ l ]
     to-from' nil = idp
-    to-from' (inl unit :: l) =
-        FreeAbGroup.exp-succ Unit fs[ inl unit :: nil ] (Word-extendᴳ ℤ-group (λ _ → 1) l)
-      ∙ ap (FreeAbGroup.comp Unit fs[ inl unit :: nil ]) (to-from' l)
-    to-from' (inr unit :: l) =
-        FreeAbGroup.exp-pred Unit fs[ inl unit :: nil ] (Word-extendᴳ ℤ-group (λ _ → 1) l)
-      ∙ ap (FreeAbGroup.comp Unit fs[ inr unit :: nil ]) (to-from' l)
+    to-from' (inl unit :: nil) = idp
+    to-from' (inl unit :: l@(_ :: _)) =
+        OneGenFreeAbGroup.exp-succ qw[ inl unit :: nil ] (Word-extendᴳ ℤ-group (λ _ → 1) l)
+      ∙ ap (OneGenFreeAbGroup.comp qw[ inl unit :: nil ]) (to-from' l)
+    to-from' (inr unit :: nil) = idp
+    to-from' (inr unit :: l@(_ :: _)) =
+        OneGenFreeAbGroup.exp-pred qw[ inl unit :: nil ] (Word-extendᴳ ℤ-group (λ _ → 1) l)
+      ∙ ap (OneGenFreeAbGroup.comp qw[ inr unit :: nil ]) (to-from' l)
 
     to-from : ∀ fs → to (from fs) == fs
-    to-from = FormalSum-elim to-from' (λ _ → prop-has-all-paths-↓)
+    to-from = QuotWord-elim to-from' (λ _ → prop-has-all-paths-↓)
 
     from-to : ∀ z → from (to z) == z
     from-to (pos 0) = idp
     from-to (pos 1) = idp
     from-to (negsucc 0) = idp
     from-to (pos (S (S n))) =
-        GroupHom.pres-comp (FreeAbGroup-extend ℤ-abgroup (λ _ → 1))
-          fs[ inl unit :: nil ] (FreeAbGroup.exp Unit fs[ inl unit :: nil ] (pos (S n)))
+        GroupHom.pres-comp (F.extend (λ _ → 1))
+          qw[ inl unit :: nil ] (OneGenFreeAbGroup.exp qw[ inl unit :: nil ] (pos (S n)))
       ∙ ap succ (from-to (pos (S n)))
     from-to (negsucc (S n)) =
-        GroupHom.pres-comp (FreeAbGroup-extend ℤ-abgroup (λ _ → 1))
-          fs[ inr unit :: nil ] (FreeAbGroup.exp Unit fs[ inl unit :: nil ] (negsucc n))
+        GroupHom.pres-comp (F.extend (λ _ → 1))
+          qw[ inr unit :: nil ] (OneGenFreeAbGroup.exp qw[ inl unit :: nil ] (negsucc n))
       ∙ ap pred (from-to (negsucc n))
 
 exp-shom : ∀ {i} {GEl : Type i} (GS : GroupStructure GEl) (g : GEl) → ℤ-group-structure →ᴳˢ GS

--- a/core/lib/groups/TensorProduct.agda
+++ b/core/lib/groups/TensorProduct.agda
@@ -1,0 +1,146 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+open import lib.Basics
+open import lib.types.Group
+open import lib.types.List
+open import lib.types.Pi
+open import lib.types.Word
+open import lib.groups.Homomorphism
+open import lib.groups.GeneratedGroup
+open import lib.groups.GeneratedAbelianGroup
+
+module lib.groups.TensorProduct {i} {j} where
+
+module _ {G : AbGroup i} {H : AbGroup j} where
+
+  record ⊗-pair : Type (lmax i j) where
+    constructor _⊗_
+    field
+      ⊗-fst : AbGroup.El G
+      ⊗-snd : AbGroup.El H
+
+module _ (G : AbGroup i) (H : AbGroup j) where
+
+  private
+    module G = AbGroup G
+    module H = AbGroup H
+
+  data ⊗-rel : Word (⊗-pair {G} {H}) → Word (⊗-pair {G} {H}) → Type (lmax i j) where
+    linear-l : (g₁ g₂ : G.El) (h : H.El) →
+      ⊗-rel (inl (G.comp g₁ g₂ ⊗ h) :: nil) (inl (g₁ ⊗ h) :: inl (g₂ ⊗ h) :: nil)
+    linear-r : (g : G.El) (h₁ h₂ : H.El) →
+      ⊗-rel (inl (g ⊗ H.comp h₁ h₂) :: nil) (inl (g ⊗ h₁) :: inl (g ⊗ h₂) :: nil)
+
+  TensorProduct : AbGroup (lmax i j)
+  TensorProduct = GeneratedAbGroup ⊗-pair ⊗-rel
+
+  module TensorProduct = AbGroup TensorProduct
+
+  module _ {k} {L : AbGroup k} where
+
+    private
+      module L = AbGroup L
+
+    is-linear-l : (G.El → H.El → L.El) → Type (lmax i (lmax j k))
+    is-linear-l b = ∀ g₁ g₂ h → b (G.comp g₁ g₂) h == L.comp (b g₁ h) (b g₂ h)
+
+    is-linear-l-is-prop : (b : G.El → H.El → L.El) → is-prop (is-linear-l b)
+    is-linear-l-is-prop b =
+      Π-level $ λ g₁ →
+      Π-level $ λ g₂ →
+      Π-level $ λ h →
+      has-level-apply L.El-level _ _
+
+    is-linear-r : (G.El → H.El → L.El) → Type (lmax i (lmax j k))
+    is-linear-r b = ∀ g h₁ h₂ → b g (H.comp h₁ h₂) == L.comp (b g h₁) (b g h₂)
+
+    is-linear-r-is-prop : (b : G.El → H.El → L.El) → is-prop (is-linear-r b)
+    is-linear-r-is-prop b =
+      Π-level $ λ g →
+      Π-level $ λ h₁ →
+      Π-level $ λ h₂ →
+      has-level-apply L.El-level _ _
+
+    record BilinearMap : Type (lmax i (lmax j k)) where
+      field
+        bmap : G.El → H.El → L.El
+        linearity-l : is-linear-l bmap
+        linearity-r : is-linear-r bmap
+
+    BilinearMap= : {b b' : BilinearMap}
+      → BilinearMap.bmap b == BilinearMap.bmap b'
+      → b == b'
+    BilinearMap= {b} {b'} idp =
+      ap2 mk-bilinear-map
+        (prop-path (is-linear-l-is-prop b.bmap) b.linearity-l b'.linearity-l)
+        (prop-path (is-linear-r-is-prop b.bmap) b.linearity-r b'.linearity-r)
+      where
+      module b  = BilinearMap b
+      module b' = BilinearMap b'
+      mk-bilinear-map : is-linear-l b.bmap → is-linear-r b.bmap → BilinearMap
+      mk-bilinear-map lin-l lin-r =
+        record { bmap = b.bmap; linearity-l = lin-l; linearity-r = lin-r }
+
+    bilinear-to-legal : BilinearMap → LegalFunction {A = ⊗-pair {G} {H}} {⊗-rel} L.grp
+    bilinear-to-legal b = record { f = f; legality = legality }
+      where
+      module b = BilinearMap b
+      f : ⊗-pair {G} {H} → L.El
+      f (g ⊗ h) = b.bmap g h
+      legality : is-legal {A = ⊗-pair {G} {H}} {⊗-rel} L.grp f
+      legality (linear-l g₁ g₂ h) =
+        Word-extendᴳ L.grp f (inl (G.comp g₁ g₂ ⊗ h) :: nil)
+          =⟨ L.unit-r _ ⟩
+        b.bmap (G.comp g₁ g₂) h
+          =⟨ b.linearity-l g₁ g₂ h ⟩
+        L.comp (b.bmap g₁ h) (b.bmap g₂ h)
+          =⟨ ap (L.comp (b.bmap g₁ h)) (! (L.unit-r _)) ⟩
+        Word-extendᴳ L.grp f (inl (g₁ ⊗ h) :: inl (g₂ ⊗ h) :: nil) =∎
+      legality (linear-r g h₁ h₂) =
+        Word-extendᴳ L.grp f (inl (g ⊗ H.comp h₁ h₂) :: nil)
+          =⟨ L.unit-r _ ⟩
+        b.bmap g (H.comp h₁ h₂)
+          =⟨ b.linearity-r g h₁ h₂ ⟩
+        L.comp (b.bmap g h₁) (b.bmap g h₂)
+          =⟨ ap (L.comp (b.bmap g h₁)) (! (L.unit-r _)) ⟩
+        Word-extendᴳ L.grp f (inl (g ⊗ h₁) :: inl (g ⊗ h₂) :: nil) =∎
+
+    legal-to-bilinear : LegalFunction {A = ⊗-pair {G} {H}} {⊗-rel} L.grp → BilinearMap
+    legal-to-bilinear lf =
+      record { bmap = bmap; linearity-l = linearity-l; linearity-r = linearity-r }
+      where
+      module lf = LegalFunction lf
+      bmap : G.El → H.El → L.El
+      bmap g h = lf.f (g ⊗ h)
+      linearity-l : is-linear-l bmap
+      linearity-l g₁ g₂ h =
+        bmap (G.comp g₁ g₂) h
+          =⟨ ! (L.unit-r _) ⟩
+        Word-extendᴳ L.grp lf.f (inl (G.comp g₁ g₂ ⊗ h) :: nil)
+          =⟨ lf.legality (linear-l g₁ g₂ h) ⟩
+        Word-extendᴳ L.grp lf.f (inl (g₁ ⊗ h) :: inl (g₂ ⊗ h) :: nil)
+          =⟨ ap (L.comp (bmap g₁ h)) (L.unit-r _) ⟩
+        L.comp (bmap g₁ h) (bmap g₂ h) =∎
+      linearity-r : is-linear-r bmap
+      linearity-r g h₁ h₂ =
+        bmap g (H.comp h₁ h₂)
+          =⟨ ! (L.unit-r _) ⟩
+        Word-extendᴳ L.grp lf.f (inl (g ⊗ H.comp h₁ h₂) :: nil)
+          =⟨ lf.legality (linear-r g h₁ h₂) ⟩
+        Word-extendᴳ L.grp lf.f (inl (g ⊗ h₁) :: inl (g ⊗ h₂) :: nil)
+          =⟨ ap (L.comp (bmap g h₁)) (L.unit-r _) ⟩
+        L.comp (bmap g h₁) (bmap g h₂) =∎
+
+    bilinear-to-legal-equiv : BilinearMap ≃ LegalFunction {A = ⊗-pair {G} {H}} {⊗-rel} L.grp
+    bilinear-to-legal-equiv =
+      equiv bilinear-to-legal
+            legal-to-bilinear
+            (λ lf → LegalFunction= L.grp idp)
+            (λ b  → BilinearMap= idp)
+
+    TensorProduct-extend-equiv : BilinearMap ≃ (TensorProduct.grp →ᴳ L.grp)
+    TensorProduct-extend-equiv =
+      GeneratedAbGroup-extend-equiv (⊗-pair {G} {H}) ⊗-rel L ∘e bilinear-to-legal-equiv
+
+    TensorProduct-extend : BilinearMap → (TensorProduct.grp →ᴳ L.grp)
+    TensorProduct-extend = –> TensorProduct-extend-equiv

--- a/core/lib/groups/TensorProduct.agda
+++ b/core/lib/groups/TensorProduct.agda
@@ -4,43 +4,56 @@ open import lib.Basics
 open import lib.types.Group
 open import lib.types.List
 open import lib.types.Pi
+open import lib.types.Sigma
 open import lib.types.Word
 open import lib.groups.Homomorphism
 open import lib.groups.GeneratedGroup
 open import lib.groups.GeneratedAbelianGroup
+open import lib.groups.Isomorphism
 
-module lib.groups.TensorProduct {i} {j} (G : AbGroup i) (H : AbGroup j) where
+module lib.groups.TensorProduct where
 
-  record ⊗-pair : Type (lmax i j) where
-    constructor _⊗_
-    field
-      ⊗-fst : AbGroup.El G
-      ⊗-snd : AbGroup.El H
+module TensorProduct₀ {i} {j} (G : AbGroup i) (H : AbGroup j) where
 
   private
     module G = AbGroup G
     module H = AbGroup H
 
+  ⊗-pair : Type (lmax i j)
+  ⊗-pair = G.El × H.El
+
   data ⊗-rel : Word ⊗-pair → Word ⊗-pair → Type (lmax i j) where
     linear-l : (g₁ g₂ : G.El) (h : H.El) →
-      ⊗-rel (inl (G.comp g₁ g₂ ⊗ h) :: nil) (inl (g₁ ⊗ h) :: inl (g₂ ⊗ h) :: nil)
+      ⊗-rel (inl (G.comp g₁ g₂ , h) :: nil) (inl (g₁ , h) :: inl (g₂ , h) :: nil)
     linear-r : (g : G.El) (h₁ h₂ : H.El) →
-      ⊗-rel (inl (g ⊗ H.comp h₁ h₂) :: nil) (inl (g ⊗ h₁) :: inl (g ⊗ h₂) :: nil)
+      ⊗-rel (inl (g , H.comp h₁ h₂) :: nil) (inl (g , h₁) :: inl (g , h₂) :: nil)
 
   private
     module Gen = GeneratedAbelianGroup ⊗-pair ⊗-rel
-  open Gen hiding (GenGroup; GenAbGroup) public
+  open Gen hiding (GenGroup; GenAbGroup; El) public
 
-  TensorProduct : AbGroup (lmax i j)
-  TensorProduct = Gen.GenAbGroup
+  abstract
+    abgroup : AbGroup (lmax i j)
+    abgroup = Gen.GenAbGroup
 
-  module TensorProduct = AbGroup TensorProduct
+  open AbGroup abgroup public
 
-  module UniversalProperty {k} (L : AbGroup k) where
+  abstract
+    infixr 80 _⊗_
+    _⊗_ : G.El → H.El → El
+    _⊗_ g h = insert (g , h)
+
+    lin-l : ∀ g₁ g₂ h → G.comp g₁ g₂ ⊗ h == comp (g₁ ⊗ h) (g₂ ⊗ h)
+    lin-l g₁ g₂ h = rel-holds (linear-l g₁ g₂ h)
+
+    lin-r : ∀ g h₁ h₂ → g ⊗ H.comp h₁ h₂ == comp (g ⊗ h₁) (g ⊗ h₂)
+    lin-r g h₁ h₂ = rel-holds (linear-r g h₁ h₂)
+
+  module BilinearMaps {k} (L : AbGroup k) where
 
     private
-      module HE = Gen.HomomorphismEquiv L
       module L = AbGroup L
+      module HE = Gen.HomomorphismEquiv L
 
     is-linear-l : (G.El → H.El → L.El) → Type (lmax i (lmax j k))
     is-linear-l b = ∀ g₁ g₂ h → b (G.comp g₁ g₂) h == L.comp (b g₁ h) (b g₂ h)
@@ -93,7 +106,7 @@ module lib.groups.TensorProduct {i} {j} (G : AbGroup i) (H : AbGroup j) where
         where
         module b = BilinearMap b
         f : ⊗-pair → L.El
-        f (g ⊗ h) = b.bmap g h
+        f (g , h) = b.bmap g h
         f-respects : HE.respects-rel f
         f-respects (linear-l g₁ g₂ h) = b.linearity-l g₁ g₂ h
         f-respects (linear-r g h₁ h₂) = b.linearity-r g h₁ h₂
@@ -102,15 +115,96 @@ module lib.groups.TensorProduct {i} {j} (G : AbGroup i) (H : AbGroup j) where
         record { bmap = bmap; linearity-l = linearity-l; linearity-r = linearity-r }
         where
         bmap : G.El → H.El → L.El
-        bmap g h = f (g ⊗ h)
+        bmap g h = f (g , h)
         linearity-l : is-linear-l bmap
         linearity-l g₁ g₂ h = f-respects (linear-l g₁ g₂ h)
         linearity-r : is-linear-r bmap
         linearity-r g h₁ h₂ = f-respects (linear-r g h₁ h₂)
 
-    TensorProduct-extend-equiv : BilinearMap ≃ (TensorProduct.grp →ᴳ L.grp)
-    TensorProduct-extend-equiv =
-      HE.extend-equiv ∘e bilinear-to-legal-equiv
+  module UniversalProperty {k} (L : AbGroup k) where
 
-    TensorProduct-extend : BilinearMap → (TensorProduct.grp →ᴳ L.grp)
-    TensorProduct-extend = –> TensorProduct-extend-equiv
+    open BilinearMaps L public
+    private
+      module HE = Gen.HomomorphismEquiv L
+
+    abstract
+      extend-equiv : BilinearMap ≃ (grp →ᴳ AbGroup.grp L)
+      extend-equiv =
+        HE.extend-equiv ∘e bilinear-to-legal-equiv
+
+      extend : BilinearMap → (grp →ᴳ AbGroup.grp L)
+      extend = –> extend-equiv
+
+      restrict : (grp →ᴳ AbGroup.grp L) → BilinearMap
+      restrict = <– extend-equiv
+
+      extend-β : ∀ b g h → GroupHom.f (extend b) (g ⊗ h) == BilinearMap.bmap b g h
+      extend-β b g h = idp
+
+      hom= : ∀ {ϕ ψ : grp →ᴳ AbGroup.grp L}
+        → (∀ g h → GroupHom.f ϕ (g ⊗ h) == GroupHom.f ψ (g ⊗ h))
+        → ϕ == ψ
+      hom= {ϕ} {ψ} e =
+        ϕ
+          =⟨ ! (<–-inv-r extend-equiv ϕ) ⟩
+        extend (restrict ϕ)
+          =⟨ ap extend (BilinearMap= (λ= (λ g → λ= (λ h → e g h)))) ⟩
+        extend (restrict ψ)
+          =⟨ <–-inv-r extend-equiv ψ ⟩
+        ψ =∎
+
+module TensorProduct₁ {i} {j} (G : AbGroup i) (H : AbGroup j) where
+
+
+  private
+    module G⊗H = TensorProduct₀ G H
+    module H⊗G = TensorProduct₀ H G
+    module F = G⊗H.UniversalProperty H⊗G.abgroup
+
+    b : F.BilinearMap
+    b =
+      record
+      { bmap = λ g h → h H⊗G.⊗ g
+      ; linearity-l = λ g₁ g₂ h → H⊗G.lin-r h g₁ g₂
+      ; linearity-r = λ g h₁ h₂ → H⊗G.lin-l h₁ h₂ g
+      }
+
+  swap : (G⊗H.grp →ᴳ H⊗G.grp)
+  swap = F.extend b
+
+  swap-β : ∀ g h →
+    GroupHom.f swap (g G⊗H.⊗ h) == h H⊗G.⊗ g
+  swap-β g h = F.extend-β b g h
+
+  open G⊗H public
+
+module TensorProduct {i} {j} (G : AbGroup i) (H : AbGroup j) where
+
+  private
+    module G⊗H = TensorProduct₁ G H
+    module H⊗G = TensorProduct₁ H G
+
+  commutative : G⊗H.grp ≃ᴳ H⊗G.grp
+  commutative =
+    to-hom , is-eq to from to-from from-to
+    where
+    to-hom : G⊗H.grp →ᴳ H⊗G.grp
+    to-hom = G⊗H.swap
+    to : G⊗H.El → H⊗G.El
+    to = GroupHom.f to-hom
+    from-hom : H⊗G.grp →ᴳ G⊗H.grp
+    from-hom = H⊗G.swap
+    from : H⊗G.El → G⊗H.El
+    from = GroupHom.f from-hom
+    to-from : ∀ s → to (from s) == s
+    to-from s =
+      ap (λ ϕ → GroupHom.f ϕ s) $
+      H⊗G.UniversalProperty.hom= H⊗G.abgroup {ϕ = to-hom ∘ᴳ from-hom} {ψ = idhom _} $
+      λ h g → ap to (H⊗G.swap-β h g) ∙ G⊗H.swap-β g h
+    from-to : ∀ t → from (to t) == t
+    from-to t =
+      ap (λ ϕ → GroupHom.f ϕ t) $
+      G⊗H.UniversalProperty.hom= G⊗H.abgroup {ϕ = from-hom ∘ᴳ to-hom} {ψ = idhom _} $
+      λ g h → ap from (G⊗H.swap-β g h) ∙ H⊗G.swap-β h g
+
+  open G⊗H public

--- a/core/lib/types/CRing.agda
+++ b/core/lib/types/CRing.agda
@@ -3,6 +3,7 @@
 open import lib.Basics
 open import lib.types.Group
 open import lib.groups.Homomorphism
+open import lib.groups.TensorProduct
 
 module lib.types.CRing where
 
@@ -82,14 +83,32 @@ record CRing i : Type (lsucc i) where
   add-group : Group i
   add-group = group El add-group-struct
 
-  add-ab-group : AbGroup i
-  add-ab-group = add-group , add-comm
+  add-abgroup : AbGroup i
+  add-abgroup = add-group , add-comm
 
   mult-hom : El → add-group →ᴳ add-group
   mult-hom g = group-hom (mult g) (distr-r g)
 
   mult-hom-zero : mult-hom zero == cst-hom
   mult-hom-zero = group-hom= (λ= mult-zero-l)
+
+  private
+    module R⊗R = TensorProduct add-abgroup add-abgroup
+    module UP = R⊗R.UniversalProperty add-abgroup
+
+    mult-bilinear-map : UP.BilinearMap
+    mult-bilinear-map =
+      record
+      { bmap = mult
+      ; linearity-l = distr-l
+      ; linearity-r = distr-r
+      }
+
+  mult-hom' : R⊗R.grp →ᴳ add-group
+  mult-hom' = UP.extend mult-bilinear-map
+
+  mult-hom'-β : ∀ a b → GroupHom.f mult-hom' (a R⊗R.⊗ b) == mult a b
+  mult-hom'-β = UP.extend-β mult-bilinear-map
 
 Ring₀ : Type (lsucc lzero)
 Ring₀ = CRing lzero

--- a/core/lib/types/List.agda
+++ b/core/lib/types/List.agda
@@ -90,6 +90,20 @@ module _ {i} {A : Type i} where
     foldr-++ b nil l₂ = idp
     foldr-++ b (a :: l₁) l₂ = ap (f a) (foldr-++ b l₁ l₂)
 
+  module _ (f : A → A → A) where
+    foldr' : A → List A → A
+    foldr' d nil = d
+    foldr' _ (a :: nil) = a
+    foldr' d (a :: l@(_ :: _)) = f a (foldr' d l)
+
+    foldr'=foldr : ∀ d → (∀ a → f a d == a)
+      → (l : List A)
+      → foldr' d l == foldr f d l
+    foldr'=foldr d is-unit-r nil = idp
+    foldr'=foldr d is-unit-r (a :: nil) = ! (is-unit-r a)
+    foldr'=foldr d is-unit-r (a :: l@(_ :: _)) =
+      ap (f a) (foldr'=foldr d is-unit-r l)
+
   -- [length] in Haskell
   length : List A → ℕ
   length = foldr (λ _ n → S n) 0

--- a/core/lib/types/List.agda
+++ b/core/lib/types/List.agda
@@ -79,10 +79,16 @@ module _ {i} {A : Type i} where
   ∈-++ : ∀ a l₁ l₂ → a ∈ (l₁ ++ l₂) → (a ∈ l₁) ⊔ (a ∈ l₂)
   ∈-++ a = Any-++ (_== a)
 
-  -- [foldr] in Haskell
-  foldr : ∀ {j} {B : Type j} → (A → B → B) → B → List A → B
-  foldr f b nil = b
-  foldr f b (a :: l) = f a (foldr f b l)
+  module _ {j} {B : Type j} (f : A → B → B) where
+    -- [foldr] in Haskell
+    foldr : B → List A → B
+    foldr b nil = b
+    foldr b (a :: l) = f a (foldr b l)
+
+    foldr-++ : ∀ b l₁ l₂
+      → foldr b (l₁ ++ l₂) == foldr (foldr b l₂) l₁
+    foldr-++ b nil l₂ = idp
+    foldr-++ b (a :: l₁) l₂ = ap (f a) (foldr-++ b l₁ l₂)
 
   -- [length] in Haskell
   length : List A → ℕ
@@ -137,11 +143,20 @@ module _ {i j} {A : Type i} {B : Type j} (f : A → B) where
   map-++ : ∀ l₁ l₂ → map (l₁ ++ l₂) == map l₁ ++ map l₂
   map-++ nil l₂ = idp
   map-++ (x :: l₁) l₂ = ap (f x ::_) (map-++ l₁ l₂)
-{-
+
   reverse-map : ∀ l → reverse (map l) == map (reverse l)
   reverse-map nil = idp
-  reverse-map (x :: l) = {! ! (map-++ (reverse l) (x :: nil)) !}
--}
+  reverse-map (x :: l) =
+    snoc (reverse (map l)) (f x)
+      =⟨ ap (λ l' → snoc l' (f x)) (reverse-map l) ⟩
+    snoc (map (reverse l)) (f x)
+      =⟨ idp ⟩
+    map (reverse l) ++ map (x :: nil)
+      =⟨ ! (map-++ (reverse l) (x :: nil)) ⟩
+    map (reverse l ++ (x :: nil))
+      =⟨ idp ⟩
+    map (reverse (x :: l)) =∎
+
 -- These functions use different [A], [B] or [f].
 module _ {i} {A : Type i} where
   -- [concat] in Haskell

--- a/core/lib/types/Word.agda
+++ b/core/lib/types/Word.agda
@@ -37,6 +37,19 @@ module _ {A : Type i} where
   Word-flip-flip nil = idp
   Word-flip-flip (x :: l) = ap2 _::_ (flip-flip x) (Word-flip-flip l)
 
+  Word-inverse : Word A → Word A
+  Word-inverse = reverse ∘ Word-flip
+
+  Word-inverse-inverse : ∀ w → Word-inverse (Word-inverse w) == w
+  Word-inverse-inverse w =
+    Word-inverse (Word-inverse w)
+      =⟨ reverse-map flip (Word-inverse w) ⟩
+    Word-flip (reverse (reverse (Word-flip w)))
+      =⟨ ap Word-flip (reverse-reverse (Word-flip w)) ⟩
+    Word-flip (Word-flip w)
+      =⟨ Word-flip-flip w ⟩
+    w =∎
+
   Word-exp : A → ℤ → Word A
   Word-exp a (pos 0) = nil
   Word-exp a (pos (S n)) = inl a :: Word-exp a (pos n)
@@ -47,12 +60,17 @@ module _ {A : Type i} {j} (G : Group j) where
   private
     module G = Group G
 
-  PlusMinus-extendᴳ : (A → G.El) → (PlusMinus A → G.El)
-  PlusMinus-extendᴳ f (inl a) = f a
-  PlusMinus-extendᴳ f (inr a) = G.inv (f a)
+  module _ (f : A → G.El) where
+    PlusMinus-extendᴳ : PlusMinus A → G.El
+    PlusMinus-extendᴳ (inl a) = f a
+    PlusMinus-extendᴳ (inr a) = G.inv (f a)
 
-  Word-extendᴳ : (A → G.El) → (Word A → G.El)
-  Word-extendᴳ f = foldr G.comp G.ident ∘ map (PlusMinus-extendᴳ f)
+    PlusMinus-extendᴳ-flip : ∀ x → PlusMinus-extendᴳ (flip x) == G.inv (PlusMinus-extendᴳ x)
+    PlusMinus-extendᴳ-flip (inl a) = idp
+    PlusMinus-extendᴳ-flip (inr a) = ! (G.inv-inv (f a))
+
+    Word-extendᴳ : Word A → G.El
+    Word-extendᴳ = foldr G.comp G.ident ∘ map PlusMinus-extendᴳ
 
   abstract
     Word-extendᴳ-++ : ∀ f l₁ l₂

--- a/core/lib/types/Word.agda
+++ b/core/lib/types/Word.agda
@@ -70,15 +70,20 @@ module _ {A : Type i} {j} (G : Group j) where
     PlusMinus-extendᴳ-flip (inr a) = ! (G.inv-inv (f a))
 
     Word-extendᴳ : Word A → G.El
-    Word-extendᴳ = foldr G.comp G.ident ∘ map PlusMinus-extendᴳ
+    Word-extendᴳ = foldr' G.comp G.ident ∘ map PlusMinus-extendᴳ
 
   abstract
     Word-extendᴳ-++ : ∀ f l₁ l₂
       → Word-extendᴳ f (l₁ ++ l₂) == G.comp (Word-extendᴳ f l₁) (Word-extendᴳ f l₂)
     Word-extendᴳ-++ f nil l₂ = ! $ G.unit-l _
-    Word-extendᴳ-++ f (x :: l₁) l₂ =
-        ap (G.comp (PlusMinus-extendᴳ f x)) (Word-extendᴳ-++ f l₁ l₂)
-      ∙ ! (G.assoc (PlusMinus-extendᴳ f x) (Word-extendᴳ f l₁)  (Word-extendᴳ f l₂))
+    Word-extendᴳ-++ f (x₁ :: nil) nil = ! (G.unit-r _)
+    Word-extendᴳ-++ f (x₁ :: nil) (x₂ :: l₂) = idp
+    Word-extendᴳ-++ f (x₁ :: l₁@(_ :: _)) l₂ =
+      G.comp (PlusMinus-extendᴳ f x₁) (Word-extendᴳ f (l₁ ++ l₂))
+        =⟨ ap (G.comp (PlusMinus-extendᴳ f x₁)) (Word-extendᴳ-++ f l₁ l₂) ⟩
+      G.comp (PlusMinus-extendᴳ f x₁) (G.comp (Word-extendᴳ f l₁) (Word-extendᴳ f l₂))
+        =⟨ ! (G.assoc _ _ _) ⟩
+      G.comp (G.comp (PlusMinus-extendᴳ f x₁) (Word-extendᴳ f l₁)) (Word-extendᴳ f l₂) =∎
 
 module _ {A : Type i} {j} (G : AbGroup j) where
   private
@@ -95,7 +100,59 @@ module _ {A : Type i} {j} (G : AbGroup j) where
       → Word-extendᴳ G.grp (λ a → G.comp (f a) (g a)) l
       == G.comp (Word-extendᴳ G.grp f l) (Word-extendᴳ G.grp g l)
     Word-extendᴳ-comp f g nil = ! (G.unit-l G.ident)
-    Word-extendᴳ-comp f g (x :: l) =
-        ap2 G.comp (PlusMinus-extendᴳ-comp f g x) (Word-extendᴳ-comp f g l)
-      ∙ G.interchange (PlusMinus-extendᴳ G.grp f x) (PlusMinus-extendᴳ G.grp g x)
-          (Word-extendᴳ G.grp f l) (Word-extendᴳ G.grp g l)
+    Word-extendᴳ-comp f g (x :: nil) = PlusMinus-extendᴳ-comp f g x
+    Word-extendᴳ-comp f g (x :: l@(_ :: _)) =
+      G.comp (PlusMinus-extendᴳ G.grp (λ a → G.comp (f a) (g a)) x)
+             (Word-extendᴳ G.grp (λ a → G.comp (f a) (g a)) l)
+        =⟨ ap2 G.comp (PlusMinus-extendᴳ-comp f g x) (Word-extendᴳ-comp f g l) ⟩
+      G.comp (G.comp (PlusMinus-extendᴳ G.grp f x) (PlusMinus-extendᴳ G.grp g x))
+             (G.comp (Word-extendᴳ G.grp f l) (Word-extendᴳ G.grp g l))
+        =⟨ G.interchange (PlusMinus-extendᴳ G.grp f x) (PlusMinus-extendᴳ G.grp g x)
+                         (Word-extendᴳ G.grp f l) (Word-extendᴳ G.grp g l) ⟩
+      G.comp (G.comp (PlusMinus-extendᴳ G.grp f x) (Word-extendᴳ G.grp f l))
+             (G.comp (PlusMinus-extendᴳ G.grp g x) (Word-extendᴳ G.grp g l)) =∎
+
+module RelationRespectingFunctions (A : Type i) {m} (R : Rel (Word A) m) {j} (G : Group j) where
+
+  private
+    module G = Group G
+
+  respects-rel : (A → G.El) → Type (lmax (lmax i j) m)
+  respects-rel f = ∀ {l₁ l₂} → R l₁ l₂ → Word-extendᴳ G f l₁ == Word-extendᴳ G f l₂
+
+  abstract
+    respects-rel-is-prop : ∀ f → is-prop (respects-rel f)
+    respects-rel-is-prop f =
+      Πi-level $ λ l₁ →
+      Πi-level $ λ l₂ →
+      Π-level  $ λ r →
+      has-level-apply G.El-level _ _
+
+  record RelationRespectingFunction : Type (lmax (lmax i j) m) where
+    constructor rel-res-fun
+    field
+      f : A → G.El
+      respects : respects-rel f
+
+  RelationRespectingFunction= : {lf lg : RelationRespectingFunction}
+    → RelationRespectingFunction.f lf == RelationRespectingFunction.f lg
+    → lf == lg
+  RelationRespectingFunction= {rel-res-fun f f-respect} {rel-res-fun .f g-respect} idp =
+    ap (rel-res-fun f) (prop-path (respects-rel-is-prop f) f-respect g-respect)
+
+{- For the empty relation, this is exactly the type of functions -}
+module _ (A : Type i) {j} (G : Group j) where
+
+  private
+    module G = Group G
+  open RelationRespectingFunctions A empty-rel G
+
+  every-function-respects-empty-rel : ∀ (f : A → G.El) → RelationRespectingFunction
+  every-function-respects-empty-rel f = rel-res-fun f (λ {_} {_} ())
+
+  every-function-respects-empty-rel-equiv : (A → G.El) ≃ RelationRespectingFunction
+  every-function-respects-empty-rel-equiv =
+    equiv every-function-respects-empty-rel
+          RelationRespectingFunction.f
+          (λ lf → RelationRespectingFunction= idp)
+          (λ f → idp)

--- a/theorems/cohomology/CupProduct/OnEM/Commutativity.agda
+++ b/theorems/cohomology/CupProduct/OnEM/Commutativity.agda
@@ -3,455 +3,511 @@
 open import HoTT
 open import homotopy.EilenbergMacLane
 
-module cohomology.CupProduct.OnEM.Commutativity {i} (R : CRing i) where
+module cohomology.CupProduct.OnEM.Commutativity where
 
-open import cohomology.CupProduct.OnEM.Definition R
-open CP₁₁
+module AntipodalMap {i} (G : AbGroup i) where
 
-open EMExplicit R.add-ab-group
+  private
+    module G = AbGroup G
+  open EMExplicit G
 
-EM₁-antipodal-map : EM₁ R₊ → EM₁ R₊
-EM₁-antipodal-map = EM₁-fmap (inv-hom R.add-ab-group)
+  ⊙EM₁-antipodal-map : ⊙EM₁ G.grp ⊙→ ⊙EM₁ G.grp
+  ⊙EM₁-antipodal-map = ⊙EM₁-fmap (inv-hom G)
 
-⊙EM₁-antipodal-map : ⊙EM₁ R₊ ⊙→ ⊙EM₁ R₊
-⊙EM₁-antipodal-map = EM₁-antipodal-map , idp
+  EM₁-antipodal-map : EM₁ G.grp → EM₁ G.grp
+  EM₁-antipodal-map = fst ⊙EM₁-antipodal-map
 
-EM₁-antipodal-map-! : ∀ g → ap EM₁-antipodal-map (emloop g) == ! (emloop g)
-EM₁-antipodal-map-! g =
-  ap EM₁-antipodal-map (emloop g)
-    =⟨ EM₁-fmap-emloop-β (inv-hom R.add-ab-group) g ⟩
-  emloop (R.neg g)
-    =⟨ emloop-inv g ⟩
-  ! (emloop g) =∎
+  private
+    EM₁-antipodal-map-!-helper : ∀ t →
+      ap EM₁-antipodal-map (emloop t) == ! (emloop t)
+    EM₁-antipodal-map-!-helper t =
+      ap EM₁-antipodal-map (emloop t)
+        =⟨ EM₁-fmap-emloop-β (inv-hom G) t ⟩
+      emloop (G.inv t)
+        =⟨ emloop-inv t ⟩
+      ! (emloop t) =∎
 
-antipodal-map : EM 2 → EM 2
-antipodal-map = Trunc-fmap (Susp-fmap EM₁-antipodal-map)
+  EM₁-antipodal-map-! : ∀ (p : embase' G.grp == embase)
+    → ap EM₁-antipodal-map p == ! p
+  EM₁-antipodal-map-! p =
+    transport (λ q → ap EM₁-antipodal-map q == ! q)
+              (<–-inv-r emloop-equiv p) $
+    EM₁-antipodal-map-!-helper (<– emloop-equiv p)
+    where
+    open import homotopy.EilenbergMacLane1 G.grp using (emloop-equiv)
 
-private
-  − : EM 2 → EM 2
-  − = antipodal-map
+  antipodal-map : EM 2 → EM 2
+  antipodal-map = Trunc-fmap (Susp-fmap EM₁-antipodal-map)
 
-module CP₀₁-comm where
+module CP₀₁-comm {i} {j} (G : AbGroup i) (H : AbGroup j) where
 
-  cp₀₁-comm : ∀ g h → ap (cp₀₁ g) (emloop h) == ap (cp₀₁ h) (emloop g)
+  private
+    module G = AbGroup G
+    module H = AbGroup H
+    module G⊗H = TensorProduct G H
+    module H⊗G = TensorProduct H G
+
+  import cohomology.CupProduct.OnEM.Definition G H as GH
+  import cohomology.CupProduct.OnEM.Definition H G as HG
+
+  private
+    swap : H⊗G.grp →ᴳ G⊗H.grp
+    swap = H⊗G.swap
+    module swap = GroupHom swap
+
+  cp₀₁-comm : ∀ g h →
+    ap (GH.cp₀₁ g) (emloop h) ==
+    ap (EM₁-fmap swap ∘ HG.cp₀₁ h) (emloop g)
   cp₀₁-comm g h =
-    ap (cp₀₁ g) (emloop h)
-      =⟨ cp₀₁-emloop-β g h ⟩
-    emloop (R.mult g h)
-      =⟨ ap emloop (R.mult-comm g h) ⟩
-    emloop (R.mult h g)
-      =⟨ ! (cp₀₁-emloop-β h g) ⟩
-    ap (cp₀₁ h) (emloop g) =∎
+    ap (GH.cp₀₁ g) (emloop h)
+      =⟨ GH.cp₀₁-emloop-β g h ⟩
+    emloop (g G⊗H.⊗ h)
+      =⟨ ap emloop (! (H⊗G.swap-β h g)) ⟩
+    emloop (swap.f (h H⊗G.⊗ g))
+      =⟨ ! (EM₁-fmap-emloop-β swap (h H⊗G.⊗ g)) ⟩
+    ap (EM₁-fmap swap) (emloop (h H⊗G.⊗ g))
+      =⟨ ap (ap (EM₁-fmap swap)) (! (HG.cp₀₁-emloop-β h g)) ⟩
+    ap (EM₁-fmap swap) (ap (HG.cp₀₁ h) (emloop g))
+      =⟨ ∘-ap (EM₁-fmap swap) (HG.cp₀₁ h) (emloop g) ⟩
+    ap (EM₁-fmap swap ∘ HG.cp₀₁ h) (emloop g) =∎
 
-module CP₁₁-comm where
+module CP₁₁-comm {i} {j} (G : AbGroup i) (H : AbGroup j) where
+
+  private
+    module G = AbGroup G
+    module H = AbGroup H
+    module G⊗H = TensorProduct G H
+    module H⊗G = TensorProduct H G
+    module swap = GroupHom H⊗G.swap
+
+  import cohomology.CupProduct.OnEM.Definition G H as GH
+  import cohomology.CupProduct.OnEM.Definition H G as HG
+  open AntipodalMap G⊗H.abgroup
+
+  infix 80 _G∪H_
+  _G∪H_ : EM₁ G.grp → EM₁ H.grp → EMExplicit.EM G⊗H.abgroup 2
+  _G∪H_ = GH.cp₁₁
+
+  infix 80 _H∪G_
+  _H∪G_ : EM₁ H.grp → EM₁ G.grp → EMExplicit.EM H⊗G.abgroup 2
+  _H∪G_ = HG.cp₁₁
+
+  ⊙−₁ : ⊙EM₁ H⊗G.grp ⊙→ ⊙EM₁ G⊗H.grp
+  ⊙−₁ = ⊙EM₁-fmap (inv-hom G⊗H.abgroup) ⊙∘ ⊙EM₁-fmap H⊗G.swap
+
+  −₁ : EM₁ H⊗G.grp → EM₁ G⊗H.grp
+  −₁ = fst ⊙−₁
+
+  − : EMExplicit.EM H⊗G.abgroup 2 → EMExplicit.EM G⊗H.abgroup 2
+  − = Trunc-fmap (Susp-fmap −₁)
 
   abstract
 
     comm-embase-emloop↯ : ∀ h →
-      ap (λ y → cp₁₁ embase y) (emloop h) =-=
-      ap (λ y → − (cp₁₁ y embase)) (emloop h)
+      ap (λ y → embase G∪H y) (emloop h) =-=
+      ap (λ y → − (y H∪G embase)) (emloop h)
     comm-embase-emloop↯ h =
-      ap (λ y → cp₁₁ embase y) (emloop h)
+      ap (λ y → embase G∪H y) (emloop h)
         =⟪idp⟫
       ap (cst [ north ]) (emloop h)
         =⟪ ap-cst [ north ] (emloop h) ⟫
       idp
         =⟪idp⟫
       ap − (idp {a = [ north ]})
-        =⟪ ! (ap (ap −) (ap-cp₁₁-embase h)) ⟫
-      ap − (ap (λ y → cp₁₁ y embase) (emloop h))
-        =⟪ ∘-ap − (λ y → cp₁₁ y embase) (emloop h) ⟫
-      ap (λ y → − (cp₁₁ y embase)) (emloop h) ∎∎
+        =⟪ ! (ap (ap −) (HG.ap-cp₁₁-embase h)) ⟫
+      ap − (ap (_H∪G embase) (emloop h))
+        =⟪ ∘-ap − (_H∪G embase) (emloop h) ⟫
+      ap (λ y → − (y H∪G embase)) (emloop h) ∎∎
 
     comm-emloop-embase↯ : ∀ g →
-      ap (λ x → cp₁₁ x embase) (emloop g) =-=
-      ap (− ∘ cp₁₁ embase) (emloop g)
+      ap (_G∪H embase) (emloop g) =-=
+      ap (λ x → − (embase H∪G x)) (emloop g)
     comm-emloop-embase↯ g =
-      ap (λ x → cp₁₁ x embase) (emloop g)
-        =⟪ ap-cp₁₁-embase g ⟫
+      ap (_G∪H embase) (emloop g)
+        =⟪ GH.ap-cp₁₁-embase g ⟫
       idp
         =⟪ ! (ap-cst [ north ] (emloop g)) ⟫
       ap (cst [ north ]) (emloop g)
         =⟪idp⟫
-      ap (− ∘ cp₁₁ embase) (emloop g) ∎∎
+      ap (λ x → − (embase H∪G x)) (emloop g) ∎∎
 
     comm-embase-emloop' : ∀ h →
-      ap (λ y → cp₁₁ embase y) (emloop h) ==
-      ap (λ y → − (cp₁₁ y embase)) (emloop h)
+      ap (embase G∪H_) (emloop h) ==
+      ap (λ y → − (y H∪G embase)) (emloop h)
     comm-embase-emloop' h = ↯ (comm-embase-emloop↯ h)
 
     comm-emloop-embase' : ∀ g →
-      ap (λ x → cp₁₁ x embase) (emloop g) ==
-      ap (λ x → − (cp₁₁ embase x)) (emloop g)
+      ap (λ x → GH.cp₁₁ x embase) (emloop g) ==
+      ap (λ x → − (embase H∪G x)) (emloop g)
     comm-emloop-embase' g = ↯ (comm-emloop-embase↯ g)
 
     comm-embase-emloop-comp' : ∀ h₁ h₂ →
-      comm-embase-emloop' (R.add h₁ h₂) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase))) (emloop-comp h₁ h₂) ◃∎
+      comm-embase-emloop' (H.comp h₁ h₂) ◃∙
+      ap (ap (λ y → − (y H∪G embase))) (emloop-comp h₁ h₂) ◃∎
       =ₛ
-      ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ◃∙
-      ap-∙ (λ y → cp₁₁ embase y) (emloop h₁) (emloop h₂) ◃∙
+      ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ◃∙
+      ap-∙ (embase G∪H_) (emloop h₁) (emloop h₂) ◃∙
       ap2 _∙_ (comm-embase-emloop' h₁) (comm-embase-emloop' h₂) ◃∙
-      ∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂) ◃∎
+      ∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂) ◃∎
     comm-embase-emloop-comp' h₁ h₂ =
-      comm-embase-emloop' (R.add h₁ h₂) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase))) (emloop-comp h₁ h₂) ◃∎
-        =ₛ⟨ 0 & 1 & expand (comm-embase-emloop↯ (R.add h₁ h₂)) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ! (ap (ap −) (ap-cp₁₁-embase (R.add h₁ h₂))) ◃∙
-      ∘-ap − (λ y → cp₁₁ y embase) (emloop (R.add h₁ h₂)) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase))) (emloop-comp h₁ h₂) ◃∎
+      comm-embase-emloop' (H.comp h₁ h₂) ◃∙
+      ap (ap (λ y → − (y H∪G embase))) (emloop-comp h₁ h₂) ◃∎
+        =ₛ⟨ 0 & 1 & expand (comm-embase-emloop↯ (H.comp h₁ h₂)) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ! (ap (ap −) (HG.ap-cp₁₁-embase (H.comp h₁ h₂))) ◃∙
+      ∘-ap − (_H∪G embase) (emloop (H.comp h₁ h₂)) ◃∙
+      ap (ap (λ y → − (y H∪G embase))) (emloop-comp h₁ h₂) ◃∎
         =ₛ⟨ 2 & 2 & !ₛ $
-            homotopy-naturality (ap − ∘ ap (λ y → cp₁₁ y embase))
-                                (ap (λ y → − (cp₁₁ y embase)))
-                                (∘-ap − (λ y → cp₁₁ y embase))
+            homotopy-naturality (ap − ∘ ap (_H∪G embase))
+                                (ap (λ y → − (y H∪G embase)))
+                                (∘-ap − (_H∪G embase))
                                 (emloop-comp h₁ h₂) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ! (ap (ap −) (ap-cp₁₁-embase (R.add h₁ h₂))) ◃∙
-      ap (ap − ∘ ap (λ y → cp₁₁ y embase)) (emloop-comp h₁ h₂) ◃∙
-      ∘-ap − (λ y → cp₁₁ y embase) (emloop h₁ ∙ emloop h₂) ◃∎
-        =ₛ₁⟨ 1 & 1 & !-ap (ap −) (ap-cp₁₁-embase (R.add h₁ h₂)) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap (ap −) (! (ap-cp₁₁-embase (R.add h₁ h₂))) ◃∙
-      ap (ap − ∘ ap (λ y → cp₁₁ y embase)) (emloop-comp h₁ h₂) ◃∙
-      ∘-ap − (λ y → cp₁₁ y embase) (emloop h₁ ∙ emloop h₂) ◃∎
-        =ₛ₁⟨ 2 & 1 & ap-∘ (ap −) (ap (λ y → cp₁₁ y embase)) (emloop-comp h₁ h₂) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap (ap −) (! (ap-cp₁₁-embase (R.add h₁ h₂))) ◃∙
-      ap (ap −) (ap (ap (λ y → cp₁₁ y embase)) (emloop-comp h₁ h₂)) ◃∙
-      ∘-ap − (λ y → cp₁₁ y embase) (emloop h₁ ∙ emloop h₂) ◃∎
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ! (ap (ap −) (HG.ap-cp₁₁-embase (H.comp h₁ h₂))) ◃∙
+      ap (ap − ∘ ap (_H∪G embase)) (emloop-comp h₁ h₂) ◃∙
+      ∘-ap − (_H∪G embase) (emloop h₁ ∙ emloop h₂) ◃∎
+        =ₛ₁⟨ 1 & 1 & !-ap (ap −) (HG.ap-cp₁₁-embase (H.comp h₁ h₂)) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap (ap −) (! (HG.ap-cp₁₁-embase (H.comp h₁ h₂))) ◃∙
+      ap (ap − ∘ ap (_H∪G embase)) (emloop-comp h₁ h₂) ◃∙
+      ∘-ap − (_H∪G embase) (emloop h₁ ∙ emloop h₂) ◃∎
+        =ₛ₁⟨ 2 & 1 & ap-∘ (ap −) (ap (_H∪G embase)) (emloop-comp h₁ h₂) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap (ap −) (! (HG.ap-cp₁₁-embase (H.comp h₁ h₂))) ◃∙
+      ap (ap −) (ap (ap (_H∪G embase)) (emloop-comp h₁ h₂)) ◃∙
+      ∘-ap − (_H∪G embase) (emloop h₁ ∙ emloop h₂) ◃∎
         =ₛ⟨ 1 & 2 &
             ap-seq-=ₛ (ap −) $
             post-rotate-seq-in {p = _ ◃∙ _ ◃∎} $
             pre-rotate'-in $
-            !ₛ $ ap-cp₁₁-embase-coh h₁ h₂ ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap (ap −) (! (ap2 _∙_ (ap-cp₁₁-embase h₁) (ap-cp₁₁-embase h₂))) ◃∙
-      ap (ap −) (! (ap-∙ (λ x → cp₁₁ x embase) (emloop h₁) (emloop h₂))) ◃∙
-      ∘-ap − (λ y → cp₁₁ y embase) (emloop h₁ ∙ emloop h₂) ◃∎
-        =ₛ₁⟨ 2 & 1 & ap-! (ap −) (ap-∙ (λ x → cp₁₁ x embase) (emloop h₁) (emloop h₂))⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap (ap −) (! (ap2 _∙_ (ap-cp₁₁-embase h₁) (ap-cp₁₁-embase h₂))) ◃∙
-      ! (ap (ap −) (ap-∙ (λ x → cp₁₁ x embase) (emloop h₁) (emloop h₂))) ◃∙
-      ∘-ap − (λ y → cp₁₁ y embase) (emloop h₁ ∙ emloop h₂) ◃∎
-        =ₛ₁⟨ 3 & 1 & ! (!ap-∘=∘-ap − (λ y → cp₁₁ y embase) (emloop h₁ ∙ emloop h₂)) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap (ap −) (! (ap2 _∙_ (ap-cp₁₁-embase h₁) (ap-cp₁₁-embase h₂))) ◃∙
-      ! (ap (ap −) (ap-∙ (λ x → cp₁₁ x embase) (emloop h₁) (emloop h₂))) ◃∙
-      ! (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₁ ∙ emloop h₂)) ◃∎
+            !ₛ $ HG.ap-cp₁₁-embase-coh h₁ h₂ ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap (ap −) (! (ap2 _∙_ (HG.ap-cp₁₁-embase h₁) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ap (ap −) (! (ap-∙ (_H∪G embase) (emloop h₁) (emloop h₂))) ◃∙
+      ∘-ap − (_H∪G embase) (emloop h₁ ∙ emloop h₂) ◃∎
+        =ₛ₁⟨ 2 & 1 & ap-! (ap −) (ap-∙ (_H∪G embase) (emloop h₁) (emloop h₂))⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap (ap −) (! (ap2 _∙_ (HG.ap-cp₁₁-embase h₁) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ! (ap (ap −) (ap-∙ (_H∪G embase) (emloop h₁) (emloop h₂))) ◃∙
+      ∘-ap − (_H∪G embase) (emloop h₁ ∙ emloop h₂) ◃∎
+        =ₛ₁⟨ 3 & 1 & ! (!ap-∘=∘-ap − (_H∪G embase) (emloop h₁ ∙ emloop h₂)) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap (ap −) (! (ap2 _∙_ (HG.ap-cp₁₁-embase h₁) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ! (ap (ap −) (ap-∙ (_H∪G embase) (emloop h₁) (emloop h₂))) ◃∙
+      ! (ap-∘ − (_H∪G embase) (emloop h₁ ∙ emloop h₂)) ◃∎
         =ₛ⟨ 2 & 2 &
             post-rotate-seq-in {p = _ ◃∙ _ ◃∎} $
             pre-rotate'-seq-in {p = _ ◃∙ _ ◃∎} $
-            ap-∘-∙-coh − (λ y → cp₁₁ y embase) (emloop h₁) (emloop h₂) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap (ap −) (! (ap2 _∙_ (ap-cp₁₁-embase h₁) (ap-cp₁₁-embase h₂))) ◃∙
-      ap-∙ − (ap (λ y → cp₁₁ y embase) (emloop h₁)) (ap (λ y → cp₁₁ y embase) (emloop h₂)) ◃∙
-      ! (ap2 _∙_ (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₁))
-                 (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₂))) ◃∙
-      ! (ap-∙ (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂)) ◃∎
+            ap-∘-∙-coh − (_H∪G embase) (emloop h₁) (emloop h₂) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap (ap −) (! (ap2 _∙_ (HG.ap-cp₁₁-embase h₁) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ap-∙ − (ap (_H∪G embase) (emloop h₁)) (ap (_H∪G embase) (emloop h₂)) ◃∙
+      ! (ap2 _∙_ (ap-∘ − (_H∪G embase) (emloop h₁))
+                 (ap-∘ − (_H∪G embase) (emloop h₂))) ◃∙
+      ! (ap-∙ (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂)) ◃∎
         =ₛ₁⟨ 1 & 1 &
-              ap (ap (ap −)) (!-ap2 _∙_ (ap-cp₁₁-embase h₁) (ap-cp₁₁-embase h₂)) ∙
-              ap-ap2 (ap −) _∙_ (! (ap-cp₁₁-embase h₁)) (! (ap-cp₁₁-embase h₂)) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap2 (λ p q → ap − (p ∙ q)) (! (ap-cp₁₁-embase h₁)) (! (ap-cp₁₁-embase h₂)) ◃∙
-      ap-∙ − (ap (λ y → cp₁₁ y embase) (emloop h₁)) (ap (λ y → cp₁₁ y embase) (emloop h₂)) ◃∙
-      ! (ap2 _∙_ (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₁))
-                 (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₂))) ◃∙
-      ! (ap-∙ (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂)) ◃∎
+              ap (ap (ap −)) (!-ap2 _∙_ (HG.ap-cp₁₁-embase h₁) (HG.ap-cp₁₁-embase h₂)) ∙
+              ap-ap2 (ap −) _∙_ (! (HG.ap-cp₁₁-embase h₁)) (! (HG.ap-cp₁₁-embase h₂)) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap2 (λ p q → ap − (p ∙ q)) (! (HG.ap-cp₁₁-embase h₁)) (! (HG.ap-cp₁₁-embase h₂)) ◃∙
+      ap-∙ − (ap (_H∪G embase) (emloop h₁)) (ap (_H∪G embase) (emloop h₂)) ◃∙
+      ! (ap2 _∙_ (ap-∘ − (_H∪G embase) (emloop h₁))
+                 (ap-∘ − (_H∪G embase) (emloop h₂))) ◃∙
+      ! (ap-∙ (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂)) ◃∎
         =ₛ⟨ 1 & 2 &
             homotopy-naturality2 (λ p q → ap − (p ∙ q))
                                   (λ p q → ap − p ∙ ap − q)
                                   (λ p q → ap-∙ − p q)
-                                  (! (ap-cp₁₁-embase h₁))
-                                  (! (ap-cp₁₁-embase h₂)) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
+                                  (! (HG.ap-cp₁₁-embase h₁))
+                                  (! (HG.ap-cp₁₁-embase h₂)) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
       idp ◃∙
-      ap2 (λ p q → ap − p ∙ ap − q) (! (ap-cp₁₁-embase h₁)) (! (ap-cp₁₁-embase h₂)) ◃∙
-      ! (ap2 _∙_ (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₁))
-                 (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₂))) ◃∙
-      ! (ap-∙ (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂)) ◃∎
+      ap2 (λ p q → ap − p ∙ ap − q) (! (HG.ap-cp₁₁-embase h₁)) (! (HG.ap-cp₁₁-embase h₂)) ◃∙
+      ! (ap2 _∙_ (ap-∘ − (_H∪G embase) (emloop h₁))
+                 (ap-∘ − (_H∪G embase) (emloop h₂))) ◃∙
+      ! (ap-∙ (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂)) ◃∎
         =ₛ⟨ 1 & 1 & expand [] ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap2 (λ p q → ap − p ∙ ap − q) (! (ap-cp₁₁-embase h₁)) (! (ap-cp₁₁-embase h₂)) ◃∙
-      ! (ap2 _∙_ (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₁))
-                 (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₂))) ◃∙
-      ! (ap-∙ (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂)) ◃∎
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap2 (λ p q → ap − p ∙ ap − q) (! (HG.ap-cp₁₁-embase h₁)) (! (HG.ap-cp₁₁-embase h₂)) ◃∙
+      ! (ap2 _∙_ (ap-∘ − (_H∪G embase) (emloop h₁))
+                 (ap-∘ − (_H∪G embase) (emloop h₂))) ◃∙
+      ! (ap-∙ (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂)) ◃∎
         =ₛ₁⟨ 1 & 1 &
-              ! (ap2-ap-lr _∙_ (ap −) (ap −) (! (ap-cp₁₁-embase h₁)) (! (ap-cp₁₁-embase h₂))) ∙
-              ap2 (ap2 _∙_) (ap-! (ap −) (ap-cp₁₁-embase h₁)) (ap-! (ap −) (ap-cp₁₁-embase h₂)) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap2 _∙_ (! (ap (ap −) (ap-cp₁₁-embase h₁))) (! (ap (ap −) (ap-cp₁₁-embase h₂))) ◃∙
-      ! (ap2 _∙_ (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₁))
-                 (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₂))) ◃∙
-      ! (ap-∙ (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂)) ◃∎
+              ! (ap2-ap-lr _∙_ (ap −) (ap −) (! (HG.ap-cp₁₁-embase h₁)) (! (HG.ap-cp₁₁-embase h₂))) ∙
+              ap2 (ap2 _∙_) (ap-! (ap −) (HG.ap-cp₁₁-embase h₁)) (ap-! (ap −) (HG.ap-cp₁₁-embase h₂)) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap2 _∙_ (! (ap (ap −) (HG.ap-cp₁₁-embase h₁))) (! (ap (ap −) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ! (ap2 _∙_ (ap-∘ − (_H∪G embase) (emloop h₁))
+                 (ap-∘ − (_H∪G embase) (emloop h₂))) ◃∙
+      ! (ap-∙ (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂)) ◃∎
         =ₛ₁⟨ 2 & 1 &
-            !-ap2 _∙_ (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₁))
-                      (ap-∘ − (λ y → cp₁₁ y embase) (emloop h₂)) ∙
-            ap2 (ap2 _∙_) (!ap-∘=∘-ap − (λ y → cp₁₁ y embase) (emloop h₁))
-                          (!ap-∘=∘-ap − (λ y → cp₁₁ y embase) (emloop h₂)) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap2 _∙_ (! (ap (ap −) (ap-cp₁₁-embase h₁))) (! (ap (ap −) (ap-cp₁₁-embase h₂))) ◃∙
-      ap2 _∙_ (∘-ap − (λ y → cp₁₁ y embase) (emloop h₁))
-              (∘-ap − (λ y → cp₁₁ y embase) (emloop h₂)) ◃∙
-      ! (ap-∙ (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂)) ◃∎
-        =ₛ₁⟨ 3 & 1 & !ap-∙=∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂) ⟩
-      ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
-      ap2 _∙_ (! (ap (ap −) (ap-cp₁₁-embase h₁))) (! (ap (ap −) (ap-cp₁₁-embase h₂))) ◃∙
-      ap2 _∙_ (∘-ap − (λ y → cp₁₁ y embase) (emloop h₁))
-              (∘-ap − (λ y → cp₁₁ y embase) (emloop h₂)) ◃∙
-      ∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂) ◃∎
+            !-ap2 _∙_ (ap-∘ − (_H∪G embase) (emloop h₁))
+                      (ap-∘ − (_H∪G embase) (emloop h₂)) ∙
+            ap2 (ap2 _∙_) (!ap-∘=∘-ap − (_H∪G embase) (emloop h₁))
+                          (!ap-∘=∘-ap − (_H∪G embase) (emloop h₂)) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap2 _∙_ (! (ap (ap −) (HG.ap-cp₁₁-embase h₁))) (! (ap (ap −) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ap2 _∙_ (∘-ap − (_H∪G embase) (emloop h₁))
+              (∘-ap − (_H∪G embase) (emloop h₂)) ◃∙
+      ! (ap-∙ (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂)) ◃∎
+        =ₛ₁⟨ 3 & 1 & !ap-∙=∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂) ⟩
+      ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
+      ap2 _∙_ (! (ap (ap −) (HG.ap-cp₁₁-embase h₁))) (! (ap (ap −) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ap2 _∙_ (∘-ap − (_H∪G embase) (emloop h₁))
+              (∘-ap − (_H∪G embase) (emloop h₂)) ◃∙
+      ∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂) ◃∎
         =ₛ⟨ 0 & 1 &
-            ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∎
+            ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∎
               =ₛ⟨ 1 & 0 & contract ⟩
-            ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
+            ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
             idp ◃∎
               =ₛ₁⟨ 1 & 1 & ! (ap-cst idp (emloop-comp h₁ h₂)) ⟩
-            ap-cst [ north ] (emloop (R.add h₁ h₂)) ◃∙
+            ap-cst [ north ] (emloop (H.comp h₁ h₂)) ◃∙
             ap (λ _ → idp) (emloop-comp h₁ h₂) ◃∎
-              =ₛ⟨ !ₛ $ homotopy-naturality (ap (cp₁₁ embase))
+              =ₛ⟨ !ₛ $ homotopy-naturality (ap (embase G∪H_))
                                            (λ _ → idp)
                                            (ap-cst [ north ])
                                            (emloop-comp h₁ h₂) ⟩
-            ap (ap (cp₁₁ embase)) (emloop-comp h₁ h₂) ◃∙
+            ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ◃∙
             ap-cst [ north ] (emloop h₁ ∙ emloop h₂) ◃∎
               =ₛ⟨ 1 & 1 & ap-cst-coh [ north ] (emloop h₁) (emloop h₂) ⟩
-            ap (ap (cp₁₁ embase)) (emloop-comp h₁ h₂) ◃∙
+            ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ◃∙
             ap-∙ (cst [ north ]) (emloop h₁) (emloop h₂) ◃∙
             ap2 _∙_ (ap-cst [ north ] (emloop h₁)) (ap-cst [ north ] (emloop h₂)) ◃∎ ∎ₛ
           ⟩
-      ap (ap (cp₁₁ embase)) (emloop-comp h₁ h₂) ◃∙
+      ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ◃∙
       ap-∙ (cst [ north ]) (emloop h₁) (emloop h₂) ◃∙
       ap2 _∙_ (ap-cst [ north ] (emloop h₁)) (ap-cst [ north ] (emloop h₂)) ◃∙
-      ap2 _∙_ (! (ap (ap −) (ap-cp₁₁-embase h₁))) (! (ap (ap −) (ap-cp₁₁-embase h₂))) ◃∙
-      ap2 _∙_ (∘-ap − (λ y → cp₁₁ y embase) (emloop h₁))
-              (∘-ap − (λ y → cp₁₁ y embase) (emloop h₂)) ◃∙
-      ∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂) ◃∎
+      ap2 _∙_ (! (ap (ap −) (HG.ap-cp₁₁-embase h₁))) (! (ap (ap −) (HG.ap-cp₁₁-embase h₂))) ◃∙
+      ap2 _∙_ (∘-ap − (_H∪G embase) (emloop h₁))
+              (∘-ap − (_H∪G embase) (emloop h₂)) ◃∙
+      ∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂) ◃∎
         =ₛ⟨ 2 & 3 & ∙-ap2-seq _∙_ (comm-embase-emloop↯ h₁) (comm-embase-emloop↯ h₂) ⟩
-      ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ◃∙
-      ap-∙ (λ y → cp₁₁ embase y) (emloop h₁) (emloop h₂) ◃∙
+      ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ◃∙
+      ap-∙ (embase G∪H_) (emloop h₁) (emloop h₂) ◃∙
       ap2 _∙_ (comm-embase-emloop' h₁) (comm-embase-emloop' h₂) ◃∙
-      ∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂) ◃∎ ∎ₛ
+      ∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂) ◃∎ ∎ₛ
 
     comm-emloop-comp-embase' : ∀ g₁ g₂ →
-      comm-emloop-embase' (R.add g₁ g₂) ◃∙
-      ap (ap (λ x → − (cp₁₁ embase x))) (emloop-comp g₁ g₂) ◃∎
+      comm-emloop-embase' (G.comp g₁ g₂) ◃∙
+      ap (ap (λ x → − (embase H∪G x))) (emloop-comp g₁ g₂) ◃∎
       =ₛ
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ◃∙
-      ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ◃∙
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ◃∙
+      ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ◃∙
       ap2 _∙_ (comm-emloop-embase' g₁) (comm-emloop-embase' g₂) ◃∙
-      ∙-ap (λ x → − (cp₁₁ embase x)) (emloop g₁) (emloop g₂) ◃∎
+      ∙-ap (λ x → − (embase H∪G x)) (emloop g₁) (emloop g₂) ◃∎
     comm-emloop-comp-embase' g₁ g₂ =
-      comm-emloop-embase' (R.add g₁ g₂) ◃∙
-      ap (ap (λ x → − (cp₁₁ embase x))) (emloop-comp g₁ g₂) ◃∎
-        =ₛ⟨ 0 & 1 & expand (comm-emloop-embase↯ (R.add g₁ g₂)) ⟩
-      ap-cp₁₁-embase (R.add g₁ g₂) ◃∙
-      ! (ap-cst [ north ] (emloop (R.add g₁ g₂))) ◃∙
-      ap (ap (λ x → − (cp₁₁ embase x))) (emloop-comp g₁ g₂) ◃∎
+      comm-emloop-embase' (G.comp g₁ g₂) ◃∙
+      ap (ap (λ x → − (embase H∪G x))) (emloop-comp g₁ g₂) ◃∎
+        =ₛ⟨ 0 & 1 & expand (comm-emloop-embase↯ (G.comp g₁ g₂)) ⟩
+      GH.ap-cp₁₁-embase (G.comp g₁ g₂) ◃∙
+      ! (ap-cst [ north ] (emloop (G.comp g₁ g₂))) ◃∙
+      ap (ap (λ x → − (embase H∪G x))) (emloop-comp g₁ g₂) ◃∎
         =ₛ⟨ 1 & 2 & !ₛ $
             homotopy-naturality
               (λ _ → idp)
               (ap (cst [ north ]))
               (λ p → ! (ap-cst [ north ] p))
               (emloop-comp g₁ g₂) ⟩
-      ap-cp₁₁-embase (R.add g₁ g₂) ◃∙
+      GH.ap-cp₁₁-embase (G.comp g₁ g₂) ◃∙
       ap (λ _ → idp) (emloop-comp g₁ g₂) ◃∙
       ! (ap-cst [ north ] (emloop g₁ ∙ emloop g₂)) ◃∎
         =ₛ⟨ 1 & 1 & =ₛ-in {t = []} (ap-cst idp (emloop-comp g₁ g₂)) ⟩
-      ap-cp₁₁-embase (R.add g₁ g₂) ◃∙
+      GH.ap-cp₁₁-embase (G.comp g₁ g₂) ◃∙
       ! (ap-cst [ north ] (emloop g₁ ∙ emloop g₂)) ◃∎
-        =ₛ⟨ 0 & 1 & ap-cp₁₁-embase-coh g₁ g₂ ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ◃∙
-      ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ◃∙
-      ap2 _∙_ (ap-cp₁₁-embase g₁) (ap-cp₁₁-embase g₂) ◃∙
+        =ₛ⟨ 0 & 1 & GH.ap-cp₁₁-embase-coh g₁ g₂ ⟩
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ◃∙
+      ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ◃∙
+      ap2 _∙_ (GH.ap-cp₁₁-embase g₁) (GH.ap-cp₁₁-embase g₂) ◃∙
       ! (ap-cst [ north ] (emloop g₁ ∙ emloop g₂)) ◃∎
         =ₛ⟨ 3 & 1 & !-=ₛ $ ap-cst-coh [ north ] (emloop g₁) (emloop g₂) ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ◃∙
-      ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ◃∙
-      ap2 _∙_ (ap-cp₁₁-embase g₁) (ap-cp₁₁-embase g₂) ◃∙
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ◃∙
+      ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ◃∙
+      ap2 _∙_ (GH.ap-cp₁₁-embase g₁) (GH.ap-cp₁₁-embase g₂) ◃∙
       ! (ap2 _∙_ (ap-cst [ north ] (emloop g₁)) (ap-cst [ north ] (emloop g₂))) ◃∙
       ! (ap-∙ (cst [ north ]) (emloop g₁) (emloop g₂)) ◃∎
         =ₛ₁⟨ 3 & 1 & ! (ap2-! _∙_ (ap-cst [ north ] (emloop g₁)) (ap-cst [ north ] (emloop g₂))) ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ◃∙
-      ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ◃∙
-      ap2 _∙_ (ap-cp₁₁-embase g₁) (ap-cp₁₁-embase g₂) ◃∙
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ◃∙
+      ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ◃∙
+      ap2 _∙_ (GH.ap-cp₁₁-embase g₁) (GH.ap-cp₁₁-embase g₂) ◃∙
       ap2 _∙_ (! (ap-cst [ north ] (emloop g₁))) (! (ap-cst [ north ] (emloop g₂))) ◃∙
       ! (ap-∙ (cst [ north ]) (emloop g₁) (emloop g₂)) ◃∎
         =ₛ⟨ 2 & 2 & ∙-ap2-seq _∙_ (comm-emloop-embase↯ g₁) (comm-emloop-embase↯ g₂) ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ◃∙
-      ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ◃∙
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ◃∙
+      ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ◃∙
       ap2 _∙_ (comm-emloop-embase' g₁) (comm-emloop-embase' g₂) ◃∙
       ! (ap-∙ (cst [ north ]) (emloop g₁) (emloop g₂)) ◃∎
         =ₛ₁⟨ 3 & 1 & !ap-∙=∙-ap (cst [ north ]) (emloop g₁) (emloop g₂) ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ◃∙
-      ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ◃∙
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ◃∙
+      ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ◃∙
       ap2 _∙_ (comm-emloop-embase' g₁) (comm-emloop-embase' g₂) ◃∙
       ∙-ap (cst [ north ]) (emloop g₁) (emloop g₂) ◃∎ ∎ₛ
 
     comm-emloop-emloop' : ∀ g h →
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
       ap2 _∙_ (comm-embase-emloop' h) (comm-emloop-embase' g) ◃∎
       =ₛ
       ap2 _∙_ (comm-emloop-embase' g) (comm-embase-emloop' h) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
     comm-emloop-emloop' g h =
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
       ap2 _∙_ (comm-embase-emloop' h) (comm-emloop-embase' g) ◃∎
         =ₛ⟨ 1 & 1 & ap2-out _∙_ (comm-embase-emloop' h) (comm-emloop-embase' g) ⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (comm-embase-emloop' h) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (comm-emloop-embase' g) ◃∎
-        =ₛ⟨ 1 & 1 & ap-seq-=ₛ (_∙ ap (λ x → cp₁₁ x embase) (emloop g))
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (comm-embase-emloop' h) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (comm-emloop-embase' g) ◃∎
+        =ₛ⟨ 1 & 1 & ap-seq-=ₛ (_∙ ap (_G∪H embase) (emloop g))
                               (take-drop-split 1 (comm-embase-emloop↯ h)) ⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (comm-emloop-embase' g) ◃∎
-        =ₛ⟨ 3 & 1 & ap-seq-∙ (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (comm-emloop-embase↯ g) ⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (ap-cp₁₁-embase g) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (ap-cst [ north ] (emloop g))) ◃∎
-        =ₛ⟨ 4 & 1 & ap-seq-=ₛ (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) step₄' ⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (ap-cp₁₁-embase g) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (↯ h₁'-seq) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (comm-emloop-embase' g) ◃∎
+        =ₛ⟨ 3 & 1 & ap-seq-∙ (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (comm-emloop-embase↯ g) ⟩
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (GH.ap-cp₁₁-embase g) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (ap-cst [ north ] (emloop g))) ◃∎
+        =ₛ⟨ 4 & 1 & ap-seq-=ₛ (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) step₄' ⟩
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (GH.ap-cp₁₁-embase g) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (↯ h₁'-seq) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
           (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
-        =ₛ⟨ 2 & 2 & ap-comm-=ₛ _∙_ (↯ (tail (comm-embase-emloop↯ h))) (ap-cp₁₁-embase g) ⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-      ap (idp ∙_) (ap-cp₁₁-embase g) ◃∙
+        =ₛ⟨ 2 & 2 & ap-comm-=ₛ _∙_ (↯ (tail (comm-embase-emloop↯ h))) (GH.ap-cp₁₁-embase g) ⟩
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+      ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∙
       ap (_∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (↯ h₁'-seq) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (↯ h₁'-seq) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
           (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
         =ₛ⟨ 3 & 2 & ap-comm-=ₛ _∙_ (↯ (tail (comm-embase-emloop↯ h))) (↯ h₁'-seq) ⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-      ap (idp ∙_) (ap-cp₁₁-embase g) ◃∙
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+      ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∙
       ap (idp ∙_) (↯ h₁'-seq) ◃∙
       ap (λ a → a ∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
           (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
         =ₛ₁⟨ 3 & 1 & ap (ap (idp ∙_)) (! (=ₛ-out heart))⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-      ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-      ap (idp ∙_) (ap-cp₁₁-embase g) ◃∙
+      ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+      ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+      ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∙
       ap (idp ∙_) (↯ h₁-seq) ◃∙
       ap (λ a → a ∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
           (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
         =ₛ⟨ 0 & 3 & top-part ⟩
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-          (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-      ap (_∙ idp) (ap-cp₁₁-embase g) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_)
+         (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+      ap (_∙ idp) (GH.ap-cp₁₁-embase g) ◃∙
       ap (idp ∙_) (↯ h₁-seq) ◃∙
       ap (λ a → a ∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-      ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
-          (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+      ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
+         (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
         =ₛ⟨ 4 & 3 & bottom-part ⟩
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-          (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-      ap (_∙ idp) (ap-cp₁₁-embase g) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_)
+         (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+      ap (_∙ idp) (GH.ap-cp₁₁-embase g) ◃∙
       ap (idp ∙_) (↯ h₁-seq) ◃∙
       ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
-        =ₛ⟨ 2 & 2 & ap-comm-=ₛ _∙_ (ap-cp₁₁-embase g) (↯ h₁-seq) ⟩
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-          (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (↯ h₁-seq) ◃∙
-      ap (_∙ idp) (ap-cp₁₁-embase g) ◃∙
+      ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
+        =ₛ⟨ 2 & 2 & ap-comm-=ₛ _∙_ (GH.ap-cp₁₁-embase g) (↯ h₁-seq) ⟩
+      ap (ap (_G∪H embase) (emloop g) ∙_)
+         (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (↯ h₁-seq) ◃∙
+      ap (_∙ idp) (GH.ap-cp₁₁-embase g) ◃∙
       ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
-        =ₛ⟨ 3 & 2 & ap-comm-=ₛ _∙_ (ap-cp₁₁-embase g) (↯ (tail (comm-embase-emloop↯ h))) ⟩
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-          (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (↯ h₁-seq) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (ap-cp₁₁-embase g) ◃∙
-      ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
-        =ₛ⟨ 4 & 2 & ∙-ap-seq (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (comm-emloop-embase↯ g) ⟩
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-          (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (↯ h₁-seq) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (comm-emloop-embase' g) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
-        =ₛ⟨ 0 & 3 & ap-seq-=ₛ (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) step₁₃' ⟩
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (ap-cst [ north ]₂ (emloop h)) ◃∙
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-      ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (comm-emloop-embase' g) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
-        =ₛ⟨ 0 & 2 & !ₛ $ ap-seq-=ₛ (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) $
+      ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
+        =ₛ⟨ 3 & 2 & ap-comm-=ₛ _∙_ (GH.ap-cp₁₁-embase g) (↯ (tail (comm-embase-emloop↯ h))) ⟩
+      ap (ap (_G∪H embase) (emloop g) ∙_)
+         (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (↯ h₁-seq) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
+      ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (GH.ap-cp₁₁-embase g) ◃∙
+      ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
+        =ₛ⟨ 4 & 2 & ∙-ap-seq (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (comm-emloop-embase↯ g) ⟩
+      ap (ap (_G∪H embase) (emloop g) ∙_)
+         (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (↯ h₁-seq) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
+      ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (comm-emloop-embase' g) ◃∙
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
+        =ₛ⟨ 0 & 3 & ap-seq-=ₛ (ap (_G∪H embase) (emloop g) ∙_) step₁₃' ⟩
+      ap (ap (_G∪H embase) (emloop g) ∙_) (ap-cst [ north ]₂ (emloop h)) ◃∙
+      ap (ap (_G∪H embase) (emloop g) ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
+      ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (comm-emloop-embase' g) ◃∙
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
+        =ₛ⟨ 0 & 2 & !ₛ $ ap-seq-=ₛ (ap (_G∪H embase) (emloop g) ∙_) $
                     take-drop-split 1 (comm-embase-emloop↯ h) ⟩
-      ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (comm-embase-emloop' h) ◃∙
-      ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (comm-emloop-embase' g) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
+      ap (ap (_G∪H embase) (emloop g) ∙_) (comm-embase-emloop' h) ◃∙
+      ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (comm-emloop-embase' g) ◃∙
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
         =ₛ⟨ 0 & 2 & !ₛ (ap2-out' _∙_ (comm-emloop-embase' g) (comm-embase-emloop' h)) ⟩
       ap2 _∙_ (comm-emloop-embase' g) (comm-embase-emloop' h) ◃∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎ ∎ₛ
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎ ∎ₛ
       where
-      h₀ : ∀ y → cp₁₁ embase y == [ north ]₂
+      h₀ : ∀ y → embase G∪H y == [ north ]₂
       h₀ y = idp
-      h₁ : ∀ y → cp₁₁ embase y == [ north ]₂
-      h₁ = transport (λ x → ∀ y → cp₁₁ x y == [ north ]₂) (emloop g) h₀
-      h₀' : ∀ x → − (cp₁₁ embase x) == [ north ]₂
+      h₁ : ∀ y → embase G∪H y == [ north ]₂
+      h₁ = transport (λ x → ∀ y → x G∪H y == [ north ]₂) (emloop g) h₀
+      h₀' : ∀ x → − (embase H∪G x) == [ north ]₂
       h₀' x = idp
-      h₁' : ∀ x → − (cp₁₁ embase x) == [ north ]₂
-      h₁' = transport (λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂) (emloop h) h₀'
-      h₁-path : ∀ y → h₁ y == ! (ap [_]₂ (η (cp₀₁ g y)))
+      h₁' : ∀ x → − (embase H∪G x) == [ north ]₂
+      h₁' = transport (λ y → ∀ x → − (y H∪G x) == [ north ]₂) (emloop h) h₀'
+      h₁-path : ∀ y → h₁ y == ! (ap [_]₂ (GH.η (GH.cp₀₁ g y)))
       h₁-path y =
-        transport (λ x → ∀ y → cp₁₁ x y == [ north ]₂) (emloop g) h₀ y
+        transport (λ x → ∀ y → x G∪H y == [ north ]₂) (emloop g) h₀ y
           =⟨ app= (Π-transp (emloop g) h₀) y ⟩
-        transport (λ x → cp₁₁ x y == [ north ]₂) (emloop g) (h₀ y)
-          =⟨ to-transp {B = λ x → cp₁₁ x y == [ north ]₂} {p = emloop g} $
-             ↓-app=cst-in' {f = λ x → cp₁₁ x y}
+        transport (λ x → x G∪H y == [ north ]₂) (emloop g) (h₀ y)
+          =⟨ to-transp {B = λ x → x G∪H y == [ north ]₂} {p = emloop g} $
+             ↓-app=cst-in' {f = _G∪H y}
                            {p = emloop g} {u = idp}
-                           {v = ! (ap (λ x → cp₁₁ x y) (emloop g))} $
-             ! (!-inv-r (ap (λ x → cp₁₁ x y) (emloop g))) ∙
-             ∙=∙' (ap (λ x → cp₁₁ x y) (emloop g)) (! (ap (λ x → cp₁₁ x y) (emloop g))) ⟩
-        ! (ap (λ x → cp₁₁ x y) (emloop g))
-          =⟨ ap ! (ap-cp₁₁ g y) ⟩
-        ! (ap [_] (η (cp₀₁ g y))) =∎
-      h₁'-path : ∀ x → h₁' x == ! (ap [_]₂ (η (EM₁-antipodal-map (cp₀₁ h x))))
+                           {v = ! (ap (_G∪H y) (emloop g))} $
+             ! (!-inv-r (ap (_G∪H y) (emloop g))) ∙
+             ∙=∙' (ap (_G∪H y) (emloop g)) (! (ap (_G∪H y) (emloop g))) ⟩
+        ! (ap (_G∪H y) (emloop g))
+          =⟨ ap ! (GH.ap-cp₁₁ g y) ⟩
+        ! (ap [_] (GH.η (GH.cp₀₁ g y))) =∎
+      h₁'-path : ∀ x → h₁' x == ! (ap [_]₂ (GH.η (−₁ (HG.cp₀₁ h x))))
       h₁'-path x =
-        transport (λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂) (emloop h) h₀' x
+        transport (λ y → ∀ x → − (y H∪G x) == [ north ]₂) (emloop h) h₀' x
           =⟨ app= (Π-transp (emloop h) h₀') x ⟩
-        transport (λ y → − (cp₁₁ y x) == [ north ]₂) (emloop h) (h₀' x)
-          =⟨ to-transp {B = λ y → − (cp₁₁ y x) == [ north ]₂} {p = emloop h} $
-              ↓-app=cst-in' {f = λ y → − (cp₁₁ y x)}
+        transport (λ y → − (y H∪G x) == [ north ]₂) (emloop h) (h₀' x)
+          =⟨ to-transp {B = λ y → − (y H∪G x) == [ north ]₂} {p = emloop h} $
+              ↓-app=cst-in' {f = λ y → − (y H∪G x)}
                             {p = emloop h} {u = idp}
-                            {v = ! (ap (λ y → − (cp₁₁ y x)) (emloop h))} $
-              ! (!-inv-r (ap (λ y → − (cp₁₁ y x)) (emloop h))) ∙
-              ∙=∙' (ap (λ y → − (cp₁₁ y x)) (emloop h))
-                   (! (ap (λ y → − (cp₁₁ y x)) (emloop h))) ⟩
-        ! (ap (λ y → − (cp₁₁ y x)) (emloop h))
-          =⟨ ap ! (ap-∘ − (λ y → cp₁₁ y x) (emloop h)) ⟩
-        ! (ap − (ap (λ y → cp₁₁ y x) (emloop h)))
-          =⟨ ap (! ∘ ap −) (ap-cp₁₁ h x) ⟩
-        ! (ap − (ap [_]₂ (η (cp₀₁ h x))))
-          =⟨ ap ! (∘-ap − [_]₂ (η (cp₀₁ h x))) ⟩
-        ! (ap (λ p → [ Susp-fmap EM₁-antipodal-map p ]₂) (η (cp₀₁ h x)))
-          =⟨ ap ! (ap-∘ [_]₂ (Susp-fmap EM₁-antipodal-map) (η (cp₀₁ h x))) ⟩
-        ! (ap [_]₂ (ap (Susp-fmap EM₁-antipodal-map) (η (cp₀₁ h x))))
-          =⟨ ! (ap (! ∘ ap [_]₂) (app= (ap fst (η-natural ⊙EM₁-antipodal-map)) (cp₀₁ h x))) ⟩
-        ! (ap [_]₂ (η (EM₁-antipodal-map (cp₀₁ h x)))) =∎
+                            {v = ! (ap (λ y → − (y H∪G x)) (emloop h))} $
+              ! (!-inv-r (ap (λ y → − (y H∪G x)) (emloop h))) ∙
+              ∙=∙' (ap (λ y → − (y H∪G x)) (emloop h))
+                   (! (ap (λ y → − (y H∪G x)) (emloop h))) ⟩
+        ! (ap (λ y → − (y H∪G x)) (emloop h))
+          =⟨ ap ! (ap-∘ − (_H∪G x) (emloop h)) ⟩
+        ! (ap − (ap (_H∪G x) (emloop h)))
+          =⟨ ap (! ∘ ap −) (HG.ap-cp₁₁ h x) ⟩
+        ! (ap − (ap [_]₂ (HG.η (HG.cp₀₁ h x))))
+          =⟨ ap ! (∘-ap − [_]₂ (HG.η (HG.cp₀₁ h x))) ⟩
+        ! (ap (λ p → [ Susp-fmap −₁ p ]₂) (HG.η (HG.cp₀₁ h x)))
+          =⟨ ap ! (ap-∘ [_]₂ (Susp-fmap −₁) (HG.η (HG.cp₀₁ h x))) ⟩
+        ! (ap [_]₂ (ap (Susp-fmap −₁) (HG.η (HG.cp₀₁ h x))))
+          =⟨ ! (ap (! ∘ ap [_]₂) (app= (ap fst (η-natural ⊙−₁)) (HG.cp₀₁ h x))) ⟩
+        ! (ap [_]₂ (GH.η (−₁ (HG.cp₀₁ h x)))) =∎
         where open import homotopy.SuspAdjointLoop using (η-natural)
       h₁-seq : idp {a = [ north ]₂} =-= idp
       h₁-seq = ! (!-inv-r (h₁ embase)) ◃∙
@@ -467,47 +523,43 @@ module CP₁₁-comm where
         ! (!-inv-r (h₁ embase)) ◃∙
         ap (λ v → h₁ v ∙ ! (h₁ embase)) (emloop h) ◃∙
         !-inv-r (h₁ embase) ◃∎
-          =ₛ⟨ =ₛ-in {t = ! (!-inv-r (! (ap [_]₂ (η embase)))) ◃∙
-                         ap (λ v → ! (ap [_]₂ (η (cp₀₁ g v))) ∙ ! (! (ap [_] (η embase)))) (emloop h) ◃∙
-                         !-inv-r (! (ap [_]₂ (η embase))) ◃∎} $
+          =ₛ⟨ =ₛ-in {t = ! (!-inv-r (! (ap [_]₂ (GH.η embase)))) ◃∙
+                         ap (λ v → ! (ap [_]₂ (GH.η (GH.cp₀₁ g v))) ∙ ! (! (ap [_] (GH.η embase)))) (emloop h) ◃∙
+                         !-inv-r (! (ap [_]₂ (GH.η embase))) ◃∎} $
               ap (λ f → ! (!-inv-r (f embase)) ∙
                         ap (λ v → f v ∙ ! (f embase)) (emloop h) ∙
                         !-inv-r (f embase))
                   (λ= h₁-path) ⟩
-        ! (!-inv-r (! (ap [_]₂ (η embase)))) ◃∙
-        ap (λ v → ! (ap [_]₂ (η (cp₀₁ g v))) ∙ ! (! (ap [_]₂ (η embase)))) (emloop h) ◃∙
-        !-inv-r (! (ap [_]₂ (η embase))) ◃∎
+        ! (!-inv-r (! (ap [_]₂ (GH.η embase)))) ◃∙
+        ap (λ v → ! (ap [_]₂ (GH.η (GH.cp₀₁ g v))) ∙ ! (! (ap [_]₂ (GH.η embase)))) (emloop h) ◃∙
+        !-inv-r (! (ap [_]₂ (GH.η embase))) ◃∎
           =ₛ₁⟨ 1 & 1 &
-                ap (λ v → ! (ap [_]₂ (η (cp₀₁ g v))) ∙ ! (! (ap [_]₂ (η embase)))) (emloop h)
-                  =⟨ ap-∘ (λ w → ! (ap [_]₂ (η w)) ∙ ! (! (ap [_]₂ (η embase)))) (cp₀₁ g) (emloop h) ⟩
-                ap (λ w → ! (ap [_]₂ (η w)) ∙ ! (! (ap [_]₂ (η embase)))) (ap (cp₀₁ g) (emloop h))
-                  =⟨ ap (ap (λ w → ! (ap [_]₂ (η w)) ∙ ! (! (ap [_]₂ (η embase))))) $
-                    ap (cp₀₁ g) (emloop h)
-                      =⟨ CP₀₁-comm.cp₀₁-comm g h ⟩
-                    ap (cp₀₁ h) (emloop g)
-                      =⟨ cp₀₁-emloop-β h g ⟩
-                    emloop (R.mult h g)
-                      =⟨ ! (!-! (emloop (R.mult h g))) ⟩
-                    ! (! (emloop (R.mult h g)))
-                      =⟨ ap ! (! (EM₁-antipodal-map-! (R.mult h g))) ⟩
-                    ! (ap EM₁-antipodal-map (emloop (R.mult h g)))
-                      =⟨ ap (! ∘ ap EM₁-antipodal-map) (! (cp₀₁-emloop-β h g)) ⟩
-                    ! (ap EM₁-antipodal-map (ap (cp₀₁ h) (emloop g)))
-                      =⟨ ap ! (∘-ap EM₁-antipodal-map (cp₀₁ h) (emloop g)) ⟩
-                    ! (ap (EM₁-antipodal-map ∘ cp₀₁ h) (emloop g)) =∎
+                ap (λ v → ! (ap [_]₂ (GH.η (GH.cp₀₁ g v))) ∙ ! (! (ap [_]₂ (GH.η embase)))) (emloop h)
+                  =⟨ ap-∘ (λ w → ! (ap [_]₂ (GH.η w)) ∙ ! (! (ap [_]₂ (GH.η embase)))) (GH.cp₀₁ g) (emloop h) ⟩
+                ap (λ w → ! (ap [_]₂ (GH.η w)) ∙ ! (! (ap [_]₂ (GH.η embase)))) (ap (GH.cp₀₁ g) (emloop h))
+                  =⟨ ap (ap (λ w → ! (ap [_]₂ (GH.η w)) ∙ ! (! (ap [_]₂ (GH.η embase))))) $
+                    ap (GH.cp₀₁ g) (emloop h)
+                      =⟨ CP₀₁-comm.cp₀₁-comm G H g h ⟩
+                    ap (EM₁-fmap H⊗G.swap ∘ HG.cp₀₁ h) (emloop g)
+                      =⟨ ! (!-! _) ⟩
+                    ! (! (ap (EM₁-fmap H⊗G.swap ∘ HG.cp₀₁ h) (emloop g)))
+                      =⟨ ap ! (! (EM₁-antipodal-map-! _)) ⟩
+                    ! (ap EM₁-antipodal-map (ap (EM₁-fmap H⊗G.swap ∘ HG.cp₀₁ h) (emloop g)))
+                      =⟨ ap ! (∘-ap EM₁-antipodal-map (EM₁-fmap H⊗G.swap ∘ HG.cp₀₁ h) (emloop g)) ⟩
+                    ! (ap (−₁ ∘ HG.cp₀₁ h) (emloop g)) =∎
                     -- Yo dawg, I herd you like continued equalities,
                     -- so we put continued equalities into your continued equalities,
-                    -- so you can reason equationally while u reason equationally.
+                    -- so u can reason equationally while u reason equationally.
                   ⟩
-                ap (λ w → ! (ap [_]₂ (η w)) ∙ ! (! (ap [_]₂ (η embase)))) (! (ap (EM₁-antipodal-map ∘ cp₀₁ h) (emloop g)))
-                  =⟨ ap-! (λ w → ! (ap [_]₂ (η w)) ∙ ! (! (ap [_]₂ (η embase)))) (ap (EM₁-antipodal-map ∘ cp₀₁ h) (emloop g)) ⟩
-                ! (ap (λ w → ! (ap [_]₂ (η w)) ∙ ! (! (ap [_]₂ (η embase)))) (ap (EM₁-antipodal-map ∘ cp₀₁ h) (emloop g)))
-                  =⟨ ap ! (∘-ap (λ w → ! (ap [_]₂ (η w)) ∙ ! (! (ap [_]₂ (η embase)))) (EM₁-antipodal-map ∘ cp₀₁ h) (emloop g)) ⟩
-                ! (ap (λ v → ! (ap [_]₂ (η (EM₁-antipodal-map (cp₀₁ h v)))) ∙ ! (! (ap [_]₂ (η embase)))) (emloop g)) =∎
+                ap (λ w → ! (ap [_]₂ (GH.η w)) ∙ ! (! (ap [_]₂ (GH.η embase)))) (! (ap (−₁ ∘ HG.cp₀₁ h) (emloop g)))
+                  =⟨ ap-! (λ w → ! (ap [_]₂ (GH.η w)) ∙ ! (! (ap [_]₂ (GH.η embase)))) (ap (−₁ ∘ HG.cp₀₁ h) (emloop g)) ⟩
+                ! (ap (λ w → ! (ap [_]₂ (GH.η w)) ∙ ! (! (ap [_]₂ (GH.η embase)))) (ap (−₁ ∘ HG.cp₀₁ h) (emloop g)))
+                  =⟨ ap ! (∘-ap (λ w → ! (ap [_]₂ (GH.η w)) ∙ ! (! (ap [_]₂ (GH.η embase)))) (−₁ ∘ HG.cp₀₁ h) (emloop g)) ⟩
+                ! (ap (λ v → ! (ap [_]₂ (GH.η (−₁ (HG.cp₀₁ h v)))) ∙ ! (! (ap [_]₂ (GH.η embase)))) (emloop g)) =∎
               ⟩
-        ! (!-inv-r (! (ap [_]₂ (η embase)))) ◃∙
-        ! (ap (λ v → ! (ap [_]₂ (η (EM₁-antipodal-map (cp₀₁ h v)))) ∙ ! (! (ap [_]₂ (η embase)))) (emloop g)) ◃∙
-        !-inv-r (! (ap [_]₂ (η embase))) ◃∎
+        ! (!-inv-r (! (ap [_]₂ (GH.η embase)))) ◃∙
+        ! (ap (λ v → ! (ap [_]₂ (GH.η (−₁ (HG.cp₀₁ h v)))) ∙ ! (! (ap [_]₂ (GH.η embase)))) (emloop g)) ◃∙
+        !-inv-r (! (ap [_]₂ (GH.η embase))) ◃∎
           =ₛ⟨ =ₛ-in {t = ! (!-inv-r (h₁' embase)) ◃∙
                          ! (ap (λ v → h₁' v ∙ ! (h₁' embase)) (emloop g)) ◃∙
                          !-inv-r (h₁' embase) ◃∎} $
@@ -539,189 +591,191 @@ module CP₁₁-comm where
           =ₛ₁⟨ !-inv-r (!-inv-r (h₀ b)) ⟩
         idp ◃∎ ∎ₛ
       top-part :
-        ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-        ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
+        ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+        ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
           =ₛ
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+        ap (ap (_G∪H embase) (emloop g) ∙_)
             (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-        ap (_∙ idp) (ap-cp₁₁-embase g) ◃∎
+        ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+        ap (_∙ idp) (GH.ap-cp₁₁-embase g) ◃∎
       top-part =
-        ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-        ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
-          =ₛ₁⟨ 1 & 1 & ap (ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g)))
-                          (! (homotopy-naturality-cst-to-cst {A = EM₁ R₊} {B = EM 2} [ north ]₂ (emloop' R₊ h))) ⟩
-        ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ◃∙
-        ap (_∙ ap (λ x → cp₁₁ x embase) (emloop g))
-           (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ (λ y → idp) (emloop' R₊ h)) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
+        ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+        ap (_∙ ap (_G∪H embase) (emloop g)) (ap-cst [ north ] (emloop h)) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
+          =ₛ₁⟨ 1 & 1 &
+               ap (ap (_∙ ap (_G∪H embase) (emloop g))) $ ! $
+               homotopy-naturality-cst-to-cst {A = EM₁ H.grp} {B = EMExplicit.EM G⊗H.abgroup 2}
+                                              [ north ]₂ (emloop' H.grp h) ⟩
+        ap-comm _G∪H_ (emloop g) (emloop h) ◃∙
+        ap (_∙ ap (_G∪H embase) (emloop g))
+           (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ (λ y → idp) (emloop' H.grp h)) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
           =ₛ⟨ 0 & 2 & post-rotate-out {r = _ ◃∙ _ ◃∙ _ ◃∎} $
-                      ap-comm-cst-coh cp₁₁ (emloop g) (emloop h) [ north ]₂ (λ y → idp) ⟩
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+                      ap-comm-cst-coh _G∪H_ (emloop g) (emloop h) [ north ]₂ (λ y → idp) ⟩
+        ap (ap (_G∪H embase) (emloop g) ∙_)
            (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-           (app= (transp-naturality {B = λ x → ∀ y → cp₁₁ x y == [ north ]₂} {C = λ x → cp₁₁ x embase == cp₁₁ x embase}
+        ap (ap (_G∪H embase) (emloop g) ∙_)
+           (app= (transp-naturality {B = λ x → ∀ y → x G∪H y == [ north ]₂} {C = λ x → x G∪H embase == x G∪H embase}
                                     (λ h → h embase ∙ ! (h embase)) (emloop g))
-                  (λ y → idp)) ◃∙
-        ! (ap-transp (λ x → cp₁₁ x embase) (λ x → cp₁₁ x embase) (emloop g) idp) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
-          =ₛ⟨ 1 & 1 & ap-seq-=ₛ (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-                                (transp-nat-idp cp₁₁ (emloop g) embase [ north ]₂ (λ y → idp)) ⟩
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+                 (λ y → idp)) ◃∙
+        ! (ap-transp (_G∪H embase) (_G∪H embase) (emloop g) idp) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
+          =ₛ⟨ 1 & 1 & ap-seq-=ₛ (ap (_G∪H embase) (emloop g) ∙_)
+                                (transp-nat-idp _G∪H_ (emloop g) embase [ north ]₂ (λ y → idp)) ⟩
+        ap (ap (_G∪H embase) (emloop g) ∙_)
            (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-            (! (transp-idp (λ a → cp₁₁ a embase) (emloop g))) ◃∙
+        ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+        ap (ap (_G∪H embase) (emloop g) ∙_)
+            (! (transp-idp (_G∪H embase) (emloop g))) ◃∙
         idp ◃∙
-        ! (ap-transp (λ x → cp₁₁ x embase) (λ x → cp₁₁ x embase) (emloop g) idp) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
+        ! (ap-transp (_G∪H embase) (_G∪H embase) (emloop g) idp) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
           =ₛ⟨ 3 & 1 & expand [] ⟩
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+        ap (ap (_G∪H embase) (emloop g) ∙_)
            (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-            (! (transp-idp (λ a → cp₁₁ a embase) (emloop g))) ◃∙
-        ! (ap-transp (λ x → cp₁₁ x embase) (λ x → cp₁₁ x embase) (emloop g) idp) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
-          =ₛ₁⟨ 2 & 1 & ap-! (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (transp-idp (λ a → cp₁₁ a embase) (emloop g)) ⟩
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+        ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+        ap (ap (_G∪H embase) (emloop g) ∙_)
+           (! (transp-idp (_G∪H embase) (emloop g))) ◃∙
+        ! (ap-transp (_G∪H embase) (_G∪H embase) (emloop g) idp) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
+          =ₛ₁⟨ 2 & 1 & ap-! (ap (_G∪H embase) (emloop g) ∙_) (transp-idp (_G∪H embase) (emloop g)) ⟩
+        ap (ap (_G∪H embase) (emloop g) ∙_)
            (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-        ! (ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
-              (transp-idp (λ a → cp₁₁ a embase) (emloop g))) ◃∙
-        ! (ap-transp (λ x → cp₁₁ x embase) (λ x → cp₁₁ x embase) (emloop g) idp) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
+        ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+        ! (ap (ap (_G∪H embase) (emloop g) ∙_)
+              (transp-idp (_G∪H embase) (emloop g))) ◃∙
+        ! (ap-transp (_G∪H embase) (_G∪H embase) (emloop g) idp) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
           =ₛ⟨ 2 & 2 & pre-rotate'-seq-in {p = _ ◃∙ _ ◃∎} {r = []} $
-                      !ₛ $ ap-transp-idp (λ x → cp₁₁ x embase) (emloop g) ⟩
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+                      !ₛ $ ap-transp-idp (_G∪H embase) (emloop g) ⟩
+        ap (ap (_G∪H embase) (emloop g) ∙_)
            (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-        ∙-unit-r (ap (λ x → cp₁₁ x embase) (emloop g)) ◃∙
-        ap (idp ∙_) (ap-cp₁₁-embase g) ◃∎
-          =ₛ⟨ 2 & 2 & !ₛ $ homotopy-naturality (_∙ idp) (idp ∙_) ∙-unit-r (ap-cp₁₁-embase g) ⟩
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+        ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+        ∙-unit-r (ap (_G∪H embase) (emloop g)) ◃∙
+        ap (idp ∙_) (GH.ap-cp₁₁-embase g) ◃∎
+          =ₛ⟨ 2 & 2 & !ₛ $ homotopy-naturality (_∙ idp) (idp ∙_) ∙-unit-r (GH.ap-cp₁₁-embase g) ⟩
+        ap (ap (_G∪H embase) (emloop g) ∙_)
            (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-        ap (_∙ idp) (ap-cp₁₁-embase g) ◃∙
+        ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+        ap (_∙ idp) (GH.ap-cp₁₁-embase g) ◃∙
         idp ◃∎
           =ₛ⟨ 3 & 1 & expand [] ⟩
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_)
+        ap (ap (_G∪H embase) (emloop g) ∙_)
            (homotopy-naturality-to-cst (λ y → [ north ]₂) [ north ]₂ h₁ (emloop h)) ◃∙
-        ap (ap (λ x → cp₁₁ x embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
-        ap (_∙ idp) (ap-cp₁₁-embase g) ◃∎ ∎ₛ
+        ap (ap (_G∪H embase) (emloop g) ∙_) (!-inv-r (h₁ embase)) ◃∙
+        ap (_∙ idp) (GH.ap-cp₁₁-embase g) ◃∎ ∎ₛ
       bottom-part :
         ap (_∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
            (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
         =ₛ
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
-        ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
+        ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
+        ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
       bottom-part =
-        ap (λ a → a ∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ap (_∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
            (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
           =ₛ⟨ 0 & 0 & contract ⟩
         idp ◃∙
         ap (_∙ idp) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
            (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
           =ₛ⟨ 0 & 2 & !ₛ (homotopy-naturality (idp ∙_) (_∙ idp) (! ∘ ∙-unit-r) (↯ (tail (comm-embase-emloop↯ h)))) ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ! (∙-unit-r (ap (λ y → − (cp₁₁ y embase)) (emloop h))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ! (∙-unit-r (ap (λ y → − (y H∪G embase)) (emloop h))) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
            (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
           =ₛ⟨ 1 & 1 & !ₛ $ post-rotate-in {p = _ ◃∙ _ ◃∎} $
-                      ap-transp-idp (λ y → − (cp₁₁ y embase)) (emloop h) ⟩
+                      ap-transp-idp (λ y → − (y H∪G embase)) (emloop h) ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap-transp (λ y → − (cp₁₁ y embase)) (λ y → − (cp₁₁ y embase)) (emloop h) idp ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (transp-idp (λ y → − (cp₁₁ y embase)) (emloop h)) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ap-transp (λ y → − (y H∪G embase)) (λ y → − (y H∪G embase)) (emloop h) idp ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (transp-idp (λ y → − (y H∪G embase)) (emloop h)) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) (! (!-inv-r (h₁' embase))) ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
            (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
-          =ₛ⟨ 2 & 2 & ap-seq-=ₛ (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_) $
-              transp-idp (λ y → − (cp₁₁ y embase)) (emloop h) ◃∙
+          =ₛ⟨ 2 & 2 & ap-seq-=ₛ (ap (λ y → − (y H∪G embase)) (emloop h) ∙_) $
+              transp-idp (λ y → − (y H∪G embase)) (emloop h) ◃∙
               ! (!-inv-r (h₁' embase)) ◃∎
                 =ₛ⟨ pre-rotate-out $ pre-rotate'-in $ post-rotate-in {p = []} $
-                    transp-nat-idp (λ y x → − (cp₁₁ y x)) (emloop h) embase [ north ]₂ (λ x → idp) ⟩
+                    transp-nat-idp (λ y x → − (y H∪G x)) (emloop h) embase [ north ]₂ (λ x → idp) ⟩
               idp ◃∙
-              ! (app= (transp-naturality {B = λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂}
+              ! (app= (transp-naturality {B = λ y → ∀ x → − (y H∪G x) == [ north ]₂}
                                           (λ h → h embase ∙ ! (h embase)) (emloop h))
                       (λ x → idp)) ◃∎
                 =ₛ⟨ 0 & 1 & expand [] ⟩
-              ! (app= (transp-naturality {B = λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂}
+              ! (app= (transp-naturality {B = λ y → ∀ x → − (y H∪G x) == [ north ]₂}
                                           (λ h → h embase ∙ ! (h embase)) (emloop h))
                       (λ x → idp)) ◃∎ ∎ₛ
             ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap-transp (λ y → − (cp₁₁ y embase)) (λ y → − (cp₁₁ y embase)) (emloop h) idp ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
-           (! (app= (transp-naturality {B = λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂}
+        ap-transp (λ y → − (y H∪G embase)) (λ y → − (y H∪G embase)) (emloop h) idp ◃∙
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
+           (! (app= (transp-naturality {B = λ y → ∀ x → − (y H∪G x) == [ north ]₂}
                                         (λ h → h embase ∙ ! (h embase)) (emloop h))
                     (λ x → idp))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
            (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
-          =ₛ₁⟨ 2 & 1 & ap-! (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
-                            (app= (transp-naturality {B = λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂}
+          =ₛ₁⟨ 2 & 1 & ap-! (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
+                            (app= (transp-naturality {B = λ y → ∀ x → − (y H∪G x) == [ north ]₂}
                                                       (λ h → h embase ∙ ! (h embase)) (emloop h))
                                   (λ x → idp)) ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap-transp (λ y → − (cp₁₁ y embase)) (λ y → − (cp₁₁ y embase)) (emloop h) idp ◃∙
-        ! (ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
-              (app= (transp-naturality {B = λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂}
+        ap-transp (λ y → − (y H∪G embase)) (λ y → − (y H∪G embase)) (emloop h) idp ◃∙
+        ! (ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
+              (app= (transp-naturality {B = λ y → ∀ x → − (y H∪G x) == [ north ]₂}
                                         (λ h → h embase ∙ ! (h embase)) (emloop h))
                     (λ x → idp))) ◃∙
-        ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
            (! (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
-          =ₛ₁⟨ 3 & 1 & ap-! (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+          =ₛ₁⟨ 3 & 1 & ap-! (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
                             (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g)) ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap-transp (λ y → − (cp₁₁ y embase)) (λ y → − (cp₁₁ y embase)) (emloop h) idp ◃∙
-        ! (ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
-              (app= (transp-naturality {B = λ y → ∀ x → − (cp₁₁ y x) == [ north ]₂}
+        ap-transp (λ y → − (y H∪G embase)) (λ y → − (y H∪G embase)) (emloop h) idp ◃∙
+        ! (ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
+              (app= (transp-naturality {B = λ y → ∀ x → − (y H∪G x) == [ north ]₂}
                                         (λ h → h embase ∙ ! (h embase)) (emloop h))
                     (λ x → idp))) ◃∙
-        ! (ap (ap (λ y → − (cp₁₁ y embase)) (emloop h) ∙_)
+        ! (ap (ap (λ y → − (y H∪G embase)) (emloop h) ∙_)
               (homotopy-naturality-to-cst (λ x → [ north ]₂) [ north ]₂ h₁' (emloop g))) ◃∎
           =ₛ⟨ 1 & 3 & pre-rotate-out $
                       pre-rotate'-seq-in {p = _ ◃∙ _ ◃∎} $
                       post-rotate-in {p = []} $
-                      ap-comm-cst-coh (λ y x → − (cp₁₁ y x))
+                      ap-comm-cst-coh (λ y x → − (y H∪G x))
                                       (emloop h) (emloop g) [ north ]₂ (λ x → idp) ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ! (ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h))
-              (homotopy-naturality-to-cst (λ x → − (cp₁₁ embase x))
+        ! (ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h))
+              (homotopy-naturality-to-cst (λ x → − (embase H∪G x))
                                           [ north ]₂ (λ x → idp) (emloop g))) ◃∙
-        ! (ap-comm (λ y x → − (cp₁₁ y x)) (emloop h) (emloop g)) ◃∎
-          =ₛ₁⟨ 2 & 1 & ! (ap-comm-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h)) ⟩
+        ! (ap-comm (λ y x → − (y H∪G x)) (emloop h) (emloop g)) ◃∎
+          =ₛ₁⟨ 2 & 1 & ! (ap-comm-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h)) ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ! (ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h))
-              (homotopy-naturality-to-cst (λ x → − (cp₁₁ embase x))
+        ! (ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h))
+              (homotopy-naturality-to-cst (λ x → − (embase H∪G x))
                                           [ north ]₂ (λ x → idp) (emloop g))) ◃∙
-        ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎
+        ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎
           =ₛ₁⟨ 1 & 1 &
-                ! (ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h))
-                      (homotopy-naturality-to-cst (λ x → − (cp₁₁ embase x))
+                ! (ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h))
+                      (homotopy-naturality-to-cst (λ x → − (embase H∪G x))
                                                   [ north ]₂ (λ x → idp) (emloop g)))
-                  =⟨ !-ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h))
-                          (homotopy-naturality-to-cst (λ x → − (cp₁₁ embase x))
+                  =⟨ !-ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h))
+                          (homotopy-naturality-to-cst (λ x → − (embase H∪G x))
                                                       [ north ]₂ (λ x → idp) (emloop g)) ⟩
-                ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h))
-                   (! (homotopy-naturality-to-cst (λ x → − (cp₁₁ embase x))
+                ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h))
+                   (! (homotopy-naturality-to-cst (λ x → − (embase H∪G x))
                                                   [ north ]₂ (λ x → idp) (emloop g)))
-                  =⟨ ap (ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) ∘ !) $
+                  =⟨ ap (ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) ∘ !) $
                      homotopy-naturality-cst-to-cst [ north ]₂ (emloop g) ⟩
-                ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) =∎
+                ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) =∎
               ⟩
         ap (idp ∙_) (↯ (tail (comm-embase-emloop↯ h))) ◃∙
-        ap (_∙ ap (λ y → − (cp₁₁ y embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
-        ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) ◃∎ ∎ₛ
+        ap (_∙ ap (λ y → − (y H∪G embase)) (emloop h)) (! (ap-cst [ north ]₂ (emloop g))) ◃∙
+        ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) ◃∎ ∎ₛ
       step₄' : ! (ap-cst [ north ] (emloop g)) ◃∎
                 =ₛ
                 ↯ h₁'-seq ◃∙
@@ -771,16 +825,16 @@ module CP₁₁-comm where
 
     comm-embase-emloop : ∀ h →
       Square idp
-              (ap (cp₁₁ embase) (emloop h))
-              (ap (λ y → − (cp₁₁ y embase)) (emloop h))
-              idp
+             (ap (embase G∪H_) (emloop h))
+             (ap (λ y → − (y H∪G embase)) (emloop h))
+             idp
     comm-embase-emloop h = vert-degen-square (comm-embase-emloop' h)
 
     comm-emloop-embase : ∀ g →
       Square idp
-              (ap (λ x → cp₁₁ x embase) (emloop g))
-              (ap (λ x → − (cp₁₁ embase x)) (emloop g))
-              idp
+             (ap (_G∪H embase) (emloop g))
+             (ap (λ x → − (embase H∪G x)) (emloop g))
+             idp
     comm-emloop-embase g = vert-degen-square (comm-emloop-embase' g)
 
     square-helper : ∀ {i} {A : Type i}
@@ -803,118 +857,118 @@ module CP₁₁-comm where
       vert-degen-square (s ∙ ap2 _∙_ p q ∙ t) =∎
 
     comm-embase-emloop-comp : ∀ h₁ h₂ →
-      comm-embase-emloop (R.add h₁ h₂) ⊡v∙
-      ap (ap (λ y → − (cp₁₁ y embase))) (emloop-comp h₁ h₂)
+      comm-embase-emloop (H.comp h₁ h₂) ⊡v∙
+      ap (ap (λ y → − (y H∪G embase))) (emloop-comp h₁ h₂)
       ==
-      ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ∙v⊡
+      ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ∙v⊡
       ↓-='-square-comp (comm-embase-emloop h₁) (comm-embase-emloop h₂)
     comm-embase-emloop-comp h₁ h₂ =
-      comm-embase-emloop (R.add h₁ h₂) ⊡v∙
-      ap (ap (λ y → − (cp₁₁ y embase))) (emloop-comp h₁ h₂)
+      comm-embase-emloop (H.comp h₁ h₂) ⊡v∙
+      ap (ap (λ y → − (y H∪G embase))) (emloop-comp h₁ h₂)
         =⟨ vert-degen-square-⊡v∙
-              (comm-embase-emloop' (R.add h₁ h₂))
-              (ap (ap (λ y → − (cp₁₁ y embase))) (emloop-comp h₁ h₂)) ⟩
+              (comm-embase-emloop' (H.comp h₁ h₂))
+              (ap (ap (λ y → − (y H∪G embase))) (emloop-comp h₁ h₂)) ⟩
       vert-degen-square
-        (comm-embase-emloop' (R.add h₁ h₂) ∙
-          ap (ap (λ y → − (cp₁₁ y embase))) (emloop-comp h₁ h₂))
+        (comm-embase-emloop' (H.comp h₁ h₂) ∙
+          ap (ap (λ y → − (y H∪G embase))) (emloop-comp h₁ h₂))
         =⟨ ap vert-degen-square (=ₛ-out (comm-embase-emloop-comp' h₁ h₂)) ⟩
       vert-degen-square
-        (ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ∙
-          ap-∙ (λ y → cp₁₁ embase y) (emloop h₁) (emloop h₂) ∙
+        (ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ∙
+          ap-∙ (embase G∪H_) (emloop h₁) (emloop h₂) ∙
           ap2 _∙_ (comm-embase-emloop' h₁) (comm-embase-emloop' h₂) ∙
-          ∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂))
-        =⟨ ! $ vert-degen-square-∙v⊡ (ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂)) _ ⟩
-      ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ∙v⊡
+          ∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂))
+        =⟨ ! $ vert-degen-square-∙v⊡ (ap (ap (embase G∪H_)) (emloop-comp h₁ h₂)) _ ⟩
+      ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ∙v⊡
       vert-degen-square
-        (ap-∙ (λ y → cp₁₁ embase y) (emloop h₁) (emloop h₂) ∙
+        (ap-∙ (embase G∪H_) (emloop h₁) (emloop h₂) ∙
           ap2 _∙_ (comm-embase-emloop' h₁) (comm-embase-emloop' h₂) ∙
-          ∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂))
-        =⟨ ap (ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ∙v⊡_) $ ! $
-           square-helper (ap-∙ (λ y → cp₁₁ embase y) (emloop h₁) (emloop h₂))
+          ∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂))
+        =⟨ ap (ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ∙v⊡_) $ ! $
+           square-helper (ap-∙ (embase G∪H_) (emloop h₁) (emloop h₂))
                          (comm-embase-emloop' h₁) (comm-embase-emloop' h₂)
-                         (∙-ap (λ y → − (cp₁₁ y embase)) (emloop h₁) (emloop h₂)) ⟩
-      ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ∙v⊡
+                         (∙-ap (λ y → − (y H∪G embase)) (emloop h₁) (emloop h₂)) ⟩
+      ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ∙v⊡
       ↓-='-square-comp' (comm-embase-emloop h₁) (comm-embase-emloop h₂)
-        =⟨ ap (ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ∙v⊡_) $
+        =⟨ ap (ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ∙v⊡_) $
            ↓-='-square-comp'=↓-='-square-comp (comm-embase-emloop h₁)
                                               (comm-embase-emloop h₂) ⟩
-      ap (ap (λ y → cp₁₁ embase y)) (emloop-comp h₁ h₂) ∙v⊡
+      ap (ap (embase G∪H_)) (emloop-comp h₁ h₂) ∙v⊡
       ↓-='-square-comp (comm-embase-emloop h₁) (comm-embase-emloop h₂) =∎
 
     comm-emloop-comp-embase : ∀ g₁ g₂ →
-      comm-emloop-embase (R.add g₁ g₂) ⊡v∙
-      ap (ap (λ x → − (cp₁₁ embase x))) (emloop-comp g₁ g₂)
+      comm-emloop-embase (G.comp g₁ g₂) ⊡v∙
+      ap (ap (λ x → − (embase H∪G x))) (emloop-comp g₁ g₂)
       ==
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ∙v⊡
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ∙v⊡
       ↓-='-square-comp (comm-emloop-embase g₁) (comm-emloop-embase g₂)
     comm-emloop-comp-embase g₁ g₂ =
-      comm-emloop-embase (R.add g₁ g₂) ⊡v∙
-      ap (ap (λ x → − (cp₁₁ embase x))) (emloop-comp g₁ g₂)
+      comm-emloop-embase (G.comp g₁ g₂) ⊡v∙
+      ap (ap (λ x → − (embase H∪G x))) (emloop-comp g₁ g₂)
         =⟨ vert-degen-square-⊡v∙
-             (comm-emloop-embase' (R.add g₁ g₂))
-             (ap (ap (λ x → − (cp₁₁ embase x))) (emloop-comp g₁ g₂)) ⟩
+             (comm-emloop-embase' (G.comp g₁ g₂))
+             (ap (ap (λ x → − (embase H∪G x))) (emloop-comp g₁ g₂)) ⟩
       vert-degen-square
-        (comm-emloop-embase' (R.add g₁ g₂) ∙
-          ap (ap (λ x → − (cp₁₁ embase x))) (emloop-comp g₁ g₂))
+        (comm-emloop-embase' (G.comp g₁ g₂) ∙
+          ap (ap (λ x → − (embase H∪G x))) (emloop-comp g₁ g₂))
           =⟨ ap vert-degen-square (=ₛ-out (comm-emloop-comp-embase' g₁ g₂)) ⟩
       vert-degen-square
-        (ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ∙
-         ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ∙
+        (ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ∙
+         ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ∙
          ap2 _∙_ (comm-emloop-embase' g₁) (comm-emloop-embase' g₂) ∙
-         ∙-ap (λ x → − (cp₁₁ embase x)) (emloop g₁) (emloop g₂))
-        =⟨ ! $ vert-degen-square-∙v⊡ (ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂)) _ ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ∙v⊡
+         ∙-ap (λ x → − (embase H∪G x)) (emloop g₁) (emloop g₂))
+        =⟨ ! $ vert-degen-square-∙v⊡ (ap (ap (_G∪H embase)) (emloop-comp g₁ g₂)) _ ⟩
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ∙v⊡
       vert-degen-square
-        (ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂) ∙
+        (ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂) ∙
          ap2 _∙_ (comm-emloop-embase' g₁) (comm-emloop-embase' g₂) ∙
-         ∙-ap (λ x → − (cp₁₁ embase x)) (emloop g₁) (emloop g₂))
-        =⟨ ap (ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ∙v⊡_) $ ! $
+         ∙-ap (λ x → − (embase H∪G x)) (emloop g₁) (emloop g₂))
+        =⟨ ap (ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ∙v⊡_) $ ! $
            square-helper
-             (ap-∙ (λ x → cp₁₁ x embase) (emloop g₁) (emloop g₂))
+             (ap-∙ (_G∪H embase) (emloop g₁) (emloop g₂))
              (comm-emloop-embase' g₁) (comm-emloop-embase' g₂)
-             (∙-ap (λ x → − (cp₁₁ embase x)) (emloop g₁) (emloop g₂)) ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ∙v⊡
+             (∙-ap (λ x → − (embase H∪G x)) (emloop g₁) (emloop g₂)) ⟩
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ∙v⊡
       ↓-='-square-comp' (comm-emloop-embase g₁) (comm-emloop-embase g₂)
-        =⟨ ap (ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ∙v⊡_) $
+        =⟨ ap (ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ∙v⊡_) $
            ↓-='-square-comp'=↓-='-square-comp
              (comm-emloop-embase g₁) (comm-emloop-embase g₂) ⟩
-      ap (ap (λ x → cp₁₁ x embase)) (emloop-comp g₁ g₂) ∙v⊡
+      ap (ap (_G∪H embase)) (emloop-comp g₁ g₂) ∙v⊡
       ↓-='-square-comp (comm-emloop-embase g₁) (comm-emloop-embase g₂) =∎
 
     comm-emloop-emloop : ∀ g h →
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ∙v⊡
+      ap-comm _G∪H_ (emloop g) (emloop h) ∙v⊡
       comm-embase-emloop h ⊡h comm-emloop-embase g
       ==
       (comm-emloop-embase g ⊡h comm-embase-emloop h) ⊡v∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h)
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h)
     comm-emloop-emloop g h =
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ∙v⊡
+      ap-comm _G∪H_ (emloop g) (emloop h) ∙v⊡
       comm-embase-emloop h ⊡h comm-emloop-embase g
-        =⟨ ap (ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ∙v⊡_) $
+        =⟨ ap (ap-comm _G∪H_ (emloop g) (emloop h) ∙v⊡_) $
            vert-degen-square-⊡h (comm-embase-emloop' h) (comm-emloop-embase' g) ⟩
-      ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ∙v⊡
+      ap-comm _G∪H_ (emloop g) (emloop h) ∙v⊡
       vert-degen-square (ap2 _∙_ (comm-embase-emloop' h) (comm-emloop-embase' g))
-        =⟨ vert-degen-square-∙v⊡ (ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h)) _ ⟩
+        =⟨ vert-degen-square-∙v⊡ (ap-comm _G∪H_ (emloop g) (emloop h)) _ ⟩
       vert-degen-square
-        (ap-comm (λ x y → cp₁₁ x y) (emloop g) (emloop h) ∙
+        (ap-comm _G∪H_ (emloop g) (emloop h) ∙
          ap2 _∙_ (comm-embase-emloop' h) (comm-emloop-embase' g))
         =⟨ ap vert-degen-square (=ₛ-out (comm-emloop-emloop' g h)) ⟩
       vert-degen-square
         (ap2 _∙_ (comm-emloop-embase' g) (comm-embase-emloop' h) ∙
-         ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h))
-        =⟨ ! $ vert-degen-square-⊡v∙ _ (ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h)) ⟩
+         ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h))
+        =⟨ ! $ vert-degen-square-⊡v∙ _ (ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h)) ⟩
       vert-degen-square (ap2 _∙_ (comm-emloop-embase' g) (comm-embase-emloop' h)) ⊡v∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h)
-        =⟨ ap (_⊡v∙ ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h)) $ ! $
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h)
+        =⟨ ap (_⊡v∙ ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h)) $ ! $
            vert-degen-square-⊡h (comm-emloop-embase' g) (comm-embase-emloop' h) ⟩
       (comm-emloop-embase g ⊡h comm-embase-emloop h) ⊡v∙
-      ap-comm (λ x y → − (cp₁₁ y x)) (emloop g) (emloop h) =∎
+      ap-comm (λ x y → − (y H∪G x)) (emloop g) (emloop h) =∎
 
   private
     module CP₁₁Comm =
-      EM₁Level₂DoublePathElim R₊ R₊ {C = EM 2} {{Trunc-level}}
-        (λ x y → cp₁₁ x y)
-        (λ x y → − (cp₁₁ y x))
+      EM₁Level₂DoublePathElim G.grp H.grp {C = EMExplicit.EM G⊗H.abgroup 2} {{Trunc-level}}
+        _G∪H_
+        (λ x y → − (y H∪G x))
         idp
         comm-embase-emloop
         comm-emloop-embase
@@ -923,5 +977,5 @@ module CP₁₁-comm where
         comm-emloop-emloop
 
   abstract
-    cp₁₁-comm : ∀ x y → cp₁₁ x y == − (cp₁₁ y x)
+    cp₁₁-comm : ∀ x y → x G∪H y == − (y H∪G x)
     cp₁₁-comm = CP₁₁Comm.f

--- a/theorems/cw/DegreeByProjection.agda
+++ b/theorems/cw/DegreeByProjection.agda
@@ -112,21 +112,26 @@ module cw.DegreeByProjection {i} where
       (take-has-degrees-with-finite-support Sm≤n skel dec fin-sup)
 
   -- the following are named [boundary'] because it is not extended to the free groups
+  open FreeAbelianGroup
 
   boundary'-last : ∀ {n} (skel : Skeleton {i} (S n)) dec
     → has-degrees-with-finite-support skel dec
-    → cells-last skel → FreeAbGroup.El (cells-last (cw-init skel))
+    → cells-last skel → FreeAbelianGroup.El (cells-last (cw-init skel))
   boundary'-last skel dec fin-sup upper = fst ((snd fin-sup) upper)
 
   boundary-last : ∀ {n} (skel : Skeleton {i} (S n)) dec
     → has-degrees-with-finite-support skel dec
-    → FreeAbGroup.grp (cells-last skel) →ᴳ FreeAbGroup.grp (cells-last (cw-init skel))
+    → FreeAbGroup.grp (cells-last skel) →ᴳ
+      FreeAbGroup.grp (cells-last (cw-init skel))
   boundary-last skel dec fin-sup =
-    FreeAbGroup-extend (FreeAbGroup (cells-last (cw-init skel))) (boundary'-last skel dec fin-sup)
+    Freeness.extend
+      (cells-last skel)
+      (FreeAbelianGroup.FreeAbGroup (cells-last (cw-init skel)))
+      (boundary'-last skel dec fin-sup)
 
   boundary'-nth : ∀ {m n} (Sm≤n : S m ≤ n) (skel : Skeleton {i} n) dec
     → has-degrees-with-finite-support skel dec
-    → cells-nth Sm≤n skel → FreeAbGroup.El (cells-last (cw-init (cw-take Sm≤n skel)))
+    → cells-nth Sm≤n skel → FreeAbelianGroup.El (cells-last (cw-init (cw-take Sm≤n skel)))
   boundary'-nth Sm≤n skel dec fin-sup =
     boundary'-last (cw-take Sm≤n skel)
       (take-has-cells-with-dec-eq Sm≤n skel dec)
@@ -137,6 +142,6 @@ module cw.DegreeByProjection {i} where
     →  FreeAbGroup.grp (cells-nth Sm≤n skel)
     →ᴳ FreeAbGroup.grp (cells-last (cw-init (cw-take Sm≤n skel)))
   boundary-nth Sm≤n skel dec fin-sup =
-    FreeAbGroup-extend
+    Freeness.extend (cells-nth Sm≤n skel)
       (FreeAbGroup (cells-last (cw-init (cw-take Sm≤n skel))))
       (boundary'-nth Sm≤n skel dec fin-sup)

--- a/theorems/cw/FinBoundary.agda
+++ b/theorems/cw/FinBoundary.agda
@@ -12,6 +12,8 @@ open import cw.DegreeByProjection {lzero}
 
 module cw.FinBoundary where
 
+  open FreeAbelianGroup
+
   fdegree-last : ∀ {n} (fin-skel : FinSkeleton (S n))
     → cells-last (FinSkeleton-realize fin-skel)
     → cells-last (cw-init (FinSkeleton-realize fin-skel)) → ℤ
@@ -33,7 +35,7 @@ module cw.FinBoundary where
 
   fboundary'-last : ∀ {n} (fin-skel : FinSkeleton (S n))
     → cells-last (FinSkeleton-realize fin-skel)
-    → FreeAbGroup.El (cells-last (cw-init (FinSkeleton-realize fin-skel)))
+    → FreeAbelianGroup.El (cells-last (cw-init (FinSkeleton-realize fin-skel)))
   fboundary'-last fin-skel upper = boundary'-last
     (FinSkeleton-realize fin-skel)
     (FinSkeleton-has-cells-with-dec-eq fin-skel)
@@ -43,6 +45,6 @@ module cw.FinBoundary where
   fboundary-last : ∀ {n} (fin-skel : FinSkeleton (S n))
     →  FreeAbGroup.grp (cells-last (FinSkeleton-realize fin-skel))
     →ᴳ FreeAbGroup.grp (cells-last (cw-init (FinSkeleton-realize fin-skel)))
-  fboundary-last fin-skel = FreeAbGroup-extend
+  fboundary-last fin-skel = Freeness.extend _
     (FreeAbGroup (cells-last (cw-init (FinSkeleton-realize fin-skel))))
     (fboundary'-last fin-skel)

--- a/theorems/cw/cohomology/ReconstructedCochainsEquivCellularCochains.agda
+++ b/theorems/cw/cohomology/ReconstructedCochainsEquivCellularCochains.agda
@@ -174,7 +174,7 @@ module cw.cohomology.ReconstructedCochainsEquivCellularCochains
       frcc-comm-fccc-augment : ∀ {n} (⊙fin-skel : ⊙FinSkeleton n)
         → CommSquareᴳ
             (CochainComplex.augment (RCC.cochain-complex ⊙⦉ ⊙fin-skel ⦊))
-            (pre∘ᴳ-hom (C2-abgroup 0) (FreeAbGroup-extend (Lift-abgroup {j = lzero} ℤ-abgroup) λ _ → lift 1))
+            (pre∘ᴳ-hom (C2-abgroup 0) (FreeAbelianGroup.Freeness.extend _ (Lift-abgroup {j = lzero} ℤ-abgroup) λ _ → lift 1))
             (GroupIso.f-hom rhead-iso-chead)
             (GroupIso.f-hom (rcc-iso-ccc-template ⊙⦉ ⊙fin-skel ⦊ (inl (O≤ n))
               (⊙FinSkeleton-has-cells-with-choice 0 ⊙fin-skel lzero)))

--- a/theorems/cw/cohomology/ReconstructedCochainsIsoCellularCochains.agda
+++ b/theorems/cw/cohomology/ReconstructedCochainsIsoCellularCochains.agda
@@ -10,6 +10,8 @@ open import cohomology.ChainComplex
 module cw.cohomology.ReconstructedCochainsIsoCellularCochains {i : ULevel}
   (OT : OrdinaryTheory i) where
 
+  open FreeAbelianGroup
+
   open OrdinaryTheory OT
   open import cw.cohomology.WedgeOfCells OT
   open import cw.cohomology.cellular.ChainComplex as CCC
@@ -22,10 +24,10 @@ module cw.cohomology.ReconstructedCochainsIsoCellularCochains {i : ULevel}
       →  AbGroup.grp (RCC.cochain-template ⊙skel (inl m≤n))
       ≃ᴳ hom-group (AbGroup.grp (CCC.chain-template (⊙Skeleton.skel ⊙skel) (inl m≤n))) (C2-abgroup 0)
     rcc-iso-ccc-nth ⊙skel {m = O} (inl idp) ac
-      =   FreeAbGroup-extend-iso (C2-abgroup 0)
+      =   Freeness.extend-iso _ (C2-abgroup 0)
       ∘eᴳ C2×CX₀-diag-β ⊙skel ac
     rcc-iso-ccc-nth ⊙skel {m = S m} (inl idp) ac
-      =   FreeAbGroup-extend-iso (C2-abgroup 0)
+      =   Freeness.extend-iso _ (C2-abgroup 0)
       ∘eᴳ CXₙ/Xₙ₋₁-diag-β ⊙skel ac
     rcc-iso-ccc-nth ⊙skel {m = O} (inr ltS) ac =
       rcc-iso-ccc-nth (⊙cw-init ⊙skel) (inl idp) (⊙init-has-cells-with-choice ⊙skel ac)

--- a/theorems/cw/cohomology/cellular/ChainComplex.agda
+++ b/theorems/cw/cohomology/cellular/ChainComplex.agda
@@ -7,6 +7,8 @@ open import cohomology.ChainComplex
 
 module cw.cohomology.cellular.ChainComplex {i : ULevel} where
 
+  open FreeAbelianGroup
+
   chain-template : ∀ {n} (skel : Skeleton {i} n) {m}
     → Dec (m ≤ n) → AbGroup i
   chain-template skel (inl m≤n) = FreeAbGroup (cells-nth m≤n skel)
@@ -47,7 +49,7 @@ module cw.cohomology.cellular.ChainComplex {i : ULevel} where
       chain m = chain-template skel (≤-dec m n)
 
       augment : AbGroup.grp (chain 0) →ᴳ AbGroup.grp head
-      augment = FreeAbGroup-extend head λ _ → lift 1
+      augment = Freeness.extend _ head λ _ → lift 1
 
       boundary : ∀ m → (AbGroup.grp (chain (S m)) →ᴳ AbGroup.grp (chain m))
       boundary m = boundary-template skel dec fin-sup (≤-dec m n) (≤-dec (S m) n)
@@ -118,7 +120,7 @@ module cw.cohomology.cellular.ChainComplex {i : ULevel} where
 
     boundary-template-β : ∀ {n} (skel : Skeleton {i} (S n)) dec fin-sup
       →  boundary-template {n = S n} skel dec fin-sup (inl lteS) (inl lteE)
-      == FreeAbGroup-extend
+      == Freeness.extend _
             (FreeAbGroup (cells-last (cw-init skel)))
             (boundary'-last skel dec fin-sup)
     boundary-template-β skel dec fin-sup = group-hom= $

--- a/theorems/cw/cohomology/cochainequiv/AugmentCommSquare.agda
+++ b/theorems/cw/cohomology/cochainequiv/AugmentCommSquare.agda
@@ -18,26 +18,28 @@ private
   ac = ⊙FinSkeleton-has-cells-with-choice 0 ⊙fin-skel lzero
   pt = ⊙FinSkeleton.skel ⊙fin-skel
 
+open FreeAbelianGroup (Σ ℕ (_< ⊙FinSkeleton.skel ⊙fin-skel)) using (module Freeness)
+
 abstract
   augment-comm-sqr :
     CommSquareEquiv
       (GroupHom.f cw-coε)
-      (_∘ᴳ FreeAbGroup-extend (Lift-abgroup {j = lzero} ℤ-abgroup) λ _ → lift 1)
+      (_∘ᴳ Freeness.extend (Lift-abgroup {j = lzero} ℤ-abgroup) λ _ → lift 1)
       ((_∘ᴳ lower-hom {j = lzero}) ∘ <– (ℤ→ᴳ-equiv-idf (C2 0)))
-      (FreeAbGroup-extend (C2-abgroup 0) ∘ GroupIso.f (C2×CX₀-diag-β ac))
+      (Freeness.extend (C2-abgroup 0) ∘ GroupIso.f (C2×CX₀-diag-β ac))
   augment-comm-sqr = comm-sqr (λ g → equiv-adj'
-    (GroupIso.f-equiv (FreeAbGroup-extend-iso (C2-abgroup 0) ∘eᴳ C2×CX₀-diag-β ac))
+    (GroupIso.f-equiv (Freeness.extend-iso (C2-abgroup 0) ∘eᴳ C2×CX₀-diag-β ac))
     (! $ pair×= idp
       ( ap (GroupIso.g (CX₀-diag-β ac)) (λ= λ _ → Group.inv-r (C2 0) g)
       ∙ GroupHom.pres-ident (GroupIso.g-hom (CX₀-diag-β ac))))) ,
     (GroupIso.f-is-equiv (pre∘ᴳ-iso (C2-abgroup 0) (lower-iso {j = lzero}) ∘eᴳ ℤ→ᴳ-iso-idf (C2-abgroup 0) ⁻¹ᴳ)) ,
-    (GroupIso.f-is-equiv (FreeAbGroup-extend-iso (C2-abgroup 0) ∘eᴳ C2×CX₀-diag-β ac))
+    (GroupIso.f-is-equiv (Freeness.extend-iso (C2-abgroup 0) ∘eᴳ C2×CX₀-diag-β ac))
 
   augment-comm-sqrᴳ :
     CommSquareEquivᴳ
       cw-coε
-      (pre∘ᴳ-hom (C2-abgroup 0) (FreeAbGroup-extend (Lift-abgroup {j = lzero} ℤ-abgroup) λ _ → lift 1))
+      (pre∘ᴳ-hom (C2-abgroup 0) (Freeness.extend (Lift-abgroup {j = lzero} ℤ-abgroup) λ _ → lift 1))
       (pre∘ᴳ-hom (C2-abgroup 0) (lower-hom {j = lzero}) ∘ᴳ GroupIso.g-hom (ℤ→ᴳ-iso-idf (C2-abgroup 0)))
-      (FreeAbGroup-extend-hom (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (C2×CX₀-diag-β ac))
+      (Freeness.extend-hom (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (C2×CX₀-diag-β ac))
   augment-comm-sqrᴳ =
     comm-sqrᴳ (fst augment-comm-sqr □$_) , snd augment-comm-sqr

--- a/theorems/cw/cohomology/cochainequiv/DualizedFirstBoundary.agda
+++ b/theorems/cw/cohomology/cochainequiv/DualizedFirstBoundary.agda
@@ -13,42 +13,41 @@ module cw.cohomology.cochainequiv.DualizedFirstBoundary (OT : OrdinaryTheory lze
   (⊙fin-skel : ⊙FinSkeleton 1) where
 
 open OrdinaryTheory OT
+open FreeAbelianGroup
 
 private
   fin-skel = ⊙FinSkeleton.skel ⊙fin-skel
   I = AttachedFinSkeleton.numCells fin-skel
-  
+
   I₋₁ = AttachedFinSkeleton.skel fin-skel
+
+  module FAG   = FreeAbelianGroup (Fin I)
+  module FAG₋₁ = FreeAbelianGroup (Fin I₋₁)
+
+  open FAG   renaming (FreeAbGroup to G)   using ()
+  open FAG₋₁ renaming (FreeAbGroup to G₋₁) using ()
 
 abstract
   rephrase-dualized-first-boundary-in-degree : ∀ g <I
-    →  FormalSum-extend (C2-abgroup 0) g (GroupHom.f (fboundary-last fin-skel) fs[ inl <I :: nil ])
+    →  GroupHom.f (Freeness.extend _ (C2-abgroup 0) g) (GroupHom.f (fboundary-last fin-skel) (FAG.insert <I))
     == Group.sum (C2 0) (λ <I₋₁ → Group.exp (C2 0) (g <I₋₁) (fdegree-last fin-skel <I <I₋₁))
   rephrase-dualized-first-boundary-in-degree g <I =
-    FormalSum-extend (C2-abgroup 0) g (GroupHom.f (fboundary-last fin-skel) fs[ inl <I :: nil ])
-      =⟨ ap (FormalSum-extend (C2-abgroup 0) g) $
-          app= (is-equiv.g-f (FreeAbGroup-extend-is-equiv (FreeAbGroup (Fin I₋₁))) (fboundary'-last fin-skel)) <I ⟩
-    FormalSum-extend (C2-abgroup 0) g
-      (Group.sum (FreeAbGroup.grp (Fin I₋₁))
-        (λ <I₋₁ → Group.exp (FreeAbGroup.grp (Fin I₋₁)) fs[ inl <I₋₁ :: nil ] (fdegree-last fin-skel <I <I₋₁)))
-      =⟨ GroupHom.pres-sum (FreeAbGroup-extend (C2-abgroup 0) g)
-          (λ <I₋₁ → Group.exp (FreeAbGroup.grp (Fin I₋₁)) fs[ inl <I₋₁ :: nil ] (fdegree-last fin-skel <I <I₋₁)) ⟩
-    Group.sum (C2 0)
-      (λ <I₋₁ → 
-        (FormalSum-extend (C2-abgroup 0) g
-          (Group.exp (FreeAbGroup.grp (Fin I₋₁)) fs[ inl <I₋₁ :: nil ] (fdegree-last fin-skel <I <I₋₁))))
-      =⟨ ap (Group.sum (C2 0))
-          (λ= λ <I₋₁ →
-            GroupHom.pres-exp (FreeAbGroup-extend (C2-abgroup 0) g)
-              fs[ inl <I₋₁ :: nil ]
-              (fdegree-last fin-skel <I <I₋₁)) ⟩
-    Group.sum (C2 0)
-      (λ <I₋₁ → 
-        (Group.exp (C2 0)
-          (FormalSum-extend (C2-abgroup 0) g fs[ inl <I₋₁ :: nil ])
-          (fdegree-last fin-skel <I <I₋₁)))
-      =⟨ ap (Group.sum (C2 0))
-          (λ= λ <I₋₁ → ap (λ g → Group.exp (C2 0) g (fdegree-last fin-skel <I <I₋₁)) $
-            app= (is-equiv.g-f (FreeAbGroup-extend-is-equiv (C2-abgroup 0)) g) <I₋₁) ⟩
-    Group.sum (C2 0) (λ <I₋₁ → (Group.exp (C2 0) (g <I₋₁) (fdegree-last fin-skel <I <I₋₁)))
+    γ.f (GroupHom.f (fboundary-last fin-skel) (FAG.insert <I))
+      =⟨ ap γ.f $ app= (is-equiv.g-f (FAG.Freeness.extend-is-equiv G₋₁) (fboundary'-last fin-skel)) <I ⟩
+    γ.f (G₋₁.sum (λ <I₋₁ → G₋₁.exp (FAG₋₁.insert <I₋₁) (fdegree-last fin-skel <I <I₋₁)))
+      =⟨ γ.pres-sum (λ <I₋₁ → G₋₁.exp (FAG₋₁.insert <I₋₁) (fdegree-last fin-skel <I <I₋₁)) ⟩
+    C⁰2.sum (λ <I₋₁ → (γ.f (G₋₁.exp (FAG₋₁.insert <I₋₁) (fdegree-last fin-skel <I <I₋₁))))
+      =⟨ ap C⁰2.sum (λ= λ <I₋₁ → γ.pres-exp (FAG₋₁.insert <I₋₁) (fdegree-last fin-skel <I <I₋₁)) ⟩
+    C⁰2.sum (λ <I₋₁ → (C⁰2.exp (γ.f (FAG₋₁.insert <I₋₁)) (fdegree-last fin-skel <I <I₋₁)))
+      =⟨ ap C⁰2.sum
+          (λ= λ <I₋₁ → ap (λ g → C⁰2.exp g (fdegree-last fin-skel <I <I₋₁)) $
+            app= (is-equiv.g-f (FAG₋₁.Freeness.extend-is-equiv C⁰2) g) <I₋₁) ⟩
+    C⁰2.sum (λ <I₋₁ → (C⁰2.exp (g <I₋₁) (fdegree-last fin-skel <I <I₋₁)))
       =∎
+    where
+      C⁰2 : AbGroup lzero
+      C⁰2 = C2-abgroup 0
+      module C⁰2 = AbGroup C⁰2
+      γ : G₋₁.grp →ᴳ C⁰2.grp
+      γ = FAG₋₁.Freeness.extend C⁰2 g
+      module γ = GroupHom γ

--- a/theorems/cw/cohomology/cochainequiv/DualizedHigherBoundary.agda
+++ b/theorems/cw/cohomology/cochainequiv/DualizedHigherBoundary.agda
@@ -14,40 +14,40 @@ open OrdinaryTheory OT
 private
   fin-skel = ⊙FinSkeleton.skel ⊙fin-skel
   I = AttachedFinSkeleton.numCells fin-skel
-  
+
   fin-skel₋₁ = AttachedFinSkeleton.skel fin-skel
   I₋₁ = AttachedFinSkeleton.numCells fin-skel₋₁
 
+  module FAG   = FreeAbelianGroup (Fin I)
+  module FAG₋₁ = FreeAbelianGroup (Fin I₋₁)
+
+  open FAG   renaming (FreeAbGroup to G)   using ()
+  open FAG₋₁ renaming (FreeAbGroup to G₋₁) using ()
+
 abstract
-  rephrase-dualized-higher-boundary-in-degree : ∀ g <I
-    → GroupIso.g (FreeAbGroup-extend-iso (C2-abgroup 0))
-        (GroupIso.f (FreeAbGroup-extend-iso (C2-abgroup 0)) g ∘ᴳ fboundary-last fin-skel) <I
+  rephrase-dualized-higher-boundary-in-degree : ∀ (g : Fin I₋₁ → Group.El (C2 0)) <I
+    → GroupIso.g (FAG.Freeness.extend-iso (C2-abgroup 0))
+        (GroupIso.f (FAG₋₁.Freeness.extend-iso (C2-abgroup 0)) g ∘ᴳ fboundary-last fin-skel) <I
     == Group.sum (C2 0) (λ <I₋₁ → Group.exp (C2 0) (g <I₋₁) (fdegree-last fin-skel <I <I₋₁))
   rephrase-dualized-higher-boundary-in-degree g <I =
-    FormalSum-extend (C2-abgroup 0) g (GroupHom.f (fboundary-last fin-skel) fs[ inl <I :: nil ])
-      =⟨ ap (FormalSum-extend (C2-abgroup 0) g) $
-          app= (is-equiv.g-f (FreeAbGroup-extend-is-equiv (FreeAbGroup (Fin I₋₁))) (fboundary'-last fin-skel)) <I ⟩
-    FormalSum-extend (C2-abgroup 0) g
-      (Group.sum (FreeAbGroup.grp (Fin I₋₁))
-        (λ <I₋₁ → Group.exp (FreeAbGroup.grp (Fin I₋₁)) fs[ inl <I₋₁ :: nil ] (fdegree-last fin-skel <I <I₋₁)))
-      =⟨ GroupHom.pres-sum (FreeAbGroup-extend (C2-abgroup 0) g)
-          (λ <I₋₁ → Group.exp (FreeAbGroup.grp (Fin I₋₁)) fs[ inl <I₋₁ :: nil ] (fdegree-last fin-skel <I <I₋₁)) ⟩
-    Group.sum (C2 0)
-      (λ <I₋₁ → 
-        (FormalSum-extend (C2-abgroup 0) g
-          (Group.exp (FreeAbGroup.grp (Fin I₋₁)) fs[ inl <I₋₁ :: nil ] (fdegree-last fin-skel <I <I₋₁))))
-      =⟨ ap (Group.sum (C2 0))
-          (λ= λ <I₋₁ →
-            GroupHom.pres-exp (FreeAbGroup-extend (C2-abgroup 0) g)
-              fs[ inl <I₋₁ :: nil ]
-              (fdegree-last fin-skel <I <I₋₁)) ⟩
-    Group.sum (C2 0)
-      (λ <I₋₁ → 
-        (Group.exp (C2 0)
-          (FormalSum-extend (C2-abgroup 0) g fs[ inl <I₋₁ :: nil ])
-          (fdegree-last fin-skel <I <I₋₁)))
-      =⟨ ap (Group.sum (C2 0))
-          (λ= λ <I₋₁ → ap (λ g → Group.exp (C2 0) g (fdegree-last fin-skel <I <I₋₁)) $
-            app= (is-equiv.g-f (FreeAbGroup-extend-is-equiv (C2-abgroup 0)) g) <I₋₁) ⟩
-    Group.sum (C2 0) (λ <I₋₁ → (Group.exp (C2 0) (g <I₋₁) (fdegree-last fin-skel <I <I₋₁)))
+    γ.f (GroupHom.f (fboundary-last fin-skel) (FAG.insert <I))
+      =⟨ ap γ.f $ app= (is-equiv.g-f (snd (FAG.Freeness.extend-equiv G₋₁)) (fboundary'-last fin-skel)) <I ⟩
+    γ.f (G₋₁.sum (λ <I₋₁ → G₋₁.exp (FAG₋₁.insert <I₋₁) (deg <I₋₁)))
+      =⟨ γ.pres-sum (λ <I₋₁ → G₋₁.exp (FAG₋₁.insert <I₋₁) (deg <I₋₁)) ⟩
+    C⁰2.sum (λ <I₋₁ → γ.f (G₋₁.exp (FAG₋₁.insert <I₋₁) (deg <I₋₁)))
+      =⟨ ap C⁰2.sum (λ= $ λ <I₋₁ → γ.pres-exp (FAG₋₁.insert <I₋₁) (deg <I₋₁)) ⟩
+    C⁰2.sum (λ <I₋₁ → C⁰2.exp (γ.f (FAG₋₁.insert <I₋₁)) (deg <I₋₁))
+      =⟨ ap C⁰2.sum
+          (λ= λ <I₋₁ → ap (λ g → C⁰2.exp g (deg <I₋₁)) $
+            app= (is-equiv.g-f (snd (FAG₋₁.Freeness.extend-equiv C⁰2)) g) <I₋₁) ⟩
+    C⁰2.sum (λ <I₋₁ → C⁰2.exp (g <I₋₁) (deg <I₋₁))
       =∎
+    where
+      deg : Fin I₋₁ → ℤ
+      deg <I₋₁ = fdegree-last fin-skel <I <I₋₁
+      C⁰2 : AbGroup lzero
+      C⁰2 = C2-abgroup 0
+      module C⁰2 = AbGroup C⁰2
+      γ : G₋₁.grp →ᴳ C⁰2.grp
+      γ = FAG₋₁.Freeness.extend C⁰2 g
+      module γ = GroupHom γ

--- a/theorems/cw/cohomology/cochainequiv/FirstCoboundaryCommSquare.agda
+++ b/theorems/cw/cohomology/cochainequiv/FirstCoboundaryCommSquare.agda
@@ -15,6 +15,7 @@ open import cw.cohomology.reconstructed.TipAndAugment OT ⊙⦉ ⊙fcw-init ⊙f
 open import cw.cohomology.reconstructed.TipCoboundary OT ⊙⦉ ⊙fin-skel ⦊
 open import cw.cohomology.cochainequiv.DualizedFirstBoundary OT ⊙fin-skel
 open import cw.cohomology.cochainequiv.FirstCoboundary OT ⊙fin-skel
+open FreeAbelianGroup
 
 private
   fin-skel = ⊙FinSkeleton.skel ⊙fin-skel
@@ -30,15 +31,15 @@ abstract
     CommSquareEquiv
       (λ g <I → Group.sum (C2 0) (λ <I₋₁ → Group.exp (C2 0) (g <I₋₁) (fdegree-last fin-skel <I <I₋₁)))
       (_∘ᴳ fboundary-last fin-skel)
-      (FreeAbGroup-extend (C2-abgroup 0))
-      (FreeAbGroup-extend (C2-abgroup 0))
+      (Freeness.extend _ (C2-abgroup 0))
+      (Freeness.extend _ (C2-abgroup 0))
   rephrase-dualized-first-boundary-comm-sqr =
     comm-sqr (λ g →
       equiv-adj'
-        (GroupIso.f-equiv (FreeAbGroup-extend-iso (C2-abgroup 0)))
+        (GroupIso.f-equiv (Freeness.extend-iso _ (C2-abgroup 0)))
         (λ= λ <I → ! (rephrase-dualized-first-boundary-in-degree g <I))) ,
-    FreeAbGroup-extend-is-equiv (C2-abgroup 0) ,
-    FreeAbGroup-extend-is-equiv (C2-abgroup 0)
+    Freeness.extend-is-equiv _ (C2-abgroup 0) ,
+    Freeness.extend-is-equiv _ (C2-abgroup 0)
 
   rephrase-cw-co∂-head-comm-sqr :
     CommSquareEquiv
@@ -58,10 +59,10 @@ abstract
     CommSquareEquiv
       (GroupHom.f cw-co∂-head)
       (_∘ᴳ fboundary-last fin-skel)
-      (FreeAbGroup-extend (C2-abgroup 0) ∘ GroupIso.f (C2×CX₀-diag-β ac₋₁))
-      (FreeAbGroup-extend (C2-abgroup 0) ∘ GroupIso.f (CXₙ/Xₙ₋₁-diag-β ac))
+      (Freeness.extend _ (C2-abgroup 0) ∘ GroupIso.f (C2×CX₀-diag-β ac₋₁))
+      (Freeness.extend _ (C2-abgroup 0) ∘ GroupIso.f (CXₙ/Xₙ₋₁-diag-β ac))
   first-coboundary-comm-sqr =
-    CommSquareEquiv-∘v  
+    CommSquareEquiv-∘v
       rephrase-dualized-first-boundary-comm-sqr
       (CommSquareEquiv-inverse-v rephrase-cw-co∂-head-comm-sqr)
 
@@ -69,7 +70,7 @@ abstract
     CommSquareEquivᴳ
       cw-co∂-head
       (pre∘ᴳ-hom (C2-abgroup 0) (fboundary-last fin-skel))
-      (FreeAbGroup-extend-hom (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (C2×CX₀-diag-β ac₋₁))
-      (FreeAbGroup-extend-hom (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (CXₙ/Xₙ₋₁-diag-β ac))
+      (Freeness.extend-hom _ (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (C2×CX₀-diag-β ac₋₁))
+      (Freeness.extend-hom _ (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (CXₙ/Xₙ₋₁-diag-β ac))
   first-coboundary-comm-sqrᴳ =
     comm-sqrᴳ (fst first-coboundary-comm-sqr □$_) , snd first-coboundary-comm-sqr

--- a/theorems/cw/cohomology/cochainequiv/HigherCoboundaryCommSquare.agda
+++ b/theorems/cw/cohomology/cochainequiv/HigherCoboundaryCommSquare.agda
@@ -24,20 +24,22 @@ private
   fin-skel₋₁ = ⊙FinSkeleton.skel ⊙fin-skel₋₁
   ac₋₁ = ⊙FinSkeleton-has-cells-with-choice 0 ⊙fin-skel₋₁ lzero
 
+open FreeAbelianGroup
+
 abstract
   rephrase-dualized-higher-boundary-comm-sqr :
     CommSquareEquiv
       (λ g <I → Group.sum (C2 0) (λ <I₋₁ → Group.exp (C2 0) (g <I₋₁) (fdegree-last fin-skel <I <I₋₁)))
       (_∘ᴳ fboundary-last fin-skel)
-      (FreeAbGroup-extend (C2-abgroup 0))
-      (FreeAbGroup-extend (C2-abgroup 0))
+      (Freeness.extend _ (C2-abgroup 0))
+      (Freeness.extend _ (C2-abgroup 0))
   rephrase-dualized-higher-boundary-comm-sqr =
     comm-sqr (λ g →
       equiv-adj'
-        (GroupIso.f-equiv (FreeAbGroup-extend-iso (C2-abgroup 0)))
+        (GroupIso.f-equiv (Freeness.extend-iso _ (C2-abgroup 0)))
         (λ= λ <I → ! (rephrase-dualized-higher-boundary-in-degree g <I))) ,
-    FreeAbGroup-extend-is-equiv (C2-abgroup 0) ,
-    FreeAbGroup-extend-is-equiv (C2-abgroup 0)
+    Freeness.extend-is-equiv _ (C2-abgroup 0) ,
+    Freeness.extend-is-equiv _ (C2-abgroup 0)
 
   rephrase-cw-co∂-last-comm-sqr :
     CommSquareEquiv
@@ -57,10 +59,10 @@ abstract
     CommSquareEquiv
       (GroupHom.f cw-co∂-last)
       (_∘ᴳ fboundary-last fin-skel)
-      (FreeAbGroup-extend (C2-abgroup 0) ∘ GroupIso.f (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel₋₁ ⦊ ac₋₁))
-      (FreeAbGroup-extend (C2-abgroup 0) ∘ GroupIso.f (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel ⦊ ac))
+      (Freeness.extend _ (C2-abgroup 0) ∘ GroupIso.f (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel₋₁ ⦊ ac₋₁))
+      (Freeness.extend _ (C2-abgroup 0) ∘ GroupIso.f (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel ⦊ ac))
   higher-coboundary-comm-sqr =
-    CommSquareEquiv-∘v  
+    CommSquareEquiv-∘v
       rephrase-dualized-higher-boundary-comm-sqr
       (CommSquareEquiv-inverse-v rephrase-cw-co∂-last-comm-sqr)
 
@@ -68,7 +70,7 @@ abstract
     CommSquareEquivᴳ
       cw-co∂-last
       (pre∘ᴳ-hom (C2-abgroup 0) (fboundary-last fin-skel))
-      (FreeAbGroup-extend-hom (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel₋₁ ⦊ ac₋₁))
-      (FreeAbGroup-extend-hom (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel ⦊ ac))
+      (Freeness.extend-hom _ (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel₋₁ ⦊ ac₋₁))
+      (Freeness.extend-hom _ (C2-abgroup 0) ∘ᴳ GroupIso.f-hom (CXₙ/Xₙ₋₁-diag-β ⊙⦉ ⊙fin-skel ⦊ ac))
   higher-coboundary-comm-sqrᴳ =
     comm-sqrᴳ (fst higher-coboundary-comm-sqr □$_) , snd higher-coboundary-comm-sqr

--- a/theorems/groups/ReducedWord.agda
+++ b/theorems/groups/ReducedWord.agda
@@ -223,7 +223,7 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
           (Word-flip-is-reduced (y :: w) (tail-is-reduced x (y :: w) red))
 
     rw-inv : ReducedWord → ReducedWord
-    rw-inv (w , red) = reverse (Word-flip w) , reverse-is-reduced (Word-flip w) (Word-flip-is-reduced w red)
+    rw-inv (w , red) = Word-inverse w , reverse-is-reduced (Word-flip w) (Word-flip-is-reduced w red)
 
     abstract
       rw-inv-l-lemma : ∀ w₁ x w₂ (red₂ : is-reduced (x :: w₂)) (red₂' : is-reduced w₂)
@@ -265,23 +265,28 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
   private
     abstract
       QuotWordRel-cons : ∀ x w₂ (red₂ : is-reduced w₂)
-        → QuotWordRel (x :: w₂) (fst (rw-cons x (w₂ , red₂)))
+        → FreeQuotWordRel A (x :: w₂) (fst (rw-cons x (w₂ , red₂)))
       QuotWordRel-cons x nil _ = qwr-refl idp
       QuotWordRel-cons (inl x) (inl y :: w) _ = qwr-refl idp
       QuotWordRel-cons (inl x) (inr y :: w) _ with dec x y
-      QuotWordRel-cons (inl x) (inr y :: w) _ | inl x=y rewrite x=y = qwr-flip (inl y) w
+      QuotWordRel-cons (inl x) (inr y :: w) _ | inl x=y rewrite x=y =
+        qwr-cong-l (qwr-flip-r (inl y)) w
       QuotWordRel-cons (inl x) (inr y :: w) _ | inr x≠y = qwr-refl idp
       QuotWordRel-cons (inr x) (inl y :: w) _ with dec x y
-      QuotWordRel-cons (inr x) (inl y :: w) _ | inl x=y rewrite x=y = qwr-flip (inr y) w
+      QuotWordRel-cons (inr x) (inl y :: w) _ | inl x=y rewrite x=y =
+        qwr-cong-l (qwr-flip-r (inr y)) w
       QuotWordRel-cons (inr x) (inl y :: w) _ | inr x≠y = qwr-refl idp
       QuotWordRel-cons (inr x) (inr y :: w) _ = qwr-refl idp
 
       QuotWordRel-++ : ∀ w₁ rw₂
-        → QuotWordRel (w₁ ++ fst rw₂) (fst (rw-++' w₁ rw₂))
+        → FreeQuotWordRel A (w₁ ++ fst rw₂) (fst (rw-++' w₁ rw₂))
       QuotWordRel-++ nil _ = qwr-refl idp
       QuotWordRel-++ (x :: w₁) rw₂ =
-        qwr-trans (qwr-cons x (QuotWordRel-++ w₁ rw₂)) $
-        uncurry (QuotWordRel-cons x) (rw-++' w₁ rw₂)
+        x :: w₁ ++ fst rw₂
+          qwr⟨ qwr-cong-r (x :: nil) (QuotWordRel-++ w₁ rw₂) ⟩
+        x :: fst (rw-++' w₁ rw₂)
+          qwr⟨ uncurry (QuotWordRel-cons x) (rw-++' w₁ rw₂) ⟩
+        fst (rw-++' (x :: w₁) rw₂) qwr∎
 
   -- freeness
   ReducedWord-to-FreeGroup : ReducedWord-group →ᴳ FreeGroup A
@@ -290,25 +295,38 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
 
   private
     abstract
-      reduce-emap : ∀ {w₁ w₂} → QuotWordRel w₁ w₂ → reduce w₁ == reduce w₂
-      reduce-emap (qwr-refl p) = ap reduce p
+      reduce-emap : ∀ {w₁ w₂ rw₃} → FreeQuotWordRel A w₁ w₂ → rw-++' w₁ rw₃ == rw-++' w₂ rw₃
+      reduce-emap {rw₃ = rw₃} (qwr-refl p) = ap (λ w → rw-++' w rw₃) p
       reduce-emap (qwr-trans qwr₁ qwr₂) = reduce-emap qwr₁ ∙ reduce-emap qwr₂
       reduce-emap (qwr-sym qwr) = ! (reduce-emap qwr)
-      reduce-emap (qwr-cons x qwr) = ap (rw-cons x) (reduce-emap qwr)
-      reduce-emap (qwr-flip x w) = rw-cons-cons-flip x (reduce w)
+      reduce-emap {rw₃ = rw₃} (qwr-cong {l₁} {l₂} {l₃} {l₄} qwr qwr') =
+        rw-++' (l₁ ++ l₃) rw₃
+          =⟨ foldr-++ rw-cons rw₃ l₁ l₃ ⟩
+        rw-++' l₁ (rw-++' l₃ rw₃)
+          =⟨ ap (rw-++' l₁) (reduce-emap qwr') ⟩
+        rw-++' l₁ (rw-++' l₄ rw₃)
+          =⟨ reduce-emap qwr ⟩
+        rw-++' l₂ (rw-++' l₄ rw₃)
+          =⟨ ! (foldr-++ rw-cons rw₃ l₂ l₄) ⟩
+        rw-++' (l₂ ++ l₄) rw₃ =∎
+      reduce-emap {rw₃ = rw₃} (qwr-flip-r x) = rw-cons-cons-flip x rw₃
+      reduce-emap (qwr-rel ())
 
     to = GroupHom.f ReducedWord-to-FreeGroup
 
-    from : QuotWord A → ReducedWord
+    from : FreeQuotWord A → ReducedWord
     from = QuotWord-rec reduce reduce-emap
 
     abstract
       QuotWordRel-reduce : ∀ w
-        → QuotWordRel w (fst (reduce w))
+        → FreeQuotWordRel A w (fst (reduce w))
       QuotWordRel-reduce nil = qwr-refl idp
       QuotWordRel-reduce (x :: w) =
-        qwr-trans (qwr-cons x (QuotWordRel-reduce w)) $
-        uncurry (QuotWordRel-cons x) (reduce w)
+        x :: w
+          qwr⟨ qwr-cong-r (x :: nil) (QuotWordRel-reduce w) ⟩
+        x :: fst (reduce w)
+          qwr⟨ uncurry (QuotWordRel-cons x) (reduce w) ⟩
+        fst (reduce (x :: w)) qwr∎
 
       to-from : ∀ qw → to (from qw) == qw
       to-from = QuotWord-elim

--- a/theorems/groups/ReducedWord.agda
+++ b/theorems/groups/ReducedWord.agda
@@ -4,6 +4,8 @@ open import HoTT
 
 module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
 
+  open FreeGroup A
+
   is-reduced : Word A → Type i
   is-reduced nil                   = Lift ⊤
   is-reduced (_     :: nil)        = Lift ⊤
@@ -265,7 +267,7 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
   private
     abstract
       QuotWordRel-cons : ∀ x w₂ (red₂ : is-reduced w₂)
-        → FreeQuotWordRel A (x :: w₂) (fst (rw-cons x (w₂ , red₂)))
+        → QuotWordRel (x :: w₂) (fst (rw-cons x (w₂ , red₂)))
       QuotWordRel-cons x nil _ = qwr-refl idp
       QuotWordRel-cons (inl x) (inl y :: w) _ = qwr-refl idp
       QuotWordRel-cons (inl x) (inr y :: w) _ with dec x y
@@ -279,7 +281,7 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
       QuotWordRel-cons (inr x) (inr y :: w) _ = qwr-refl idp
 
       QuotWordRel-++ : ∀ w₁ rw₂
-        → FreeQuotWordRel A (w₁ ++ fst rw₂) (fst (rw-++' w₁ rw₂))
+        → QuotWordRel (w₁ ++ fst rw₂) (fst (rw-++' w₁ rw₂))
       QuotWordRel-++ nil _ = qwr-refl idp
       QuotWordRel-++ (x :: w₁) rw₂ =
         x :: w₁ ++ fst rw₂
@@ -289,13 +291,13 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
         fst (rw-++' (x :: w₁) rw₂) qwr∎
 
   -- freeness
-  ReducedWord-to-FreeGroup : ReducedWord-group →ᴳ FreeGroup A
+  ReducedWord-to-FreeGroup : ReducedWord-group →ᴳ FreeGroup
   ReducedWord-to-FreeGroup = group-hom (λ rw → qw[ fst rw ])
     (λ rw₁ rw₂ → ! $ quot-rel $ QuotWordRel-++ (fst rw₁) rw₂)
 
   private
     abstract
-      reduce-emap : ∀ {w₁ w₂ rw₃} → FreeQuotWordRel A w₁ w₂ → rw-++' w₁ rw₃ == rw-++' w₂ rw₃
+      reduce-emap : ∀ {w₁ w₂ rw₃} → QuotWordRel w₁ w₂ → rw-++' w₁ rw₃ == rw-++' w₂ rw₃
       reduce-emap {rw₃ = rw₃} (qwr-refl p) = ap (λ w → rw-++' w rw₃) p
       reduce-emap (qwr-trans qwr₁ qwr₂) = reduce-emap qwr₁ ∙ reduce-emap qwr₂
       reduce-emap (qwr-sym qwr) = ! (reduce-emap qwr)
@@ -314,12 +316,12 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
 
     to = GroupHom.f ReducedWord-to-FreeGroup
 
-    from : FreeQuotWord A → ReducedWord
+    from : QuotWord → ReducedWord
     from = QuotWord-rec reduce reduce-emap
 
     abstract
       QuotWordRel-reduce : ∀ w
-        → FreeQuotWordRel A w (fst (reduce w))
+        → QuotWordRel w (fst (reduce w))
       QuotWordRel-reduce nil = qwr-refl idp
       QuotWordRel-reduce (x :: w) =
         x :: w
@@ -336,5 +338,5 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
       from-to : ∀ rw → from (to rw) == rw
       from-to = Group.unit-r ReducedWord-group
 
-  ReducedWord-iso-FreeGroup : ReducedWord-group ≃ᴳ FreeGroup A
+  ReducedWord-iso-FreeGroup : ReducedWord-group ≃ᴳ FreeGroup
   ReducedWord-iso-FreeGroup = ReducedWord-to-FreeGroup , is-eq to from to-from from-to

--- a/theorems/homotopy/EilenbergMacLane.agda
+++ b/theorems/homotopy/EilenbergMacLane.agda
@@ -228,5 +228,14 @@ module _ {i j} {G : Group i} {H : Group j} (φ : G →ᴳ H) where
     EM₁-fmap-emloop-β : ∀ g → ap EM₁-fmap (emloop g) == emloop (φ.f g)
     EM₁-fmap-emloop-β = EM₁FmapRec.emloop-β
 
-    ⊙EM₁-fmap : ⊙EM₁ G ⊙→ ⊙EM₁ H
-    ⊙EM₁-fmap = EM₁-fmap , idp
+  ⊙EM₁-fmap : ⊙EM₁ G ⊙→ ⊙EM₁ H
+  ⊙EM₁-fmap = EM₁-fmap , idp
+
+module _ {i j} {G : AbGroup i} {H : AbGroup j} (φ : AbGroup.grp G →ᴳ AbGroup.grp H) where
+
+  ⊙EM-fmap : ∀ n → EMExplicit.⊙EM G n ⊙→ EMExplicit.⊙EM H n
+  ⊙EM-fmap O = ⊙Ω-fmap (⊙EM₁-fmap φ)
+  ⊙EM-fmap (S n) = ⊙Trunc-fmap (⊙Susp^-fmap n (⊙EM₁-fmap φ))
+
+  EM-fmap : ∀ n → EMExplicit.EM G n → EMExplicit.EM H n
+  EM-fmap n = fst (⊙EM-fmap n)

--- a/theorems/homotopy/EilenbergMacLane1.agda
+++ b/theorems/homotopy/EilenbergMacLane1.agda
@@ -280,8 +280,8 @@ module homotopy.EilenbergMacLane1 {i} (G : Group i) where
     decode-encode : ∀ {x} (α : embase' G == x) → decode (encode α) == α
     decode-encode idp = emloop-ident {G = G}
 
-    emloop-equiv : G.El ≃ (embase' G == embase)
-    emloop-equiv = equiv emloop encode decode-encode encode-emloop
+  emloop-equiv : G.El ≃ (embase' G == embase)
+  emloop-equiv = equiv emloop encode decode-encode encode-emloop
 
   instance
     EM₁-level₁ : {n : ℕ₋₂} → has-level (S (S (S n))) (EM₁ G)


### PR DESCRIPTION
This generalizes the cup product to a map EM₁(G) → EM₁(H) → EM₂(G ⊗ H) where G ⊗ H is the tensor product of abelian groups G and H. Before, the type of the cup product map (in degrees m=1, n=1) was EM₁(R) → EM₁(R) → EM₂(R) where R was required to be a commutative ring. We can recover this old map using the fact that multiplication induces a group homomorphism R ⊗ R → R.